### PR TITLE
fix: response error display

### DIFF
--- a/frontend/src/services/client.ts
+++ b/frontend/src/services/client.ts
@@ -146,9 +146,13 @@ export async function apiRequest<T>(
       try {
         const errorResponse = await error.response.json<IErrorResponse>()
 
-        // 🔥 【关键修改】将解析后的数据挂载到 error 对象上
-        // 这样上层组件通过 error.data 就能拿到后端返回的 { code, msg }
-        Object.assign(error, { data: errorResponse })
+        // Mount the parsed error response data to the error object
+        // This allows upper-level components to access backend response { code, msg } via error.data
+        // Also mount HTTP status code for error display
+        Object.assign(error, {
+          data: errorResponse,
+          httpStatus: error.response.status,
+        })
 
         // 根据错误码进行不同处理
         switch (errorResponse.code) {


### PR DESCRIPTION
修复前端错误信息显示问题：后端返回的错误信息虽然已传递到前端，但前端无法正确显示，导致用户无法看到具体的错误原因，影响用户体验。本次修改使前端能够正确展示后端返回的 HTTP 状态码、业务错误码和错误消息。

### 修改

- **前端错误处理增强**：修改 `showErrorToast` 函数，新增对 HTTPError（来自 ky 库）的处理支持，能够从 `error.data` 中读取后端返回的错误信息
- **错误信息展示优化**：错误提示现在同时显示 HTTP 状态码、业务错误码和错误消息，格式为 `[HTTP {status}] [Code {code}] {message}`
- **API 请求错误处理**：在 `apiRequest` 函数中将 HTTP 状态码挂载到 error 对象上，方便错误展示函数使用

### 测试

- 测试了使用 Dockerfile 进行镜像构建时的错误提交，验证了后端返回的错误信息能够正常显示

---

Fix frontend error message display issue: Although error messages returned by the backend are passed to the frontend, the frontend cannot display them correctly, preventing users from seeing specific error causes and impacting user experience. This modification enables the frontend to correctly display HTTP status codes, business error codes, and error messages returned by the backend.

### Changes

- **Frontend error handling enhancement**: Modified `showErrorToast` function to add support for handling HTTPError (from ky library), enabling reading error information from `error.data` returned by the backend
- **Error message display optimization**: Error notifications now simultaneously display HTTP status code, business error code, and error message in the format `[HTTP {status}] [Code {code}] {message}`
- **API request error handling**: Mount HTTP status code to error object in `apiRequest` function for easy use by error display functions

### Testing

- Tested error submission when building images using Dockerfile, verified that error messages returned by the backend can be displayed correctly

---

Resolve #329

Resolve #330