### PR TITLE
fix: enhance dependabot auto-merge with random retry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,13 +14,16 @@
 
 version: 2
 updates:
-  # 配置submodules更新
+  # Submodules updates - rely on workflow retry mechanism to handle concurrent issues
+  # See: https://github.com/raids-lab/crater/issues/126
+  # Note: Cannot separate gitsubmodule configs due to overlapping directories constraint
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "daily"
-      time: "17:00"  # UTC时间，对应北京时间凌晨1点
-    open-pull-requests-limit: 5
+      time: "01:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 3
     labels:
       - "dependabot"
     commit-message:

--- a/.github/workflows/dependabot-auto-process.yml
+++ b/.github/workflows/dependabot-auto-process.yml
@@ -87,7 +87,33 @@ jobs:
             }
             
       - name: Enable auto-merge for submodule updates
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: |
+          # Enhanced retry mechanism with randomization to handle concurrent PR issues
+          # See: https://github.com/raids-lab/crater/issues/126
+          
+          # Random initial delay (0-60 seconds) to spread out concurrent workflows
+          INITIAL_DELAY=$((RANDOM % 61))
+          sleep $INITIAL_DELAY
+          
+          MAX_RETRIES=3
+          RETRY_COUNT=0
+          # Random base delay between 8-12 seconds
+          BASE_DELAY=$((8 + RANDOM % 5))
+          
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            if gh pr merge --auto --squash "$PR_URL"; then
+              exit 0
+            else
+              RETRY_COUNT=$((RETRY_COUNT + 1))
+              if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                # Exponential backoff with random base delay: base_delay * 2^retry_count
+                RETRY_DELAY=$((BASE_DELAY * (2 ** RETRY_COUNT)))
+                sleep $RETRY_DELAY
+              else
+                exit 1
+              fi
+            fi
+          done
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- Use squash merge to maintain linear git history
- Add randomized retry mechanism with exponential backoff
- Optimize dependabot schedule with Asia/Shanghai timezone

Resolves: https://github.com/raids-lab/crater/issues/126