### PR TITLE
fix: admin job detail node jump

### DIFF
--- a/frontend/src/components/badge/node-badges.tsx
+++ b/frontend/src/components/badge/node-badges.tsx
@@ -21,10 +21,13 @@ import { Button } from '@/components/ui/button'
 import { DropdownMenuLabel } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
+import useIsAdmin from '@/hooks/use-admin'
+
 import { cn } from '@/lib/utils'
 
 const NodeBadges = ({ nodes }: { nodes?: string[] }) => {
   const navigate = useNavigate()
+  const isAdminView = useIsAdmin()
 
   if (!nodes || nodes.length === 0 || nodes[0] === '') {
     return <></>
@@ -34,7 +37,7 @@ const NodeBadges = ({ nodes }: { nodes?: string[] }) => {
   const handleBadgeClick = () => {
     if (isSingleNode) {
       navigate({
-        to: '/portal/overview/$node',
+        to: isAdminView ? '/admin/cluster/nodes/$node' : '/portal/overview/$node',
         params: { node: nodes[0] },
       })
     }
@@ -82,7 +85,7 @@ const NodeBadges = ({ nodes }: { nodes?: string[] }) => {
                       className="z-10 cursor-pointer justify-start bg-transparent px-2 py-1"
                       onClick={() =>
                         navigate({
-                          to: '/portal/overview/$node',
+                          to: isAdminView ? '/admin/cluster/nodes/$node' : '/portal/overview/$node',
                           params: { node },
                         })
                       }

--- a/frontend/src/routes/admin/cluster/nodes/index.tsx
+++ b/frontend/src/routes/admin/cluster/nodes/index.tsx
@@ -95,7 +95,7 @@ function NodesForAdmin() {
   }, [queryClient])
 
   const handleNodeScheduling = useCallback(
-     async (nodeId: string, reason?: string) => {
+    async (nodeId: string, reason?: string) => {
       try {
         await apichangeNodeScheduling(nodeId, { reason })
         await refetchTaskList()
@@ -277,7 +277,7 @@ function NodesForAdmin() {
         },
       },
     ],
-    [handleNodeScheduling, nodeColumns, t]
+    [handleNodeScheduling, nodeColumns, t, getNicknameByName]
   ) // 确保依赖项是稳定的
 
   return (
@@ -308,7 +308,7 @@ function NodesForAdmin() {
               <AccountSelect value={selectedAccount} onChange={setSelectedAccount} />
               {/* 占有原因输入 */}
               <div className="grid gap-2">
-                <Label htmlFor="occupation-reason" className="text-sm text-muted-foreground">
+                <Label htmlFor="occupation-reason" className="text-muted-foreground text-sm">
                   占有原因
                 </Label>
                 <Input
@@ -366,7 +366,7 @@ function NodesForAdmin() {
             </p>
             {/* 禁止调度原因输入 */}
             <div className="grid gap-2">
-              <Label htmlFor="scheduling-reason" className="text-sm text-muted-foreground">
+              <Label htmlFor="scheduling-reason" className="text-muted-foreground text-sm">
                 原因
               </Label>
               <Input


### PR DESCRIPTION
修复管理员视图下节点详情页面跳转错误，并修复节点管理页面的 lint 问题。这些 lint 问题是由于前几天 pre-commit 钩子失效且前端 workflow 没有 lint 检查导致的。

### 修改

- **NodeBadges 组件**：修复节点跳转路由问题，根据当前视图类型（管理员/用户）动态选择正确的节点详情页面路由，确保管理员在作业管理页面点击节点时跳转到管理员节点详情页面而非用户节点详情页面
- **节点管理页面**：修复 lint 问题，包括 `useMemo` Hook 的依赖数组警告和其他因 pre-commit 钩子失效且前端 workflow 缺少 lint 检查导致的问题

### 测试

- 测试了管理员在单一节点作业详情页面中点击节点跳转的情况，确认跳转到正确的管理员节点详情页面
- 测试了显示账户独占和禁止调度的原因的功能是否正常，确认 lint 修改后的功能未受影响

---

Fix node detail page navigation error in admin view and resolve lint issues in node management page. These lint issues were caused by pre-commit hook failures and missing lint checks in frontend workflow in recent days.

### Changes

- **NodeBadges component**: Fix node navigation route issue by dynamically selecting the correct node detail page route based on current view type (admin/user), ensuring administrators clicking nodes in job management pages navigate to admin node detail pages instead of user node detail pages
- **Node management page**: Fix lint issues including `useMemo` Hook dependency array warning and other issues caused by pre-commit hook failures and missing lint checks in frontend workflow in recent days

### Testing

- Tested node navigation when administrators click nodes in single-node job detail pages, confirming navigation to the correct admin node detail page
- Tested account occupation and scheduling disable reason display functionality to ensure it works correctly after lint fixes

---

Resolve #220
Related to #222