### PR TITLE
feat: add ip in node list

### DIFF
--- a/frontend/src/components/node/node-list.tsx
+++ b/frontend/src/components/node/node-list.tsx
@@ -24,6 +24,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 
 import NodeStatusBadge, { nodeStatuses } from '@/components/badge/node-status-badge'
 import TooltipLink from '@/components/label/tooltip-link'
+import TooltipCopy from '@/components/label/tooltop-copy'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
 import { DataTableToolbarConfig } from '@/components/query-table/toolbar'
 import { ProgressBar, progressTextColor } from '@/components/ui-custom/colorful-progress'
@@ -337,6 +338,17 @@ export const getNodeColumns = (
           tooltip={`查看 ${row.original.name} 节点详情`}
         />
       ),
+    },
+    {
+      accessorKey: 'address',
+      header: ({ column }) => <DataTableColumnHeader column={column} title={'IP地址'} />,
+      cell: ({ row }) => {
+        const address = row.getValue<string>('address')
+        if (!address) {
+          return <span className="font-mono">-</span>
+        }
+        return <TooltipCopy name={address} className="font-mono" />
+      },
     },
     {
       accessorKey: 'role',

--- a/frontend/src/routes/admin/cluster/nodes/index.tsx
+++ b/frontend/src/routes/admin/cluster/nodes/index.tsx
@@ -353,6 +353,7 @@ function NodesForAdmin() {
         initialColumnVisibility={{
           gpuDriver: false, // 默认隐藏加速卡驱动版本列
           kernelVersion: false,
+          address: false, // 默认隐藏IP地址列
         }}
       />
       {/* 占有 / 释放 弹窗：在占有分支中增加 reason 输入 */}

--- a/frontend/src/services/api/cluster.ts
+++ b/frontend/src/services/api/cluster.ts
@@ -47,6 +47,7 @@ export interface INodeBriefInfo {
   annotations: Record<string, string>
   kernelVersion?: string
   gpuDriver?: string
+  address?: string
 }
 export interface IClusterPodInfo {
   // from backend


### PR DESCRIPTION
为管理员节点管理页面添加 IP 地址列，默认隐藏，支持点击复制功能，与节点详情页的 IP 显示保持一致。

### 修改

- **后端**：在 `NodeBriefInfo` 结构体中添加 `Address` 字段，创建 `getNodeIP` 辅助函数统一提取节点 IP 地址逻辑，并在 `ListNodes` 和 `GetNode` 函数中使用该逻辑确保列表和详情页的 IP 地址一致
- **前端**：在节点列表接口中添加 `address` 字段，在节点列表列定义中添加 IP 地址列并使用 `TooltipCopy` 组件实现点击复制和 hover 提示功能，在管理员节点管理页面设置 IP 地址列默认隐藏

### 测试

- 本地运行后端和前端服务，进入管理员节点管理页面验证 IP 地址列显示正常
- 测试 IP 地址列的点击复制功能和 hover 提示是否正常工作
- 验证节点列表的 IP 地址与节点详情页的 IP 地址显示一致
- 验证 IP 地址列默认隐藏，可通过列选择器显示

---

Add an IP address column to the admin node management page, hidden by default, with click-to-copy functionality, keeping it consistent with the IP display on the node detail page.

### Changes

- **Backend**: Add `Address` field to `NodeBriefInfo` struct, create `getNodeIP` helper function to unify node IP address extraction logic, and use this logic in both `ListNodes` and `GetNode` functions to ensure IP addresses are consistent between list and detail pages
- **Frontend**: Add `address` field to node list interface, add IP address column to node list column definitions using `TooltipCopy` component for click-to-copy and hover tooltip functionality, set IP address column to be hidden by default in admin node management page

### Testing

- Run backend and frontend services locally, navigate to admin node management page to verify IP address column displays correctly
- Test click-to-copy functionality and hover tooltip for IP address column
- Verify IP addresses in node list match those displayed on node detail page
- Verify IP address column is hidden by default and can be shown via column selector

---

Resolve #273