### PR TITLE
chore: config dependabot to auto update submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Copyright 2025 Crater
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+updates:
+  # 配置submodules更新
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "21:00"  # UTC时间，对应北京时间凌晨5点
+    open-pull-requests-limit: 5
+    labels:
+      - "dependabot"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/auto-label-dependabot.yml
+++ b/.github/workflows/auto-label-dependabot.yml
@@ -1,0 +1,68 @@
+# Copyright 2025 Crater
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Auto Label Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-label:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto Label Dependabot PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            
+            // 根据PR标题添加特定标签
+            if (title.includes('crater-backend')) {
+              if (!labels.includes('backend')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  labels: ['backend']
+                });
+                console.log('Added backend label to PR #' + context.payload.pull_request.number);
+              }
+            }
+            
+            if (title.includes('crater-frontend')) {
+              if (!labels.includes('frontend')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  labels: ['frontend']
+                });
+                console.log('Added frontend label to PR #' + context.payload.pull_request.number);
+              }
+            }
+            
+            if (title.includes('storage-server')) {
+              if (!labels.includes('storage server')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  labels: ['storage server']
+                });
+                console.log('Added storage server label to PR #' + context.payload.pull_request.number);
+              }
+            }


### PR DESCRIPTION
Config Github Dependabot to auto-update submodules such as _crater-backend_.

* Check for updates on submodules at 5am Beijing time and automatically create PR.
* Label PR automatically with workflow.
* **Will not** update image tag in charts values.
* Still need to be tested.