### PR TITLE
fix: about crater page commit url

### DIFF
--- a/frontend/src/components/version/VersionPage.tsx
+++ b/frontend/src/components/version/VersionPage.tsx
@@ -106,7 +106,7 @@ export default function VersionPage() {
               </span>
               {frontendCommitSha ? (
                 <a
-                  href={`https://github.com/raids-lab/crater-frontend/commit/${frontendCommitSha}`}
+                  href={`https://github.com/raids-lab/crater/commit/${frontendCommitSha}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-muted-foreground hover:text-foreground transition-colors"
@@ -166,7 +166,7 @@ export default function VersionPage() {
               </span>
               {backendVersion?.commitSHA ? (
                 <a
-                  href={`https://github.com/raids-lab/crater-backend/commit/${backendVersion.commitSHA}`}
+                  href={`https://github.com/raids-lab/crater/commit/${backendVersion.commitSHA}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-muted-foreground hover:text-foreground transition-colors"
@@ -192,7 +192,7 @@ export default function VersionPage() {
             <span>{t('about.copyright')}</span>
             <span>•</span>
             <a
-              href="https://github.com/raids-lab"
+              href="https://github.com/raids-lab/crater"
               target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-foreground transition-colors"


### PR DESCRIPTION
更改“关于 Crater”页面的链接以适应仓库结构的变更。

* 修改前后端版本 GitHub 按钮的链接，使之指向 crater 主仓库，而不是之前前后端分别的仓库（由于前后端依旧是两个不同的镜像，存在版本不一致的可能，因此仍然保留了分别展示前后端版本的设计）
* 修改版权行的链接，指向 crater 主仓库，而不是指向 raids-lab 组织

---

Update links on the "About Crater" page to adapt to repository structure changes.

* Updated frontend and backend version GitHub links to point to the main crater repository instead of separate repositories (Frontend and backend versions are still displayed separately since they are different images with potential version mismatches)

* Updated the copyright line link to point to the main crater repository instead of the raids-lab organization