### PR TITLE
chore: manage config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ etc/*
 # Do not ignore template
 !etc/example-config.yaml
 
+# Configuration backups (created by make config-link)
+*.bak
+
 # Test binary, build with `go test -c`
 *.test
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,24 @@ pre-commit-check: install-hooks ## Run the installed pre-commit hook.
 	@echo "$(BLUE)Running pre-commit hook...$(RESET)"
 	@$(GIT_HOOKS_DIR)/pre-commit
 
+##@ Configuration Management
+
+.PHONY: config-link
+config-link: ## Create symlinks for configuration files (usage: make config-link CONFIG_DIR=~/develop/crater/config)
+	@bash hack/config.sh link $(CONFIG_DIR)
+
+.PHONY: config-status
+config-status: ## Show status of configuration files
+	@bash hack/config.sh status
+
+.PHONY: config-unlink
+config-unlink: ## Remove configuration symlinks (only symlinks, not regular files)
+	@bash hack/config.sh unlink
+
+.PHONY: config-restore
+config-restore: ## Restore configuration files from .bak backups
+	@bash hack/config.sh restore
+
 # 默认目标
 .DEFAULT_GOAL := help
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,41 @@ Then configure the development environment for the component you want to develop
 - **Storage Service Development Environment**: Please refer to [Storage Service Development Guide](./storage/README.md)
 - **Documentation Website Development Environment**: Please refer to [Documentation Website Development Guide](./website/README.md)
 
+### 📁 Configuration File Management
+
+Crater provides a unified configuration file management system to help developers manage configuration files across different components. This system allows you to centralize all configuration files in a single directory and create symlinks in each project directory.
+
+**Configuration Directory Structure:**
+
+The configuration directory should have the following structure:
+
+```
+config/
+├── backend/
+│   ├── .debug.env              # Backend debug environment variables
+│   ├── kubeconfig              # Kubernetes config file (optional)
+│   └── debug-config.yaml       # Backend debug configuration
+├── frontend/
+│   └── .env.development        # Frontend development environment variables
+└── storage/
+    ├── .env                    # Storage service environment variables
+    └── config.yaml             # Storage service configuration
+```
+
+**Available Make Targets:**
+
+- `make config-link`: Create symlinks for configuration files. If a configuration file already exists as a regular file, it will be backed up with a `.bak` suffix. If it exists as a symlink, it will be replaced.
+
+  ```bash
+  make config-link CONFIG_DIR=~/develop/crater/config
+  ```
+
+- `make config-status`: Display the status of all configuration files, showing whether they exist, are symlinks, or are missing.
+
+- `make config-unlink`: Remove configuration symlinks (only symlinks, regular files are preserved).
+
+- `make config-restore`: Restore configuration files from `.bak` backups.
+
 ### 💻 Development
 
 Enter the corresponding directory for the component you want to modify:

--- a/backend/README.md
+++ b/backend/README.md
@@ -82,6 +82,8 @@ go env -w GOPROXY=https://goproxy.cn,direct
 
 ### Preparing Configuration Files
 
+**Note:** It is recommended to manage these configuration files through the unified configuration management system in the main repository. For details, please refer to the main repository README.
+
 #### `kubeconfig`
 
 To run the project, you need at least one Kubernetes cluster and have Kubectl installed.

--- a/backend/README.zh-CN.md
+++ b/backend/README.zh-CN.md
@@ -82,6 +82,8 @@ go env -w GOPROXY=https://goproxy.cn,direct
 
 ### 准备配置文件
 
+**注意：** 建议通过主仓库的统一配置文件管理系统来管理这些配置文件，详见主仓库 README。
+
 #### `kubeconfig`
 
 要运行项目，你至少需要有一个 Kubernetes 集群，并安装 Kubectl。

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -137,6 +137,41 @@ make install-hooks
 - **存储服务开发环境**: 请参考 [存储服务开发指南](../../storage/README_CN.md)
 - **文档网站开发环境**: 请参考 [文档网站开发指南](../../website/README.zh-CN.md)
 
+### 📁 配置文件管理
+
+Crater 提供了统一的配置文件管理系统，帮助开发者管理不同组件的配置文件。该系统允许您将所有配置文件集中在一个目录中，并在各个项目目录中创建软链接。
+
+**配置文件目录结构：**
+
+配置文件目录应具有以下结构：
+
+```
+config/
+├── backend/
+│   ├── .debug.env              # 后端调试环境变量
+│   ├── kubeconfig              # Kubernetes 配置文件（可选）
+│   └── debug-config.yaml       # 后端调试配置
+├── frontend/
+│   └── .env.development        # 前端开发环境变量
+└── storage/
+    ├── .env                    # 存储服务环境变量
+    └── config.yaml             # 存储服务配置
+```
+
+**可用的 Make 目标：**
+
+- `make config-link`: 创建配置文件的软链接。如果配置文件已存在为普通文件，将被备份为 `.bak` 后缀。如果已存在为软链接，将被替换。
+
+  ```bash
+  make config-link CONFIG_DIR=~/develop/crater/config
+  ```
+
+- `make config-status`: 显示所有配置文件的状态，包括是否存在、是否为软链接或缺失。
+
+- `make config-unlink`: 删除配置文件的软链接（仅删除软链接，普通文件会被保留）。
+
+- `make config-restore`: 从 `.bak` 备份恢复配置文件。
+
 ### 💻 进行开发
 
 根据您要修改的组件，进入相应的目录进行开发：

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -87,6 +87,8 @@ Use MSW for API simulation during development:
 1. Set `VITE_USE_MSW=true` in `.env.development`
 2. Add handlers in `src/mocks/handlers.ts`
 
+**Note:** It is recommended to manage the `.env.development` file through the unified configuration management system in the main repository. For details, please refer to the main repository README.
+
 ### Dependency Management 📦
 
 Check updates:

--- a/frontend/README.zh-CN.md
+++ b/frontend/README.zh-CN.md
@@ -98,6 +98,8 @@ Crater Frontend 基于现代 React 技术栈构建，主要包括：
 
 当后端服务尚未就绪或本地联调不便时，可通过 [MSW](https://mswjs.io/) 进行接口模拟，方便开发调试。
 
+**注意：** 建议通过主仓库的统一配置文件管理系统来管理 `.env.development` 文件，详见主仓库 README。
+
 使用步骤：
 
 1. 在 `.env.development` 中设置：

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -1,0 +1,564 @@
+#!/bin/bash
+
+# Configuration file management script
+# Compatible with both macOS and Linux
+# Usage:
+#   bash hack/config.sh link      # Create symlinks (reads config dir from stdin)
+#   bash hack/config.sh status    # Show status of configuration files
+#   bash hack/config.sh unlink    # Remove configuration symlinks
+
+# set -e  # Commented out to avoid early exit in some checks
+
+# Color definitions
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+BLUE='\033[34m'
+CYAN='\033[36m'
+RESET='\033[0m'
+
+# Detect operating system
+detect_os() {
+    case "$(uname -s)" in
+        Darwin*)
+            echo "macos"
+            ;;
+        Linux*)
+            echo "linux"
+            ;;
+        *)
+            echo "unknown"
+            ;;
+    esac
+}
+
+OS=$(detect_os)
+
+# Get absolute path (cross-platform compatible function)
+get_absolute_path() {
+    local path="$1"
+    
+    # Expand ~
+    path=$(eval echo "$path")
+    
+    # Convert to absolute path
+    if [ "$OS" = "macos" ]; then
+        # macOS: Use cd and pwd to get absolute path
+        if [ -d "$path" ] || [ -f "$path" ]; then
+            local dir=$(cd "$(dirname "$path")" && pwd)
+            echo "$dir/$(basename "$path")"
+        else
+            # If path doesn't exist, try using Python (macOS usually has Python)
+            if command -v python3 >/dev/null 2>&1; then
+                python3 -c "import os; print(os.path.abspath('$path'))"
+            else
+                echo "$path"
+            fi
+        fi
+    else
+        # Linux: Use realpath (if available) or readlink -f
+        if command -v realpath >/dev/null 2>&1; then
+            realpath "$path" 2>/dev/null || echo "$path"
+        elif command -v readlink >/dev/null 2>&1; then
+            readlink -f "$path" 2>/dev/null || echo "$path"
+        else
+            # Fallback to cd/pwd method
+            local dir=$(cd "$(dirname "$path")" && pwd)
+            echo "$dir/$(basename "$path")"
+        fi
+    fi
+}
+
+# Get relative path (cross-platform compatible function)
+get_relative_path() {
+    local target="$1"
+    local base="$2"
+    
+    # Ensure paths are absolute
+    target=$(get_absolute_path "$target")
+    base=$(get_absolute_path "$base")
+    
+    # Use Python to calculate relative path (cross-platform compatible)
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c "import os; print(os.path.relpath('$target', '$base'))"
+    else
+        # Simple fallback: if target is under base, return relative path
+        if [[ "$target" == "$base"* ]]; then
+            echo "${target#$base/}"
+        else
+            echo "$target"
+        fi
+    fi
+}
+
+# Get symlink target (cross-platform compatible function)
+get_link_target() {
+    local link_path="$1"
+    
+    if [ -L "$link_path" ]; then
+        # Both macOS and Linux support readlink (without -f)
+        local target=$(readlink "$link_path")
+        
+        # If relative path, convert to absolute path
+        if [[ "$target" != /* ]]; then
+            local link_dir=$(dirname "$link_path")
+            target="$link_dir/$target"
+        fi
+        
+        # Normalize path (remove .. and .)
+        if command -v python3 >/dev/null 2>&1; then
+            python3 -c "import os; print(os.path.normpath('$target'))"
+        else
+            echo "$target"
+        fi
+    else
+        echo ""
+    fi
+}
+
+# Configuration file list
+declare -A CONFIG_FILES=(
+    ["backend/.debug.env"]="backend/.debug.env"
+    ["backend/kubeconfig"]="backend/kubeconfig"
+    ["backend/etc/debug-config.yaml"]="backend/etc/debug-config.yaml"
+    ["frontend/.env.development"]="frontend/.env.development"
+    ["storage/.env"]="storage/.env"
+    ["storage/etc/config.yaml"]="storage/etc/config.yaml"
+)
+
+# Get project root directory
+get_project_root() {
+    # Get script directory
+    local script_path="${BASH_SOURCE[0]}"
+    if [ -z "$script_path" ]; then
+        script_path="$0"
+    fi
+    
+    # If relative path, convert to absolute path
+    if [[ "$script_path" != /* ]]; then
+        script_path="$(pwd)/$script_path"
+    fi
+    
+    local script_dir=$(cd "$(dirname "$script_path")" 2>/dev/null && pwd)
+    if [ -z "$script_dir" ]; then
+        # If failed, use current working directory
+        script_dir="$(pwd)/hack"
+    fi
+    
+    local project_root=$(cd "$script_dir/.." 2>/dev/null && pwd)
+    if [ -z "$project_root" ]; then
+        # If failed, use current working directory
+        project_root="$(pwd)"
+    fi
+    
+    echo "$project_root"
+}
+
+PROJECT_ROOT=$(get_project_root)
+
+# Show help information
+show_help() {
+    echo "Configuration file management script"
+    echo ""
+    echo "Usage:"
+    echo "  $0 link [CONFIG_DIR]     Create symlinks for configuration files"
+    echo "  $0 status                Show status of configuration files"
+    echo "  $0 unlink                Remove configuration symlinks (only symlinks, not regular files)"
+    echo "  $0 restore               Restore configuration files from .bak backups"
+    echo ""
+    echo "Examples:"
+    echo "  $0 link ~/develop/crater/config"
+    echo "  echo '~/develop/crater/config' | $0 link"
+    echo "  make config-link CONFIG_DIR=~/develop/crater/config"
+    echo "  $0 status"
+    echo "  $0 unlink"
+    echo "  $0 restore"
+}
+
+# Function to create symlink
+create_symlink() {
+    local source_file="$1"
+    local target_link="$2"
+    local description="$3"
+    
+    # Check if source file exists
+    if [ ! -f "$source_file" ]; then
+        echo -e "${YELLOW}⚠️  Skipping $description: source file not found at $source_file${RESET}"
+        return 1
+    fi
+    
+    # If target directory doesn't exist, create it
+    local target_dir=$(dirname "$target_link")
+    if [ ! -d "$target_dir" ]; then
+        mkdir -p "$target_dir"
+        echo -e "${BLUE}Created directory: $target_dir${RESET}"
+    fi
+    
+    # Handle existing target file
+    if [ -e "$target_link" ]; then
+        if [ -L "$target_link" ]; then
+            # If it's a symlink, remove it directly
+            rm "$target_link"
+            echo -e "${YELLOW}Removed existing symlink: $description${RESET}"
+        elif [ -f "$target_link" ]; then
+            # If it's a regular file, backup as .bak
+            local backup_file="${target_link}.bak"
+            mv "$target_link" "$backup_file"
+            echo -e "${YELLOW}Backed up existing file: $description -> ${description}.bak${RESET}"
+        fi
+    fi
+    
+    # Calculate relative path
+    local relative_path=$(get_relative_path "$source_file" "$(dirname "$target_link")")
+    
+    # Create symlink
+    ln -sf "$relative_path" "$target_link"
+    echo -e "${GREEN}✅ Linked $description${RESET}"
+    echo "   $target_link -> $relative_path"
+}
+
+# Execute link operation
+do_link() {
+    # Read from command line argument first, otherwise read from stdin
+    if [ -n "$2" ]; then
+        CONFIG_DIR_INPUT="$2"
+    else
+        # Show prompt
+        echo -e "${BLUE}Enter the config directory path:${RESET}"
+        echo -e "${YELLOW}  Examples:${RESET}"
+        echo "    ~/develop/crater/config"
+        echo "    /absolute/path/to/config"
+        echo "    ../relative/path/to/config"
+        echo ""
+        echo -n "Config directory: "
+        
+        # Read config directory from stdin
+        read -r CONFIG_DIR_INPUT || true
+    fi
+
+    if [ -z "$CONFIG_DIR_INPUT" ]; then
+        echo -e "${RED}❌ Error: No config directory provided${RESET}"
+        echo "Usage:"
+        echo "  $0 link [CONFIG_DIR]"
+        echo "  echo '/path/to/config' | $0 link"
+        echo "  make config-link CONFIG_DIR=/path/to/config"
+        exit 1
+    fi
+
+    # Parse path
+    CONFIG_DIR=$(get_absolute_path "$CONFIG_DIR_INPUT")
+
+    # Validate directory exists
+    if [ ! -d "$CONFIG_DIR" ]; then
+        echo -e "${RED}❌ Error: Config directory does not exist: $CONFIG_DIR${RESET}"
+        exit 1
+    fi
+
+    # Define subdirectories
+    BACKEND_CONFIG_DIR="$CONFIG_DIR/backend"
+    FRONTEND_CONFIG_DIR="$CONFIG_DIR/frontend"
+    STORAGE_CONFIG_DIR="$CONFIG_DIR/storage"
+
+    echo -e "${BLUE}Using config directory: ${CONFIG_DIR}${RESET}"
+    echo ""
+
+    # Backend configurations
+    echo -e "${CYAN}Linking backend configurations...${RESET}"
+    create_symlink "$BACKEND_CONFIG_DIR/.debug.env" "$PROJECT_ROOT/backend/.debug.env" "backend/.debug.env"
+    create_symlink "$BACKEND_CONFIG_DIR/kubeconfig" "$PROJECT_ROOT/backend/kubeconfig" "backend/kubeconfig"
+    create_symlink "$BACKEND_CONFIG_DIR/debug-config.yaml" "$PROJECT_ROOT/backend/etc/debug-config.yaml" "backend/etc/debug-config.yaml"
+
+    # Frontend configurations
+    echo ""
+    echo -e "${CYAN}Linking frontend configurations...${RESET}"
+    create_symlink "$FRONTEND_CONFIG_DIR/.env.development" "$PROJECT_ROOT/frontend/.env.development" "frontend/.env.development"
+
+    # Storage configurations
+    echo ""
+    echo -e "${CYAN}Linking storage configurations...${RESET}"
+    create_symlink "$STORAGE_CONFIG_DIR/.env" "$PROJECT_ROOT/storage/.env" "storage/.env"
+    create_symlink "$STORAGE_CONFIG_DIR/config.yaml" "$PROJECT_ROOT/storage/etc/config.yaml" "storage/etc/config.yaml"
+
+    echo ""
+    echo -e "${GREEN}✅ All symlinks created successfully!${RESET}"
+}
+
+# Function to check file status
+check_file_status() {
+    local file_path="$1"
+    local description="$2"
+    local is_optional="${3:-false}"  # Third parameter, defaults to false (required file)
+    
+    if [ ! -e "$file_path" ]; then
+        if [ "$is_optional" = "true" ]; then
+            # Show warning when optional file is missing
+            echo -e "  ${YELLOW}⚠️ ${RESET}${description}"
+            echo -e "     ${YELLOW}Status: Missing (optional)${RESET}"
+        else
+            # Show error when required file is missing
+            echo -e "  ${RED}❌${RESET} ${description}"
+            echo -e "     ${YELLOW}Status: Missing${RESET}"
+        fi
+        return 1
+    elif [ -L "$file_path" ]; then
+        local target=$(get_link_target "$file_path")
+        echo -e "  ${GREEN}🔗${RESET} ${description}"
+        echo -e "     ${CYAN}Status: Symlink${RESET}"
+        echo -e "     ${BLUE}Target: $target${RESET}"
+        return 0
+    elif [ -f "$file_path" ]; then
+        echo -e "  ${YELLOW}📄${RESET} ${description}"
+        echo -e "     ${YELLOW}Status: Regular file${RESET}"
+        # Check if backup file exists
+        if [ -f "${file_path}.bak" ]; then
+            echo -e "     ${CYAN}Backup: ${file_path}.bak exists${RESET}"
+        fi
+        return 0
+    else
+        echo -e "  ${RED}❓${RESET} ${description}"
+        echo -e "     ${RED}Status: Unknown type${RESET}"
+        return 1
+    fi
+}
+
+# Execute status operation
+do_status() {
+    echo -e "${CYAN}Configuration File Status${RESET}"
+    echo ""
+
+    # Backend configurations
+    echo -e "${BLUE}Backend:${RESET}"
+    check_file_status "$PROJECT_ROOT/backend/.debug.env" "backend/.debug.env"
+    check_file_status "$PROJECT_ROOT/backend/kubeconfig" "backend/kubeconfig" "true"  # kubeconfig is optional
+    check_file_status "$PROJECT_ROOT/backend/etc/debug-config.yaml" "backend/etc/debug-config.yaml"
+
+    echo ""
+
+    # Frontend configurations
+    echo -e "${BLUE}Frontend:${RESET}"
+    check_file_status "$PROJECT_ROOT/frontend/.env.development" "frontend/.env.development"
+
+    echo ""
+
+    # Storage configurations
+    echo -e "${BLUE}Storage:${RESET}"
+    check_file_status "$PROJECT_ROOT/storage/.env" "storage/.env"
+    check_file_status "$PROJECT_ROOT/storage/etc/config.yaml" "storage/etc/config.yaml"
+
+    echo ""
+}
+
+# Function to remove symlink
+remove_symlink() {
+    local file_path="$1"
+    local description="$2"
+    
+    if [ ! -e "$file_path" ]; then
+        echo -e "  ${YELLOW}⚠️  ${description}: File does not exist, skipping${RESET}"
+        return 0
+    elif [ -L "$file_path" ]; then
+        rm "$file_path"
+        echo -e "  ${GREEN}✅ Removed symlink: ${description}${RESET}"
+        return 0
+    elif [ -f "$file_path" ]; then
+        echo -e "  ${RED}❌ ${description}: Regular file (not a symlink), skipping${RESET}"
+        echo -e "     ${YELLOW}Hint: This is a regular file, not a symlink. Use 'rm' manually if needed.${RESET}"
+        return 1
+    else
+        echo -e "  ${YELLOW}⚠️  ${description}: Unknown file type, skipping${RESET}"
+        return 1
+    fi
+}
+
+# Execute unlink operation
+do_unlink() {
+    set -e  # Enable error checking in do_unlink
+    echo -e "${BLUE}Removing configuration symlinks...${RESET}"
+    echo ""
+
+    removed_count=0
+    skipped_count=0
+
+    # Backend configurations
+    echo -e "${CYAN}Backend:${RESET}"
+    if remove_symlink "$PROJECT_ROOT/backend/.debug.env" "backend/.debug.env"; then
+        removed_count=$((removed_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    if remove_symlink "$PROJECT_ROOT/backend/kubeconfig" "backend/kubeconfig"; then
+        removed_count=$((removed_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    if remove_symlink "$PROJECT_ROOT/backend/etc/debug-config.yaml" "backend/etc/debug-config.yaml"; then
+        removed_count=$((removed_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    echo ""
+
+    # Frontend configurations
+    echo -e "${CYAN}Frontend:${RESET}"
+    if remove_symlink "$PROJECT_ROOT/frontend/.env.development" "frontend/.env.development"; then
+        removed_count=$((removed_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    echo ""
+
+    # Storage configurations
+    echo -e "${CYAN}Storage:${RESET}"
+    if remove_symlink "$PROJECT_ROOT/storage/.env" "storage/.env"; then
+        removed_count=$((removed_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    if remove_symlink "$PROJECT_ROOT/storage/etc/config.yaml" "storage/etc/config.yaml"; then
+        removed_count=$((removed_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    echo ""
+    if [ $removed_count -gt 0 ]; then
+        echo -e "${GREEN}✅ Removed $removed_count symlink(s)${RESET}"
+    fi
+    if [ $skipped_count -gt 0 ]; then
+        echo -e "${YELLOW}⚠️  Skipped $skipped_count file(s) (not symlinks)${RESET}"
+    fi
+}
+
+# Function to restore backup file
+restore_backup() {
+    local file_path="$1"
+    local description="$2"
+    local backup_file="${file_path}.bak"
+    
+    # Check if backup file exists
+    if [ ! -f "$backup_file" ]; then
+        echo -e "  ${YELLOW}⚠️  ${description}: No backup file found, skipping${RESET}"
+        return 1
+    fi
+    
+    # Handle target file
+    if [ ! -e "$file_path" ]; then
+        # Target file doesn't exist, restore directly
+        mv "$backup_file" "$file_path"
+        echo -e "  ${GREEN}✅ Restored ${description}${RESET}"
+        return 0
+    elif [ -L "$file_path" ]; then
+        # Target file is a symlink, remove it then restore
+        rm "$file_path"
+        mv "$backup_file" "$file_path"
+        echo -e "  ${GREEN}✅ Restored ${description} (replaced symlink)${RESET}"
+        return 0
+    elif [ -f "$file_path" ]; then
+        # Target file is a regular file, prompt user
+        echo -e "  ${RED}❌ ${description}: Regular file already exists, skipping${RESET}"
+        echo -e "     ${YELLOW}Hint: Target file exists. Remove it manually if you want to restore from backup.${RESET}"
+        return 1
+    else
+        echo -e "  ${YELLOW}⚠️  ${description}: Unknown file type, skipping${RESET}"
+        return 1
+    fi
+}
+
+# Execute restore operation
+do_restore() {
+    echo -e "${BLUE}Restoring configuration files from backups...${RESET}"
+    echo ""
+
+    restored_count=0
+    skipped_count=0
+
+    # Backend configurations
+    echo -e "${CYAN}Backend:${RESET}"
+    if restore_backup "$PROJECT_ROOT/backend/.debug.env" "backend/.debug.env"; then
+        restored_count=$((restored_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    if restore_backup "$PROJECT_ROOT/backend/kubeconfig" "backend/kubeconfig"; then
+        restored_count=$((restored_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    if restore_backup "$PROJECT_ROOT/backend/etc/debug-config.yaml" "backend/etc/debug-config.yaml"; then
+        restored_count=$((restored_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    echo ""
+
+    # Frontend configurations
+    echo -e "${CYAN}Frontend:${RESET}"
+    if restore_backup "$PROJECT_ROOT/frontend/.env.development" "frontend/.env.development"; then
+        restored_count=$((restored_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    echo ""
+
+    # Storage configurations
+    echo -e "${CYAN}Storage:${RESET}"
+    if restore_backup "$PROJECT_ROOT/storage/.env" "storage/.env"; then
+        restored_count=$((restored_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    if restore_backup "$PROJECT_ROOT/storage/etc/config.yaml" "storage/etc/config.yaml"; then
+        restored_count=$((restored_count + 1))
+    else
+        skipped_count=$((skipped_count + 1))
+    fi
+
+    echo ""
+    if [ $restored_count -gt 0 ]; then
+        echo -e "${GREEN}✅ Restored $restored_count file(s)${RESET}"
+    fi
+    if [ $skipped_count -gt 0 ]; then
+        echo -e "${YELLOW}⚠️  Skipped $skipped_count file(s)${RESET}"
+    fi
+}
+
+# Main logic
+case "${1:-}" in
+    link)
+        do_link "$@"
+        ;;
+    status)
+        do_status
+        ;;
+    unlink)
+        do_unlink
+        ;;
+    restore)
+        do_restore
+        ;;
+    help|--help|-h)
+        show_help
+        ;;
+    "")
+        echo -e "${RED}❌ Error: No command specified${RESET}"
+        echo ""
+        show_help
+        exit 1
+        ;;
+    *)
+        echo -e "${RED}❌ Error: Unknown command: $1${RESET}"
+        echo ""
+        show_help
+        exit 1
+        ;;
+esac

--- a/storage/README.md
+++ b/storage/README.md
@@ -114,6 +114,8 @@ This project supports two ways to run: **Local Development** and **Deployment on
 
 #### 📄 Configuration:
 
+**Note:** It is recommended to manage these configuration files (`config.yaml` and `.env`) through the unified configuration management system in the main repository. For details, please refer to the main repository README.
+
 Make sure you have a [config.yaml](./etc/config.yaml) file with the correct database settings. 
 
 Create a `.env` file at the root directory to customize local ports. This file is ignored by Git:

--- a/storage/README_CN.md
+++ b/storage/README_CN.md
@@ -107,6 +107,8 @@ go mod download
 
 #### 📄 配置：
 
+**注意：** 建议通过主仓库的统一配置文件管理系统来管理这些配置文件（`config.yaml` 和 `.env`），详见主仓库 README。
+
 确保您有一个 [config.yaml](./etc/config.yaml) 文件，其中包含正确的数据库设置。
 
 在根目录创建 `.env` 文件以自定义本地端口。此文件被 Git 忽略：


### PR DESCRIPTION
为项目添加统一的配置文件管理系统，通过符号链接集中管理各子仓库的配置文件，解决配置文件分散管理的问题。

### 修改

- **新增配置管理 Make 目标**：在主仓库 `Makefile` 中添加 `config-link`、`config-status`、`config-unlink`、`config-restore` 四个目标，并创建 `hack/config.sh` 脚本实现跨平台（Linux/macOS）的配置文件管理功能，支持通过符号链接统一管理各子仓库的配置文件，当源文件不存在时跳过并继续处理后续文件
- **更新主仓库文档**：在 `README.md` 和 `docs/zh-CN/README.md` 中添加"Configuration File Management"章节，说明配置文件目录结构、各 Make 目标的使用方法及示例
- **更新子仓库文档**：在 `backend`、`frontend`、`storage` 子仓库的 README 文件（中英文版本）中，在配置相关章节开头添加建议使用主仓库统一配置管理系统的提示
- **更新 Git 忽略规则**：在 `.gitignore` 中添加 `*.bak` 规则，避免 `make config-link` 创建的备份文件被提交到仓库

### 测试

- 在 Linux 系统上测试 `make config-link`、`make config-status`、`make config-unlink`、`make config-restore` 各目标的功能
- 在 macOS 系统上测试 `make config-link`、`make config-status`、`make config-unlink`、`make config-restore` 各目标的功能

---

Add a unified configuration file management system to the project, centralizing configuration files from all sub-repositories through symlinks, solving the problem of scattered configuration file management.

### Changes

- **Add configuration management Make targets**: Add four targets (`config-link`, `config-status`, `config-unlink`, `config-restore`) to the main repository `Makefile`, and create `hack/config.sh` script to implement cross-platform (Linux/macOS) configuration file management functionality, supporting unified management of configuration files from all sub-repositories through symlinks, skipping missing source files and continuing with subsequent files
- **Update main repository documentation**: Add "Configuration File Management" section to `README.md` and `docs/zh-CN/README.md`, explaining the configuration directory structure, usage of each Make target, and examples
- **Update sub-repository documentation**: Add a note at the beginning of configuration-related sections in README files (both English and Chinese versions) of `backend`, `frontend`, and `storage` sub-repositories, suggesting the use of the main repository's unified configuration management system
- **Update Git ignore rules**: Add `*.bak` rule to `.gitignore` to prevent backup files created by `make config-link` from being committed to the repository

### Testing

- Test functionality of `make config-link`, `make config-status`, `make config-unlink`, and `make config-restore` targets on Linux systems
- Test functionality of `make config-link`, `make config-status`, `make config-unlink`, and `make config-restore` targets on macOS systems

---

Resolve #326