### PR TITLE
fix(ci): Improve lint error reporting for forked PRs

### DIFF
--- a/.github/workflows/autocorrect.yml
+++ b/.github/workflows/autocorrect.yml
@@ -15,7 +15,7 @@
 name: AutoCorrect Website Files
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - '.github/**'
       - 'crater-website/src/**'        
@@ -31,7 +31,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout code
+      - name: Checkout PR code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/autocorrect.yml
+++ b/.github/workflows/autocorrect.yml
@@ -63,6 +63,8 @@ jobs:
         uses: huacnlee/autocorrect-action@v2
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWDOG_REPORTER: github-pr-review
+          REVIEWDOG_LEVEL: warning
         with:
           reviewdog: true
           args: --lint

--- a/.github/workflows/autocorrect.yml
+++ b/.github/workflows/autocorrect.yml
@@ -28,6 +28,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -52,6 +53,16 @@ jobs:
 
       - name: Lint Check (for forked PRs)
         if: github.event.pull_request.head.repo.full_name != github.repository
+        id: lint
         uses: huacnlee/autocorrect-action@v2
         with:
+          args: --lint
+
+      - name: Report with Reviewdog (for forked PRs)
+        if: failure() && steps.lint.conclusion == 'failure' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: huacnlee/autocorrect-action@v2
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          reviewdog: true
           args: --lint


### PR DESCRIPTION
The `autocorrect --lint` output in CI logs was not effective at showing contributors what needed to be changed, especially for simple spacing errors.

This commit resolves the issue by integrating reviewdog. When the linting step fails on a PR from a fork, a follow-up step is triggered to post a PR review with inline comments. This provides clear, visual feedback directly where the code is being reviewed.