### PR TITLE
chore(ci): add AutoCorrect workflow for website

### DIFF
--- a/.github/workflows/autocorrect.yml
+++ b/.github/workflows/autocorrect.yml
@@ -1,0 +1,43 @@
+name: AutoCorrect Website Files
+
+on:
+  pull_request:
+    paths:
+      - 'crater-website/**'
+
+jobs:
+  autocorrect:
+    name: Run AutoCorrect on Website
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: AutoCorrect and Commit (for internal PRs)
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: huacnlee/autocorrect@v2
+        with:
+          working-directory: ./crater-website
+          args: --fix
+
+      - name: Commit changes (for internal PRs)
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style(website): Auto-correct files by autocorrect-action"
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          commit_author: GitHub Actions <41898282+github-actions[bot]@users.noreply.github.com>
+
+      - name: Lint Check (for forked PRs)
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        uses: huacnlee/autocorrect@v2
+        with:
+          working-directory: ./crater-website
+          args: --lint


### PR DESCRIPTION
Integrate huacnlee/autocorrect to automatically enforce code style and spelling standards for the website.

This new GitHub Actions workflow triggers on pull requests that modify files within the `crater-website/` directory.

- For PRs from internal branches, it automatically fixes issues (--fix) and commits the changes.
- For PRs from external forks, it runs in lint-only mode for security, failing the check if issues are found.

close #6 