### PR TITLE
fix: mem vpa

### DIFF
--- a/frontend/src/components/badge/resource-badges.tsx
+++ b/frontend/src/components/badge/resource-badges.tsx
@@ -73,15 +73,7 @@ const ResourceBadge = ({
     return /^\d+(\.\d+)?Gi$/.test(editValue)
   }, [keyName, editValue])
 
-  // 检查内存是否减小
-  const isMemoryDecreased = useMemo(() => {
-    if (keyName !== 'memory') return false
-    const originalValue = parseFloat(value)
-    const newValue = parseFloat(editValue)
-    return !isNaN(originalValue) && !isNaN(newValue) && newValue < originalValue
-  }, [keyName, value, editValue])
-
-  const isSaveDisabled = !editValue || !isValidMemoryFormat || isMemoryDecreased
+  const isSaveDisabled = !editValue || !isValidMemoryFormat
 
   if (!editable) {
     return (
@@ -126,13 +118,9 @@ const ResourceBadge = ({
                 </Button>
               </div>
             </TooltipTrigger>
-            {(isMemoryDecreased || !isValidMemoryFormat) && (
+            {!isValidMemoryFormat && (
               <TooltipContent>
-                {isMemoryDecreased ? (
-                  <p>减小内存需要重启容器，暂不支持</p>
-                ) : (
-                  <p>内存格式必须为 xGi（例如：7Gi）</p>
-                )}
+                <p>内存格式必须为 xGi（例如：7Gi）</p>
               </TooltipContent>
             )}
           </Tooltip>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "crater",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
支持管理员使用 VPA 调小任务内存使用。
此举绕过 k8s 要求调整容器内存 limits 必须重启容器的限制，仅通过调小 requests 实现 VPA，存在极端情况下的隐患，但可适用于当前 crater 的生产环境，且为不重启容器减少内存占用的唯一手段。