### PR TITLE
Fix node status badge style error

### DIFF
--- a/frontend/src/components/badge/node-status-badge.tsx
+++ b/frontend/src/components/badge/node-status-badge.tsx
@@ -93,34 +93,33 @@ const getNodeStatusLabel = (
   }
 }
 
-// 修改点:支持传入可选的 reason 字段(比如来自 annotations)并在 badge 的 description 中显示。
-// 说明:PhaseBadge 会通过 getPhaseLabel(status) 获取 label/color/description,
-// 所以这里传入一个闭包 getPhaseLabel 用于在存在 reason 时覆盖 description。
-// disableTooltip: 当为 true 时,不显示 PhaseBadge 内部的默认 tooltip(用于外部自定义 tooltip 场景)
 const NodeStatusBadge = ({
   status,
   reason,
-  disableTooltip = false,
+  disableDefaultTooltip = false,
 }: {
   status: string
   reason?: string
-  disableTooltip?: boolean
+  disableDefaultTooltip?: boolean
 }) => {
-  // 本地的 getPhaseLabel 会基于原始映射生成结果,
-  // 当提供了 reason(非空)时,用 reason 覆盖 description 字段,确保悬浮/描述显示用户传入的原因文本。
   const getPhaseLabel = (s: string) => {
     const base = getNodeStatusLabel(s)
     if (reason && typeof reason === 'string' && reason.trim() !== '') {
       return {
         ...base,
-        // 覆盖 description,显示传入的原因(去除前后空白)
         description: reason.trim(),
       }
     }
     return base
   }
 
-  return <PhaseBadge phase={status} getPhaseLabel={getPhaseLabel} disableTooltip={disableTooltip} />
+  return (
+    <PhaseBadge
+      phase={status}
+      getPhaseLabel={getPhaseLabel}
+      disableDefaultTooltip={disableDefaultTooltip}
+    />
+  )
 }
 
 export default NodeStatusBadge

--- a/frontend/src/components/badge/phase-badge.tsx
+++ b/frontend/src/components/badge/phase-badge.tsx
@@ -27,18 +27,18 @@ export interface PhaseBadgeData {
 interface PhaseBadgeProps<T> {
   phase: T
   getPhaseLabel: (phase: T) => PhaseBadgeData
-  disableTooltip?: boolean
+  disableDefaultTooltip?: boolean
 }
 
 export const PhaseBadge = <T,>({
   phase,
   getPhaseLabel,
-  disableTooltip = false,
+  disableDefaultTooltip = false,
 }: PhaseBadgeProps<T>) => {
   const data = getPhaseLabel(phase)
 
   // 如果禁用 tooltip,直接返回 badge
-  if (disableTooltip) {
+  if (disableDefaultTooltip) {
     return (
       <Badge className={cn('border-none', data.color)} variant="outline">
         <div>{data.label}</div>

--- a/frontend/src/components/node/node-list.tsx
+++ b/frontend/src/components/node/node-list.tsx
@@ -379,7 +379,7 @@ export const getNodeColumns = (
             <Tooltip>
               <TooltipTrigger asChild>
                 <span>
-                  <NodeStatusBadge status={status} disableTooltip={true} />
+                  <NodeStatusBadge status={status} disableDefaultTooltip={true} />
                 </span>
               </TooltipTrigger>
               <TooltipContent>{tooltipContent}</TooltipContent>


### PR DESCRIPTION
节点状态 Badge 自带默认 tooltip 提示信息，在鼠标光标随机 hover 时可能弹出，现已修复。