### PR TITLE
chore: auto merge submodules update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "21:00"  # UTC时间，对应北京时间凌晨5点
+      time: "17:00"  # UTC时间，对应北京时间凌晨1点
     open-pull-requests-limit: 5
     labels:
       - "dependabot"
     commit-message:
       prefix: "chore"
       include: "scope"
+    auto-merge: true

--- a/.github/workflows/auto-label-dependabot.yml
+++ b/.github/workflows/auto-label-dependabot.yml
@@ -22,6 +22,9 @@ jobs:
   auto-label:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - name: Auto Label Dependabot PRs
         uses: actions/github-script@v7


### PR DESCRIPTION
Auto merge submodules updating pr created by Dependabot.

* Fix permission problem in auto label workflow.
* Set `auto-merge` in dependabot config.
* Enable Allow auto-merge in repository settings.