### PR TITLE
fix: remove redundant copy command in SS dockerfile

### DIFF
--- a/storage/Dockerfile
+++ b/storage/Dockerfile
@@ -11,8 +11,6 @@ ENV TZ=Asia/Shanghai
 
 COPY $BIN_DIR/bin-${TARGETPLATFORM//\//_}/storage-server .
 
-COPY ./etc /etc 
-
 RUN chmod +x storage-server
 
 EXPOSE 7320 


### PR DESCRIPTION
修复 storage-server Dockerfile 中冗余的 COPY 命令，解决构建失败问题。

### 修改

- **storage/Dockerfile**：删除 `COPY ./etc /etc` 命令，因为配置文件在运行时通过 Kubernetes ConfigMap 挂载到 `/etc/config.yaml`，构建时不需要复制该目录

### 测试

- 确认 etc 目录在 #245 中已被移除，配置文件通过 ConfigMap 正确挂载

---

Fix redundant COPY command in storage-server Dockerfile to resolve build failures.

### Changes

- **storage/Dockerfile**: Remove `COPY ./etc /etc` command, as the configuration file is mounted via Kubernetes ConfigMap to `/etc/config.yaml` at runtime, and does not need to be copied during build

### Testing

- Confirmed that etc directory was removed in #245 and configuration file is correctly mounted via ConfigMap
