### PR TITLE
chore: fix backend workflow cache

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: "backend/go.mod" # get Go version from go.mod
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: backend/go.sum # get Go version from go.mod
 
       - name: Download dependencies
         run: |
@@ -84,6 +85,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "backend/go.mod"
+          cache-dependency-path: backend/go.sum
 
       - name: Download dependencies
         run: |

--- a/.github/workflows/backend-pr.yml
+++ b/.github/workflows/backend-pr.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "backend/go.mod"
+          cache-dependency-path: backend/go.sum
 
       - name: Download dependencies
         run: |
@@ -69,6 +70,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "backend/go.mod"
+          cache-dependency-path: backend/go.sum
 
       - name: Download dependencies
         run: |

--- a/.github/workflows/storage-build.yml
+++ b/.github/workflows/storage-build.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "storage/go.mod" # get Go version from go.mod
+          cache-dependency-path: storage/go.sum
 
       - name: Download dependencies
         run: |
@@ -84,6 +85,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "storage/go.mod"
+          cache-dependency-path: storage/go.sum
 
       - name: Download dependencies
         run: |

--- a/.github/workflows/storage-pr.yml
+++ b/.github/workflows/storage-pr.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "storage/go.mod"
+          cache-dependency-path: storage/go.sum
 
       - name: Download dependencies
         run: |
@@ -69,6 +70,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "storage/go.mod"
+          cache-dependency-path: storage/go.sum
 
       - name: Download dependencies
         run: |


### PR DESCRIPTION
修复了后端和存储服务的 GitHub Actions workflow 缓存配置问题，解决了 "Dependencies file is not found" 警告，使 Go 依赖缓存能够正常工作。

### 修改

- **backend workflow**：在 `backend-pr.yml` 和 `backend-build.yml` 的所有 "Set up Go" 步骤中添加 `cache-dependency-path: backend/go.sum` 配置
- **storage workflow**：在 `storage-pr.yml` 和 `storage-build.yml` 的所有 "Set up Go" 步骤中添加 `cache-dependency-path: storage/go.sum` 配置

### 测试

- 在 fork 仓库中提交 PR 并检查 workflow 运行情况，确认不再出现警告，并在同一 workflow 的第二个阶段（build 阶段）观察到缓存命中

---

Fix GitHub Actions workflow cache configuration issues for backend and storage services, resolving the "Dependencies file is not found" warning and enabling proper Go dependency caching.

### Changes

- **backend workflow**: Add `cache-dependency-path: backend/go.sum` configuration to all "Set up Go" steps in `backend-pr.yml` and `backend-build.yml`
- **storage workflow**: Add `cache-dependency-path: storage/go.sum` configuration to all "Set up Go" steps in `storage-pr.yml` and `storage-build.yml`

### Testing

- Submit PR in fork repository and check workflow execution, confirming no warnings appear and observing cache hits in the second stage (build stage) of the same workflow

---

Resolve #300