### PR TITLE
chore: format translation in pre-commit hook

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -104,6 +104,15 @@ lint: ## 🔍 Run ESLint and TypeScript checks
 
 .PHONY: pre-commit-check
 pre-commit-check: ## Run pre-commit checks (lint and lint-staged).
+	@echo "$(BLUE)Formatting translation files...$(RESET)"
+	@if python3 hack/format_translation.py; then \
+		echo "$(BLUE)Staging formatted translation files...$(RESET)"; \
+		git add -u -- src/i18n/ 2>/dev/null || true; \
+		echo "$(GREEN)✅ Translation files formatted and staged$(RESET)"; \
+	else \
+		echo "$(RED)❌ Translation file formatting failed!$(RESET)"; \
+		exit 1; \
+	fi
 	@echo "$(BLUE)Running lint checks...$(RESET)"
 	@if ! pnpm run lint; then \
 		echo "$(RED)❌ Frontend lint failed!$(RESET)"; \


### PR DESCRIPTION
在 pre-commit hook 中集成翻译文件格式化脚本，在提交检查时自动格式化翻译文件并暂存修改。

### 修改

- **frontend/Makefile**：在 `pre-commit-check` 目标中添加翻译文件格式化步骤，使用现有的 `format_translation.py` 脚本格式化翻译文件，格式化成功后使用 `git add -u` 自动暂存被修改的文件

### 测试

- 实际执行 `git commit` 测试 pre-commit hook 的行为，验证翻译文件能够被正确格式化并自动暂存

---

Integrate translation file formatting script into pre-commit hook to automatically format translation files and stage changes during commit checks.

### Changes

- **frontend/Makefile**: Add translation file formatting step in `pre-commit-check` target, using `format_translation.py` script to format translation files, and automatically stage modified files with `git add -u` after successful formatting

### Testing

- Execute `git commit` to test pre-commit hook behavior, verifying that translation files are correctly formatted and automatically staged