### PR TITLE
fix: cluster nodelist crash

### DIFF
--- a/frontend/src/components/node/node-list.tsx
+++ b/frontend/src/components/node/node-list.tsx
@@ -214,7 +214,7 @@ export const getNodeColumns = (
       header: ({ column }) => <DataTableColumnHeader column={column} title={'架构'} />,
       cell: ({ row }) => {
         const arch = row.getValue<string>('arch')
-        const isArm = arch?.toLowerCase().includes('arm')
+        const isArm = arch?.toLowerCase()?.includes('arm') ?? false
         return (
           <Badge
             variant="outline"


### PR DESCRIPTION
<img width="416" height="126" alt="微信图片_2025-11-23_202426_063" src="https://github.com/user-attachments/assets/c27cefa3-fac3-453b-9212-4c9bf7362180" />

fix #263

对于上述报错，后端返回的某节点体系结构字段可能为`undefined`（节点信息不完整、正在数据迁移、节点状态异常等情况导致），原前端代码如下：
```
const isArm = arch?.toLowerCase().includes('arm')
```
对于`undefined`情况，没有`include`方法，所以导致程序崩溃报错。对于这种情况，直接置`isArm`为`false`，防止崩溃，修改如下：
```
const isArm = arch?.toLowerCase()?.includes('arm') ?? false
```