### PR TITLE
fix: response error display

### DIFF
--- a/backend/internal/handler/image/build.go
+++ b/backend/internal/handler/image/build.go
@@ -233,7 +233,7 @@ func (mgr *ImagePackMgr) buildFromDockerfile(c *gin.Context, data *DockerfileBui
 	imagepackName := fmt.Sprintf("%s-%s", data.UserName, uuid.New().String()[:5])
 	imageLink, err := utils.GenerateNewImageLinkForDockerfileBuild(data.BaseImage, data.UserName, data.ImageName, data.ImageTag)
 	if err != nil {
-		resputil.Error(c, "generate new image link failed", resputil.NotSpecified)
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
 		return
 	}
 

--- a/backend/pkg/utils/image.go
+++ b/backend/pkg/utils/image.go
@@ -34,7 +34,10 @@ func GetImageNameAndTag(imageLink string) (name, tag string, err error) {
 	re := regexp.MustCompile(getNameTagRegExp)
 	matches := re.FindStringSubmatch(imageLink)
 	if len(matches) != parts {
-		return "", "", fmt.Errorf("invalid image link: %s", imageLink)
+		return "", "", fmt.Errorf(
+			"regex pattern mismatch: base image '%s' does not match required format. "+
+				"Please provide a complete image URL. Required regex pattern: %s",
+			imageLink, getNameTagRegExp)
 	}
 	name, tag = matches[2], matches[3]
 	return name, tag, nil

--- a/frontend/src/services/client.ts
+++ b/frontend/src/services/client.ts
@@ -146,9 +146,13 @@ export async function apiRequest<T>(
       try {
         const errorResponse = await error.response.json<IErrorResponse>()
 
-        // 🔥 【关键修改】将解析后的数据挂载到 error 对象上
-        // 这样上层组件通过 error.data 就能拿到后端返回的 { code, msg }
-        Object.assign(error, { data: errorResponse })
+        // Mount the parsed error response data to the error object
+        // This allows upper-level components to access backend response { code, msg } via error.data
+        // Also mount HTTP status code for error display
+        Object.assign(error, {
+          data: errorResponse,
+          httpStatus: error.response.status,
+        })
 
         // 根据错误码进行不同处理
         switch (errorResponse.code) {


### PR DESCRIPTION
修复前端错误显示问题，使后端返回的错误信息能够正确展示给用户，并细化 Dockerfile 构建时的错误描述，提升用户体验。

### 修改

- **前端错误显示**：修复 `showErrorToast` 函数对 `HTTPError`（来自 `ky` 库）的处理逻辑，使其能够正确解析并展示后端返回的 HTTP 状态码、业务错误码和错误消息，格式为 `[HTTP {status}] [Code {code}] {message}`（修改文件：`frontend/src/utils/toast.ts`、`frontend/src/services/client.ts`）
- **后端错误信息细化**：在 Dockerfile 构建时，当基础镜像格式不符合正则表达式要求时，返回详细的错误信息，告知用户需要提供完整的镜像 URL，并展示所需匹配的正则表达式格式（修改文件：`backend/pkg/utils/image.go`、`backend/internal/handler/image/build.go`）

### 测试

- 测试使用 Dockerfile 进行镜像构建时的错误提交，验证后端返回的错误信息能够正确显示

---

Fix frontend error display issues to correctly show error messages returned by the backend, and refine error descriptions for Dockerfile builds to improve user experience.

### Changes

- **Frontend error display**: Fix `showErrorToast` function's handling logic for `HTTPError` (from `ky` library) to correctly parse and display HTTP status codes, business error codes, and error messages returned by the backend in the format `[HTTP {status}] [Code {code}] {message}` (modified files: `frontend/src/utils/toast.ts`, `frontend/src/services/client.ts`)
- **Backend error message refinement**: When building images from Dockerfile, if the base image format does not match the required regex pattern, return detailed error information informing users to provide a complete image URL and display the required regex pattern format (modified files: `backend/pkg/utils/image.go`, `backend/internal/handler/image/build.go`)

### Testing

- Test error submission when building images using Dockerfile, verified that error messages returned by the backend can be displayed correctly

---

Resolve #329

Resolve #330