### PR TITLE
fix: image start failed caused by image rename during snapshot

### DIFF
--- a/backend/internal/handler/vcjob/jupyter.go
+++ b/backend/internal/handler/vcjob/jupyter.go
@@ -477,17 +477,7 @@ func (mgr *VolcanojobMgr) CreateJupyterSnapshot(c *gin.Context) {
 
 	// generate image link
 	currentImageName := pod.Spec.Containers[0].Image
-	// 根据作业类型设置镜像名前缀
-	var imageNamePrefix string
-	switch job.JobType {
-	case model.JobTypeJupyter:
-		imageNamePrefix = "jupyter"
-	case model.JobTypeCustom:
-		imageNamePrefix = "custom"
-	default:
-		imageNamePrefix = "snapshot"
-	}
-	imageLink, err := utils.GenerateNewImageLinkForDockerfileBuild(currentImageName, token.Username, imageNamePrefix, "")
+	imageLink, err := utils.GenerateNewImageLinkForDockerfileBuild(currentImageName, token.Username, "", "")
 	if err != nil {
 		resputil.Error(c, "generate new image link failed", resputil.NotSpecified)
 		return


### PR DESCRIPTION
修复快照功能中镜像名称被错误修改导致启动脚本选择失败的问题。由于 #252 引入的功能会根据作业类型强制修改快照镜像的名称，导致平台无法根据镜像名称正确选择 Jupyter 启动脚本。

### 修改

- **快照镜像名称生成**：移除根据作业类型（Jupyter/Custom）强制设置镜像名前缀的逻辑，恢复为保留原始镜像名称并只生成新的 tag，确保镜像名称中的关键特征信息（如是否包含 "jupyter"、"envd" 等）得以保留

### 测试

- 进行了代码静态检查（肉眼观察）

---

Fix the issue where snapshot images fail to start due to incorrect image name modification. The feature introduced in #252 forcibly modified snapshot image names based on job types, causing the platform to fail in selecting the correct Jupyter startup scripts based on image names.

### Changes

- **Snapshot image name generation**: Remove the logic that forcibly sets image name prefixes based on job types (Jupyter/Custom), restore to preserve original image names and only generate new tags, ensuring key characteristic information in image names (such as whether they contain "jupyter", "envd", etc.) is preserved

### Testing

- Code static checks (read) performed

---

Resolve #257