### PR TITLE
chore: fix hardcode in workflow

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -25,7 +25,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_REPO: raids-lab/crater-backend
+  REPOSITORY: raids-lab
+  IMAGE_NAME: crater-backend
   # Golang-lint version
   GOLANGCI_LINT_VERSION: v2.6.2
 
@@ -168,7 +169,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -193,7 +194,7 @@ jobs:
           owner-type: org # or user
           token: ${{ secrets.PAT_TOKEN  }}
           repository-owner: ${{ github.repository_owner }}
-          package-name: crater-backend
+          package-name: ${{ env.IMAGE_NAME }}
           delete-untagged: true
           keep-at-most: 2
           skip-tags: v*

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -27,7 +27,8 @@ env:
   # Modified to use GHCR configuration
   REGISTRY: ghcr.io
   # Set your Docker Hub username and repository name
-  IMAGE_REPO: raids-lab/crater-frontend
+  REPOSITORY: raids-lab
+  IMAGE_NAME: crater-frontend
 
 jobs:
   lint:
@@ -171,7 +172,7 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            ghcr.io/raids-lab/crater-frontend
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch
@@ -195,7 +196,7 @@ jobs:
           owner-type: org # or user
           token: ${{ secrets.PAT_TOKEN  }}
           repository-owner: ${{ github.repository_owner }}
-          package-name: crater-frontend
+          package-name: ${{ env.IMAGE_NAME }}
           delete-untagged: true
           keep-at-most: 2
           skip-tags: v*

--- a/.github/workflows/storage-build.yml
+++ b/.github/workflows/storage-build.yml
@@ -25,7 +25,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_REPO: raids-lab/storage-server
+  REPOSITORY: raids-lab
+  IMAGE_NAME: storage-server
   # Golang-lint version
   GOLANGCI_LINT_VERSION: v2.6.2
 
@@ -163,7 +164,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -188,7 +189,7 @@ jobs:
           owner-type: org # or user
           token: ${{ secrets.PAT_TOKEN  }}
           repository-owner: ${{ github.repository_owner }}
-          package-name: storage-server
+          package-name: ${{ env.IMAGE_NAME }}
           delete-untagged: true
           keep-at-most: 2
           skip-tags: v*

--- a/docs/en/CI.md
+++ b/docs/en/CI.md
@@ -187,7 +187,7 @@ After building, images are tagged with multiple labels to help users select appr
   id: meta
   uses: docker/metadata-action@v5
   with:
-    images: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}
+    images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
     tags: |
       type=ref,event=branch
       type=semver,pattern={{version}}
@@ -197,7 +197,7 @@ After building, images are tagged with multiple labels to help users select appr
       type=sha
 ```
 
-The `images` parameter specifies the base name of the image, composed of `${{ env.REGISTRY }}` and `${{ env.IMAGE_REPO }}`. The complete image address will be detailed in the next section "Image Push & Cleanup".
+The `images` parameter specifies the base name of the image, composed of `${{ env.REGISTRY }}`, `${{ env.REPOSITORY }}`, and `${{ env.IMAGE_NAME }}`. The complete image address will be detailed in the next section "Image Push & Cleanup".
 
 Each line under the `tags` parameter is an independent tag generation rule, and these rules generate corresponding tags in parallel based on trigger conditions. For example, when creating version tag `v1.2.3`, multiple tags are generated simultaneously: `v1.2.3`, `1.2`, `1`, and SHA tag; when pushing to the main branch, `main`, `latest`, and SHA tags are generated.
 
@@ -213,7 +213,7 @@ Tag rule parameter descriptions:
 
 ### Image Push & Cleanup
 
-After image building is complete, images need to be pushed to the image registry and old images cleaned up to control storage space. Image pushing uses GHCR (GitHub Container Registry) as the repository. The complete image address format is `${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}`, i.e., `ghcr.io/raids-lab/crater-backend`, `ghcr.io/raids-lab/crater-frontend`, and `ghcr.io/raids-lab/storage-server`.
+After image building is complete, images need to be pushed to the image registry and old images cleaned up to control storage space. Image pushing uses GHCR (GitHub Container Registry) as the repository. The complete image address format is `${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}`, i.e., `ghcr.io/raids-lab/crater-backend`, `ghcr.io/raids-lab/crater-frontend`, and `ghcr.io/raids-lab/storage-server`.
 
 Before pushing, you need to log in to GHCR with the following configuration:
 

--- a/docs/zh-CN/CI.md
+++ b/docs/zh-CN/CI.md
@@ -187,7 +187,7 @@ QEMU 通过 CPU 模拟实现跨平台构建，允许在 amd64 架构的构建机
   id: meta
   uses: docker/metadata-action@v5
   with:
-    images: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}
+    images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
     tags: |
       type=ref,event=branch
       type=semver,pattern={{version}}
@@ -197,7 +197,7 @@ QEMU 通过 CPU 模拟实现跨平台构建，允许在 amd64 架构的构建机
       type=sha
 ```
 
-`images` 参数指定镜像的基础名称，由 `${{ env.REGISTRY }}` 和 `${{ env.IMAGE_REPO }}` 组成，完整的镜像地址将在下一节"镜像推送与清理"中详细说明。
+`images` 参数指定镜像的基础名称，由 `${{ env.REGISTRY }}`、`${{ env.REPOSITORY }}` 和 `${{ env.IMAGE_NAME }}` 组成，完整的镜像地址将在下一节"镜像推送与清理"中详细说明。
 
 `tags` 参数下的每一行都是一个独立的标签生成规则，这些规则会根据触发条件并行生成对应的标签。例如，当创建版本标签 `v1.2.3` 时，会同时生成多个标签：`v1.2.3`、`1.2`、`1` 和 SHA 标签；当推送到 main 分支时，会生成 `main`、`latest` 和 SHA 标签。
 
@@ -213,7 +213,7 @@ QEMU 通过 CPU 模拟实现跨平台构建，允许在 amd64 架构的构建机
 
 ### 镜像推送与清理
 
-镜像构建完成后，需要推送到镜像仓库并清理旧镜像以控制存储空间。镜像推送使用 GHCR（GitHub Container Registry）作为仓库，完整的镜像地址格式为 `${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}`，即 `ghcr.io/raids-lab/crater-backend`、`ghcr.io/raids-lab/crater-frontend` 和 `ghcr.io/raids-lab/storage-server`。
+镜像构建完成后，需要推送到镜像仓库并清理旧镜像以控制存储空间。镜像推送使用 GHCR（GitHub Container Registry）作为仓库，完整的镜像地址格式为 `${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}`，即 `ghcr.io/raids-lab/crater-backend`、`ghcr.io/raids-lab/crater-frontend` 和 `ghcr.io/raids-lab/storage-server`。
 
 推送前需要先登录到 GHCR，配置如下：
 


### PR DESCRIPTION
修复了 GitHub Actions 工作流中的镜像仓库环境变量硬编码问题，将原先合并的 IMAGE_REPO 变量拆分为 REPOSITORY 和 IMAGE_NAME 两个独立变量，提高代码一致性与可维护性。

### 修改

- **工作流文件**：将 `.github/workflows/` 目录下所有工作流文件中的 `IMAGE_REPO` 环境变量拆分为 `REPOSITORY` 和 `IMAGE_NAME` 两个独立变量
- **文档更新**：同步更新了中英文 CI 文档中关于环境变量使用的说明，保持文档与代码的一致性

### 测试

- 通过阅读和检查工作流配置文件，确认修改后的环境变量组合生成的镜像地址与之前完全一致

---

Fix the hardcoded image repository environment variables in GitHub Actions workflows by splitting the original combined IMAGE_REPO variable into two separate variables: REPOSITORY and IMAGE_NAME, improving code consistency and maintainability.

### Changes

- **Workflow files**: Split the `IMAGE_REPO` environment variable into two separate variables `REPOSITORY` and `IMAGE_NAME` in all workflow files under `.github/workflows/`
- **Documentation updates**: Synchronized updates to both Chinese and English CI documentation regarding environment variable usage to maintain consistency between documentation and code

### Testing

- Verified through reading and inspecting workflow configuration files that the modified environment variable combinations generate identical image addresses as before

---

Resolve #309