### PR TITLE
fix: forward rule delete bug

### DIFF
--- a/frontend/src/components/codeblock/pod-container-dialog.tsx
+++ b/frontend/src/components/codeblock/pod-container-dialog.tsx
@@ -58,7 +58,7 @@ export interface PodIngressDialogProps {
   namespacedName: NamespacedName
   setNamespacedName: (namespacedName: NamespacedName) => void
   userName: string
-  jobName: string
+  jobType?: string
 }
 
 export function ContainerSelect({

--- a/frontend/src/components/job/detail/external-access-list.tsx
+++ b/frontend/src/components/job/detail/external-access-list.tsx
@@ -66,6 +66,8 @@ export const ExternalAccessItem = ({
   fullURL,
   isDeleting,
   handleDeleteItem,
+  isDeleteDisabled,
+  deleteDisabledReason,
 }: {
   name: string
   port: number
@@ -73,9 +75,11 @@ export const ExternalAccessItem = ({
   fullURL?: string
   isDeleting?: boolean
   handleDeleteItem: () => void
+  isDeleteDisabled?: boolean
+  deleteDisabledReason?: string
 }) => (
-  <div className="bg-sidebar/75 flex items-center space-x-2 rounded-md border p-3">
-    <div className="ml-2 flex grow flex-col items-start justify-start gap-0.5">
+  <div className="bg-sidebar/75 flex min-w-0 items-center space-x-2 rounded-md border p-3">
+    <div className="ml-2 flex min-w-0 grow flex-col items-start justify-start gap-0.5">
       <div className="flex flex-row items-center justify-start gap-2">
         <p className="font-semibold">{name}</p>
         <TipBadge
@@ -87,7 +91,9 @@ export const ExternalAccessItem = ({
           }
         />
       </div>
-      <div className="text-muted-foreground flex flex-row font-mono text-xs">{url}</div>
+      <div className="text-muted-foreground flex w-full flex-row font-mono text-xs break-all">
+        {url}
+      </div>
     </div>
     <TooltipButton
       variant="ghost"
@@ -107,8 +113,8 @@ export const ExternalAccessItem = ({
           variant="ghost"
           size="icon"
           className="hover:text-destructive"
-          tooltipContent="删除"
-          disabled={isDeleting}
+          tooltipContent={isDeleteDisabled ? deleteDisabledReason || '删除已禁用' : '删除'}
+          disabled={isDeleting || isDeleteDisabled}
         >
           <Trash2 className="size-4" />
         </TooltipButton>
@@ -125,7 +131,11 @@ export const ExternalAccessItem = ({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>取消</AlertDialogCancel>
-          <AlertDialogAction variant="destructive" onClick={handleDeleteItem} disabled={isDeleting}>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={handleDeleteItem}
+            disabled={isDeleting || isDeleteDisabled}
+          >
             {isDeleting ? '删除中...' : '删除'}
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/frontend/src/components/job/detail/index.tsx
+++ b/frontend/src/components/job/detail/index.tsx
@@ -321,7 +321,7 @@ export default function BaseCore({ jobName, ...props }: DetailPageCoreProps & { 
           key: 'base',
           icon: LayoutGridIcon,
           label: '基本信息',
-          children: <PodTable jobName={jobName} userName={data.username} />,
+          children: <PodTable jobName={jobName} userName={data.username} jobType={data.jobType} />,
           scrollable: true,
           hidden: jobStatus === JobStatus.MetadataOnly || isCompletedOver3Days,
         },

--- a/frontend/src/components/job/detail/ingress.tsx
+++ b/frontend/src/components/job/detail/ingress.tsx
@@ -29,7 +29,7 @@ export default function PodIngressDialog({
   namespacedName,
   setNamespacedName,
   userName,
-  jobName,
+  jobType,
 }: PodIngressDialogProps) {
   const [isOpen, setIsOpen] = useNamespacedState(namespacedName, setNamespacedName)
   const [activeTab, setActiveTab] = useState<'ingress' | 'nodeport'>('ingress')
@@ -65,7 +65,7 @@ export default function PodIngressDialog({
               style={{ display: activeTab === "ingress" ? "block" : "none" }}
             >
               {namespacedName && (
-                <IngressPanel namespacedName={namespacedName} jobName={jobName} />
+                <IngressPanel namespacedName={namespacedName} jobType={jobType} />
               )}
             </TabsContent>
 

--- a/frontend/src/components/job/detail/nodeport-panel.tsx
+++ b/frontend/src/components/job/detail/nodeport-panel.tsx
@@ -125,8 +125,15 @@ export function NodeportPanel({ namespacedName }: NodeportPanelProps) {
   }
 
   const handleDeleteNodeport = (data: PodNodeport) => {
-    if (namespacedName) {
-      deleteNodeportMutation(data)
+    if (namespacedName && data.name && data.containerPort) {
+      // 转换为 PodNodeportMgr 格式，只包含 name 和 containerPort
+      const nodeportMgr: PodNodeportMgr = {
+        name: data.name,
+        containerPort: data.containerPort,
+      }
+      deleteNodeportMutation(nodeportMgr)
+    } else {
+      toast.error('删除失败：数据不完整')
     }
   }
 
@@ -135,7 +142,7 @@ export function NodeportPanel({ namespacedName }: NodeportPanelProps) {
       <ExternalAccessItem
         key={nodePort.name}
         name={nodePort.name}
-        port={nodePort.nodePort}
+        port={nodePort.containerPort}
         url={`${nodePort.address}:${nodePort.nodePort}`}
         fullURL={`http://${nodePort.address}:${nodePort.nodePort}`}
         isDeleting={isDeleting}

--- a/frontend/src/components/job/detail/pod-table.tsx
+++ b/frontend/src/components/job/detail/pod-table.tsx
@@ -45,6 +45,7 @@ import PodIngressDialog from './ingress'
 interface PodTableProps {
   jobName: string
   userName: string
+  jobType?: string
 }
 
 const getHeader = (key: string): string => {
@@ -150,7 +151,7 @@ const PodInfo = ({
   )
 }
 
-export const PodTable = ({ jobName, userName }: PodTableProps) => {
+export const PodTable = ({ jobName, userName, jobType }: PodTableProps) => {
   const [showLog, setShowLog] = useState<NamespacedName>()
   const [showTerminal, setShowTerminal] = useState<NamespacedName>()
   const [showIngress, setShowIngress] = useState<NamespacedName>()
@@ -329,7 +330,7 @@ export const PodTable = ({ jobName, userName }: PodTableProps) => {
         namespacedName={showIngress}
         setNamespacedName={setShowIngress}
         userName={userName}
-        jobName={jobName}
+        jobType={jobType}
       />
       <Sheet open={showMonitor} onOpenChange={setShowMonitor}>
         <SheetContent className="sm:max-w-4xl">

--- a/frontend/src/services/api/tool.ts
+++ b/frontend/src/services/api/tool.ts
@@ -92,10 +92,7 @@ export const apiDeletePodIngress = (
   namespace: string,
   podName: string,
   ingressMgr: PodIngressMgr
-) =>
-  apiV1Delete<IResponse<string>>(`namespaces/${namespace}/pods/${podName}/ingresses`, {
-    data: ingressMgr,
-  })
+) => apiV1Delete<IResponse<string>>(`namespaces/${namespace}/pods/${podName}/ingresses`, ingressMgr)
 
 export interface PodNodeport {
   name: string
@@ -128,6 +125,4 @@ export const apiDeletePodNodeport = (
   podName: string,
   nodeportMgr: PodNodeportMgr
 ) =>
-  apiV1Delete<IResponse<string>>(`namespaces/${namespace}/pods/${podName}/nodeports`, {
-    data: nodeportMgr,
-  })
+  apiV1Delete<IResponse<string>>(`namespaces/${namespace}/pods/${podName}/nodeports`, nodeportMgr)


### PR DESCRIPTION
修复外部访问规则删除功能

主要修复：
- 修复删除 Bug：解决 NodePort 和 Ingress 规则删除时的 API 参数验证错误
- 显示优化：NodePort 规则显示容器端口而非节点端口，改善 URL 显示换行
- Jupyter 保护：为 Jupyter 作业的默认 notebook 规则（端口 8888）添加删除保护