### PR TITLE
fix: delete kernel version from adminNodeDetail

### DIFF
--- a/frontend/src/components/layout/detail-page.tsx
+++ b/frontend/src/components/layout/detail-page.tsx
@@ -123,9 +123,9 @@ export default function DetailPage({
 
   return (
     <div className="flex h-full w-full flex-col space-y-6">
-      <div className="min-h-32 space-y-6">
+      <div className="h-32 space-y-6">
         {header}
-        <div className="text-muted-foreground grid grid-cols-3 gap-3 pb-2 text-sm">
+        <div className="text-muted-foreground grid grid-cols-3 gap-3 text-sm">
           {info.map((data, index) => (
             <div key={index} className={cn('flex items-center', data.className)}>
               <data.icon className="text-muted-foreground mr-1.5 size-4" />

--- a/frontend/src/components/node/node-detail.tsx
+++ b/frontend/src/components/node/node-detail.tsx
@@ -504,15 +504,6 @@ export const NodeDetail = ({ nodeName, ...props }: NodeDetailProps) => {
           title: t('nodeDetail.info.containerRuntime'),
           value: <span className="font-mono">{nodeDetail?.containerRuntimeVersion}</span>,
         },
-        ...(isAdminView && nodeDetail?.kernelVersion
-          ? [
-              {
-                icon: ServerIcon,
-                title: t('nodeDetail.info.kernelVersion'),
-                value: <span className="font-mono">{nodeDetail?.kernelVersion}</span>,
-              },
-            ]
-          : []),
       ]}
       tabs={[
         {


### PR DESCRIPTION
管理员节点详情界面删除了“内核版本”信息，上部恢复到两行：
<img width="1916" height="932" alt="屏幕截图 2025-11-12 161807" src="https://github.com/user-attachments/assets/da4ac668-36ae-420b-96ed-21da873c80a5" />
