### PR TITLE
fix(ci): Overhaul AutoCorrect Workflow for Fairness and Clarity

### DIFF
--- a/.github/workflows/autocorrect.yml
+++ b/.github/workflows/autocorrect.yml
@@ -18,7 +18,7 @@ on:
   pull_request_target:
     paths:
       - '.github/**'
-      - 'crater-website/src/**'        
+      - 'crater-website/src/**'
       - 'crater-website/content/**'
 
 jobs:
@@ -35,8 +35,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
-      - name: AutoCorrect and Commit (for internal PRs)
+      - name: AutoCorrect and Fix (for internal PRs)
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: huacnlee/autocorrect-action@v2
         with:
@@ -51,20 +52,26 @@ jobs:
           commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
           commit_author: GitHub Actions <41898282+github-actions[bot]@users.noreply.github.com>
 
-      - name: Lint Check (for forked PRs)
+      - name: Get changed files (for forked PRs)
         if: github.event.pull_request.head.repo.full_name != github.repository
+        id: changed-files
+        run: |
+          echo "files=$(git diff --name-only -z --diff-filter=AM ${{ github.event.pull_request.base.sha }} | xargs -0)" >> $GITHUB_OUTPUT
+
+      - name: Lint Changed Files (for forked PRs)
+        if: github.event.pull_request.head.repo.full_name != github.repository && steps.changed-files.outputs.files != ''
         id: lint
         uses: huacnlee/autocorrect-action@v2
         with:
-          args: --lint
+          args: --lint ${{ steps.changed-files.outputs.files }}
+        continue-on-error: true
 
       - name: Report with Reviewdog (for forked PRs)
-        if: failure() && steps.lint.conclusion == 'failure' && github.event.pull_request.head.repo.full_name != github.repository
+        if: |
+          github.event.pull_request.head.repo.full_name != github.repository &&
+          steps.lint.outcome == 'failure'
         uses: huacnlee/autocorrect-action@v2
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REVIEWDOG_REPORTER: github-pr-review
-          REVIEWDOG_LEVEL: warning
         with:
           reviewdog: true
-          args: --lint


### PR DESCRIPTION
### Summary

This PR overhauls the `autocorrect-action` workflow to address several critical issues related to usability, fairness for external contributors, and limitations in CI feedback. The core change is to implement a dual-strategy approach that treats internal and forked PRs differently.

### The Problems

The previous workflow had the following issues:

1.  **GitHub UI Display Bug**: A known issue in GitHub's diff view ([huacnlee/autocorrect#255](https://github.com/huacnlee/autocorrect/issues/255)) prevents whitespace changes from being rendered. This made it impossible for contributors to understand and fix linting errors when the workflow failed.
2.  **Unfair Responsibility**: The workflow was triggered by changes in specific paths but would lint the *entire* repository. This meant a contributor (Contributor B) could have their PR blocked by a pre-existing linting error introduced by someone else (Contributor A) in an unrelated file.
3.  **Ineffective Reviewdog Integration**: An attempt to fix the UI bug with Reviewdog was problematic. Reviewdog can only comment on files changed within a given PR, so it couldn't report the pre-existing errors from Contributor A on Contributor B's PR, causing confusion.

### The Solution

This new workflow resolves all three problems with the following logic:

-   **For Internal PRs (from the base repository):**
    - The original behavior is maintained. `autocorrect --fix` runs on the entire repository.
    - This allows internal contributors to collectively resolve any existing linting debt and keep the codebase consistent.

-   **For Forked PRs (from external contributors):**
    - The workflow now only lints files that have been **added or modified** in that specific PR.
    - It uses **Reviewdog** to post clear, inline comments directly on the lines with errors. This provides actionable feedback and bypasses the GitHub UI bug.
    - This approach is fairer to external contributors, as they are only responsible for the quality of the code they submit.

### Key Implementation Details

-   The workflow trigger has been changed from `pull_request` to `pull_request_target`. This is necessary to grant Reviewdog the permissions required to post comments on forked PRs.
-   This change is considered safe because the workflow only lints the code (`git diff` + `autocorrect --lint`) and does not execute any code from the fork.
-   A new step, `Get changed files`, is introduced for forked PRs to reliably identify the files to be linted, correctly handling filenames with special characters.