### PR TITLE
chore: add build & pr workflow for storage server

### DIFF
--- a/.github/workflows/storage-build.yml
+++ b/.github/workflows/storage-build.yml
@@ -12,21 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Storage Server Build
+name: Storage Build
 
 on:
   push:
     branches: [main]
     paths:
       - "storage/**"
-      - ".github/workflows/storage-server.yml"
+      - ".github/workflows/storage-build.yml"
     tags:
       - "v*.*.*"
 
 env:
   REGISTRY: ghcr.io
   IMAGE_REPO: raids-lab/storage-server
-  GOLANGCI_LINT_VERSION: v1.61.0
+  # Golang-lint version
+  GOLANGCI_LINT_VERSION: v2.2.1
 
 jobs:
   lint:
@@ -36,14 +37,14 @@ jobs:
         working-directory: storage
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version-file: "storage/go.mod"
+          go-version-file: "storage/go.mod" # get Go version from go.mod
 
       - name: Download dependencies
         run: |
@@ -52,18 +53,10 @@ jobs:
           go mod download
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --print-issued-lines=false --out-format code-climate:gl-code-quality-report.json,line-number
           working-directory: storage
-
-      - name: Upload code quality report
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-quality-report
-          path: storage/gl-code-quality-report.json
-          retention-days: 7
 
   build_storage_server:
     runs-on: ubuntu-latest
@@ -83,12 +76,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "storage/go.mod"
 
@@ -98,10 +91,33 @@ jobs:
           go env -w GOPROXY=https://goproxy.cn,direct
           go mod download
 
+      - name: Set version variables
+        id: set-version
+        run: |
+          COMMIT_SHA="${{ github.sha }}"
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+
+          # Check if triggered by tag
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            # Tag trigger: use tag version (keep v prefix)
+            APP_VERSION="${{ github.ref_name }}"
+            BUILD_TYPE="release"
+          else
+            # Branch trigger: use commit SHA
+            APP_VERSION="$SHORT_SHA"
+            BUILD_TYPE="development"
+          fi
+
+          # Set outputs
+          echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT
+          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "build_type=$BUILD_TYPE" >> $GITHUB_OUTPUT
+          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
       - name: Build storage server binaries
         run: |
           mkdir -p bin/${{ matrix.platform.image_platform }}
-          go build -ldflags="-w -s" -o bin/${{ matrix.platform.image_platform }}/storage-server main.go
+          go build -ldflags="-X main.AppVersion=${{ steps.set-version.outputs.app_version }} -X main.CommitSHA=${{ steps.set-version.outputs.commit_sha }} -X main.BuildType=${{ steps.set-version.outputs.build_type }} -X main.BuildTime=${{ steps.set-version.outputs.build_time }} -w -s" -o bin/${{ matrix.platform.image_platform }}/storage-server main.go
         env:
           CGO_ENABLED: 0
           GOOS: ${{ matrix.platform.goos }}
@@ -121,10 +137,10 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all platform binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: storage/bin/
 
@@ -174,3 +190,4 @@ jobs:
           delete-untagged: true
           keep-at-most: 2
           skip-tags: v*
+

--- a/.github/workflows/storage-pr.yml
+++ b/.github/workflows/storage-pr.yml
@@ -1,0 +1,101 @@
+# Copyright 2025 RAIDS Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Storage PR Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "storage/**"
+      - ".github/workflows/storage-pr.yml"
+
+env:
+  GOLANGCI_LINT_VERSION: v2.2.1
+
+jobs:
+  storage-lint-check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: storage
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "storage/go.mod"
+
+      - name: Download dependencies
+        run: |
+          go env -w GO111MODULE=on
+          go env -w GOPROXY=https://goproxy.cn,direct
+          go mod download
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          working-directory: storage
+
+  storage-build-check:
+    runs-on: ubuntu-latest
+    needs: storage-lint-check
+    defaults:
+      run:
+        working-directory: storage
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "storage/go.mod"
+
+      - name: Download dependencies
+        run: |
+          go env -w GO111MODULE=on
+          go env -w GOPROXY=https://goproxy.cn,direct
+          go mod download
+
+      - name: Set version variables
+        id: set-version
+        run: |
+          COMMIT_SHA="${{ github.sha }}"
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+
+          # PR builds are always development builds
+          APP_VERSION="$SHORT_SHA"
+          BUILD_TYPE="development"
+
+          # Set outputs
+          echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT
+          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "build_type=$BUILD_TYPE" >> $GITHUB_OUTPUT
+          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Build storage server binary
+        run: |
+          mkdir -p bin/linux_amd64
+          go build -ldflags="-X main.AppVersion=${{ steps.set-version.outputs.app_version }} -X main.CommitSHA=${{ steps.set-version.outputs.commit_sha }} -X main.BuildType=${{ steps.set-version.outputs.build_type }} -X main.BuildTime=${{ steps.set-version.outputs.build_time }} -w -s" -o bin/linux_amd64/storage-server main.go
+        env:
+          CGO_ENABLED: 0
+

--- a/storage/.golangci.yml
+++ b/storage/.golangci.yml
@@ -1,110 +1,14 @@
-# This configuration file is not a recommendation.
-#
-# We intentionally use a limited set of linters.
-# This configuration file is used with different version of golangci-lint to avoid regressions:
-# the linters can change between version,
-# their configuration may be not compatible or their reports can be different,
-# and this can break some of our tests.
-# Also, some linters are not relevant for the project (e.g. linters related to SQL).
-#
-# We have specific constraints, so we use a specific configuration.
-#
-# See the file `.golangci.reference.yml` to have a list of all available configuration options.
-
-linters-settings:
-  depguard:
-    rules:
-      logger:
-        deny:
-          # logging is allowed only by logutils.Log,
-          - pkg: "github.com/pkg/errors"
-            desc: Should be replaced by standard lib errors package.
-          - pkg: "github.com/instana/testify"
-            desc: It's a fork of github.com/stretchr/testify.
-  dupl:
-    threshold: 100
-  funlen:
-    lines: -1 # the number of lines (code + empty lines) is not a right metric and leads to code without empty line or one-liner.
-    statements: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-  gocyclo:
-    min-complexity: 15
-  godox:
-    keywords:
-      - FIXME
-  gofmt:
-    rewrite-rules:
-      - pattern: "interface{}"
-        replacement: "any"
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
-  mnd:
-    # don't include the "operation" and "assign"
-    checks:
-      - argument
-      - case
-      - condition
-      - return
-    ignored-numbers:
-      - "0"
-      - "1"
-      - "2"
-      - "3"
-    ignored-functions:
-      - strings.SplitN
-  govet:
-    settings:
-      printf:
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-    enable:
-      - nilness
-      - shadow
-  errorlint:
-    asserts: false
-  lll:
-    line-length: 140
-  misspell:
-    locale: US
-    ignore-words:
-      - "importas" # linter name
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: true # require an explanation for nolint directives
-    require-specific: true # require nolint directives to be specific about which linter is being skipped
-  revive:
-    rules:
-      - name: unexported-return
-        disabled: true
-      - name: unused-parameter
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
+    - copyloopvar
     - depguard
     - dogsled
     - dupl
     - errcheck
     - errorlint
-    - copyloopvar
     - funlen
     - gocheckcompilerdirectives
     - gochecknoinits
@@ -112,81 +16,176 @@ linters:
     - gocritic
     - gocyclo
     - godox
-    - gofmt
-    - goimports
-    - mnd
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
+    - mnd
     - nakedret
     - noctx
     - nolintlint
     - revive
     - staticcheck
-    - stylecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-
-  # This list of linters is not a recommendation (same thing for all this configuration file).
-  # We intentionally use a limited set of linters.
-  # See the comment on top of this file.
-
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: (.+)_test\.go
-      linters:
-        - dupl
-        - mnd
-        - lll
-
-    - path: pkg/golinters
-      linters:
-        - dupl
-
-    - path: pkg/golinters/errcheck.go
-      linters: [staticcheck]
-      text: "SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead"
-    - path: pkg/commands/run.go
-      linters: [staticcheck]
-      text: "SA1019: lsc.Errcheck.Exclude is deprecated: use ExcludeFunctions instead"
-    - path: pkg/commands/run.go
-      linters: [staticcheck]
-      text: "SA1019: c.cfg.Run.ShowStats is deprecated: use Output.ShowStats instead."
-    - path: pkg/golinters/govet.go
-      text: "SA1019: cfg.CheckShadowing is deprecated: the linter should be enabled inside `Enable`."
-    - path: pkg/commands/config.go
-      text: "SA1019: cfg.Run.UseDefaultSkipDirs is deprecated: use Issues.UseDefaultExcludeDirs instead."
-
-    - path: pkg/golinters/godot.go
-      linters: [staticcheck]
-      text: "SA1019: settings.CheckAll is deprecated: use `Scope` instead"
-
-    - path: pkg/golinters/gofumpt.go
-      linters: [staticcheck]
-      text: "SA1019: settings.LangVersion is deprecated: use the global `run.go` instead."
-    - path: pkg/golinters/staticcheck_common.go
-      linters: [staticcheck]
-      text: "SA1019: settings.GoVersion is deprecated: use the global `run.go` instead."
-    - path: pkg/lint/lintersdb/manager.go
-      linters: [staticcheck]
-      text: "SA1019: (.+).(GoVersion|LangVersion) is deprecated: use the global `run.go` instead."
-
-    - path: pkg/golinters/unused.go
-      linters: [gocritic]
-      text: "rangeValCopy: each iteration copies 160 bytes \\(consider pointers or indexing\\)"
-
-  exclude-dirs:
-    - test/testdata_etc # test files
-    - internal/cache # extracted from Go code
-    - internal/renameio # extracted from Go code
-    - internal/robustio # extracted from Go code
-
-run:
-  timeout: 5m
+  settings:
+    depguard:
+      rules:
+        logger:
+          deny:
+            - pkg: github.com/pkg/errors
+              desc: Should be replaced by standard lib errors package.
+            - pkg: github.com/instana/testify
+              desc: It's a fork of github.com/stretchr/testify.
+    dupl:
+      threshold: 100
+    errorlint:
+      asserts: false
+    funlen:
+      lines: -1
+      statements: 100
+    goconst:
+      min-len: 2
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    godox:
+      keywords:
+        - FIXME
+    govet:
+      enable:
+        - nilness
+        - shadow
+      settings:
+        printf:
+          funcs:
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+      ignore-rules:
+        - importas
+    mnd:
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+      ignored-numbers:
+        - "0"
+        - "1"
+        - "2"
+        - "3"
+      ignored-functions:
+        - strings.SplitN
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-unused: false
+    revive:
+      rules:
+        - name: unexported-return
+          disabled: true
+        - name: unused-parameter
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - lll
+          - mnd
+        path: (.+)_test\.go
+      - linters:
+          - dupl
+        path: pkg/golinters
+      - linters:
+          - staticcheck
+        path: pkg/golinters/errcheck.go
+        text: 'SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead'
+      - linters:
+          - staticcheck
+        path: pkg/commands/run.go
+        text: 'SA1019: lsc.Errcheck.Exclude is deprecated: use ExcludeFunctions instead'
+      - linters:
+          - staticcheck
+        path: pkg/commands/run.go
+        text: 'SA1019: c.cfg.Run.ShowStats is deprecated: use Output.ShowStats instead.'
+      - path: pkg/golinters/govet.go
+        text: 'SA1019: cfg.CheckShadowing is deprecated: the linter should be enabled inside `Enable`.'
+      - path: pkg/commands/config.go
+        text: 'SA1019: cfg.Run.UseDefaultSkipDirs is deprecated: use Issues.UseDefaultExcludeDirs instead.'
+      - linters:
+          - staticcheck
+        path: pkg/golinters/godot.go
+        text: 'SA1019: settings.CheckAll is deprecated: use `Scope` instead'
+      - linters:
+          - staticcheck
+        path: pkg/golinters/gofumpt.go
+        text: 'SA1019: settings.LangVersion is deprecated: use the global `run.go` instead.'
+      - linters:
+          - staticcheck
+        path: pkg/golinters/staticcheck_common.go
+        text: 'SA1019: settings.GoVersion is deprecated: use the global `run.go` instead.'
+      - linters:
+          - staticcheck
+        path: pkg/lint/lintersdb/manager.go
+        text: 'SA1019: (.+).(GoVersion|LangVersion) is deprecated: use the global `run.go` instead.'
+      - linters:
+          - gocritic
+        path: pkg/golinters/unused.go
+        text: 'rangeValCopy: each iteration copies 160 bytes \(consider pointers or indexing\)'
+    paths:
+      - test/testdata_etc
+      - internal/cache
+      - internal/renameio
+      - internal/robustio
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+    goimports:
+      local-prefixes:
+        - github.com/golangci/golangci-lint
+  exclusions:
+    generated: lax
+    paths:
+      - test/testdata_etc
+      - internal/cache
+      - internal/renameio
+      - internal/robustio
+      - third_party$
+      - builtin$
+      - examples$

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -2,6 +2,7 @@ module webdav
 
 go 1.24.0
 
+toolchain go1.24.4
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/sirupsen/logrus v1.9.3

--- a/storage/service/dataset.go
+++ b/storage/service/dataset.go
@@ -82,11 +82,12 @@ func MoveDatasetOrModel(c *gin.Context) {
 		return
 	}
 	var dest string
-	if dataset.Type == model.DataTypeModel {
+	switch dataset.Type {
+	case model.DataTypeModel:
 		dest = model.ModelPrefix
-	} else if dataset.Type == model.DataTypeDataset {
+	case model.DataTypeDataset:
 		dest = model.DatasetPrefix
-	} else {
+	default:
 		response.Error(c, "The type of dataset is incorrect", response.NotSpecified)
 		return
 	}


### PR DESCRIPTION
为 storage-server 创建与后端一致的 CI 流水线，解决升级 Go 版本后构建失败的问题。

### 修改

- **创建 storage-build.yml**：将原有的 storage-server.yml 重命名并重构，添加完整的构建和镜像推送 workflow，支持多平台构建（linux/amd64、linux/arm64），包含 lint、构建和镜像推送步骤
- **创建 storage-pr.yml**：新增 storage-server 的 PR 检查 workflow，包含代码检查和构建验证步骤
- **更新 golangci-lint 配置**：将 storage/.golangci.yml 从旧版本配置更新为与 golangci-lint v2.2.1 兼容的配置
- **统一 golangci-lint 版本**：在 workflow 中指定 golangci-lint 版本为 v2.2.1，与后端保持一致
- **代码适配**：修改 storage/service/dataset.go 中的代码以符合 golangci-lint v2.2.1 的检查规则（将 if-else 链改为 switch 语句）

### 测试

- 在 fork 仓库中验证新创建的 workflow 可以正常通过，包括 lint 检查、构建和镜像推送流程

---

Create CI pipelines for storage-server consistent with the backend to fix build failures after Go version upgrade.

### Changes

- **Create storage-build.yml**: Rename and refactor the original storage-server.yml, add complete build and image push workflow supporting multi-platform builds (linux/amd64, linux/arm64), including lint, build, and image push steps
- **Create storage-pr.yml**: Add new PR check workflow for storage-server, including code check and build verification steps
- **Update golangci-lint configuration**: Update storage/.golangci.yml from old version configuration to be compatible with golangci-lint v2.2.1
- **Unify golangci-lint version**: Specify golangci-lint version as v2.2.1 in workflows to match the backend
- **Code adaptation**: Modify code in storage/service/dataset.go to comply with golangci-lint v2.2.1 check rules (refactor if-else chain to switch statement)

### Testing

- Verified in fork repository that the newly created workflows pass successfully, including lint checks, build, and image push processes

---

Resolves #247