### PR TITLE
chore: add lint into frontend workflow

### DIFF
--- a/.github/workflows/backend-pr.yml
+++ b/.github/workflows/backend-pr.yml
@@ -25,7 +25,7 @@ env:
   GOLANGCI_LINT_VERSION: v2.2.1
 
 jobs:
-  lint:
+  backend-lint-check:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -53,9 +53,9 @@ jobs:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: backend
 
-  build_backend_test:
+  backend-build-check:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: backend-lint-check
     defaults:
       run:
         working-directory: backend

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -30,8 +30,39 @@ env:
   IMAGE_REPO: raids-lab/crater-frontend
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: "frontend/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run lint
+        run: pnpm run lint
+
   build-frontend:
     runs-on: ubuntu-latest
+    needs: lint
     defaults:
       run:
         working-directory: frontend

--- a/.github/workflows/frontend-pr.yml
+++ b/.github/workflows/frontend-pr.yml
@@ -22,8 +22,39 @@ on:
       - ".github/workflows/frontend-pr.yml"
 
 jobs:
-  build-test:
+  frontend-lint-check:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: "frontend/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run lint
+        run: pnpm run lint
+
+  frontend-build-check:
+    runs-on: ubuntu-latest
+    needs: frontend-lint-check
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
为前端 PR workflow 添加 lint 检查，并统一前后端 workflow 的 job 命名格式为 `{service}-{action}-check`，确保在分支保护规则中能够清晰识别每个检查项。

### 修改

- **为前端 workflow 添加 lint**：添加 `frontend-lint-check` job（执行 TypeScript 类型检查和 ESLint），并将 `build-test` 重命名为 `frontend-build-check`。两个 job 都配置了 pnpm 依赖缓存，当 `pnpm-lock.yaml` 未变化时可以从缓存中快速恢复依赖，一般分别可以在 1 分钟内完成
- **重命名后端 workflow job**：将 `lint` 和 `build_backend_test` 重命名为 `backend-lint-check` 和 `backend-build-check`，统一命名格式。在 GitHub 分支保护规则中设置 Required Status Checks 时，界面仅显示 job 名称而不显示所属的 workflow 文件，使用 `{service}-{action}-check` 格式可以避免命名冲突并清晰标识每个检查项

### 测试

在 fork 仓库进行了以下测试：

- 没有前端 lint 问题的 PR 能够正常通过检查
- 合并后 main 分支上能够成功构建
- 有前端 lint 问题的 PR 无法通过检查

---

Add lint check to frontend PR workflow and unify job naming format for both frontend and backend workflows to `{service}-{action}-check`, ensuring clear identification of each check item in branch protection rules.

### Changes

- **Add lint to frontend workflow**: Add `frontend-lint-check` job (runs TypeScript type checking and ESLint), rename `build-test` to `frontend-build-check`. Both jobs are configured with pnpm dependency caching, allowing quick dependency restoration from cache when `pnpm-lock.yaml` remains unchanged, typically completing within 1 minute each
- **Rename backend workflow jobs**: Rename `lint` and `build_backend_test` to `backend-lint-check` and `backend-build-check` respectively, unifying naming format. When setting Required Status Checks in GitHub branch protection rules, the interface only displays job names without showing which workflow file they belong to. Using the `{service}-{action}-check` format avoids naming conflicts and clearly identifies each check item

### Testing

The following tests were performed in fork repository:

- PRs without frontend lint issues pass checks successfully
- Main branch builds successfully after merge
- PRs with frontend lint issues fail checks as expected

---

Resolves #222