### PR TITLE
docs: rdma ulimit

### DIFF
--- a/website/content/docs/admin/more/rdma.en.mdx
+++ b/website/content/docs/admin/more/rdma.en.mdx
@@ -4,7 +4,7 @@ description: "RDMA"
 ---
 
 > - [K8s test via Infiniband network - Adapters and Cables / InfiniBand/VPI Adapter Cards - NVIDIA Developer Forums](https://forums.developer.nvidia.com/t/k8s-test-via-infiniband-network/285610)
-> - [Running tightly coupled HPC/AI workloads with InfiniBand using NVIDIA Network Operator on AKS \| Microsoft Community Hub](https://techcommunity.microsoft.com/blog/azurehighperformancecomputingblog/running-tightly-coupled-hpcai-workloads-with-infiniband-using-nvidia-network-ope/4117209)
+> - [Running tightly coupled HPC/AI workloads with InfiniBand using NVIDIA Network Operator on AKS | Microsoft Community Hub](https://techcommunity.microsoft.com/blog/azurehighperformancecomputingblog/running-tightly-coupled-hpcai-workloads-with-infiniband-using-nvidia-network-ope/4117209)
 > - [Basic Knowledge and Differences of RoCE, IB, and TCP Networks](https://support.huawei.com/enterprise/en/doc/EDOC1100203339)
 
 Before officially starting, we first supplement some basic knowledge related to RDMA:
@@ -791,9 +791,13 @@ According to the vLLM documentation on distributed inference[^7], we enabled `NC
 
 During the inference process, Kubernetes also does not detect inter-machine communication traffic, indicating that our deployment has been successful.
 
-## Problem Records
+## Lifting the Memory Lock Limit
 
-### 1. Connectivity Test Error
+### 0. Problem Description
+
+The following errors are caused by the memory lock limit.
+
+The following error occurs during connectivity testing:
 
 ```bash
 [host1] $ ib_read_bw -q 30
@@ -810,3 +814,355 @@ During the inference process, Kubernetes also does not detect inter-machine comm
  ibv_wr* API     : ON
  CQ Moderation   : 1
  Mtu             : 4096[B]
+ Link type       : IB
+ Outstand reads  : 16
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ethernet_read_keys: Couldn't read remote address
+ Unable to read to socket/rdma_cm
+Failed to exchange data between server and clients
+```
+
+```bash
+[host2] $ ib_read_bw -q 30 10.244.46.50
+Couldn't allocate MR
+failed to create mr
+Failed to create MR
+ Couldn't create IB resources
+```
+
+When performing RDMA bandwidth testing, small data volume (e.g., 1024 bytes) transmission is normal, but 1M and above data volume transmission fails. The specific error message is similar to above, see [Issue #339](https://github.com/raids-lab/crater/issues/339).
+
+Directly using `ulimit -l` to view the limit, what we get is 64KB, which is the system's default memory lock limit.
+
+At this time, using `ulimit -l unlimited` in the container or modifying `/etc/security/limits.conf` will not successfully change the memory lock limit.
+
+### 1. Problem Analysis
+
+The core of RDMA is letting the hardware (network card HCA) bypass the CPU and directly access remote memory. In normal operations, to optimize memory, the operating system will "page out" or move data at any time, causing the physical address corresponding to the virtual address to change. If the kernel pages out or moves a page of memory while the network card is transmitting data, it will lead to a transmission crash or even a system error.
+
+So, to ensure the address is absolutely stable, RDMA must perform "Memory Registration" (MR) before transmission. This action "locks" the specified virtual memory pages into physical memory at the kernel level, prohibiting the kernel from moving or swapping them to disk.
+
+Crater has already allowed jobs to perform memory locking operations by setting `CAP_IPC_LOCK`, but it hasn't modified the limit on the allowed locking amount. Also, since the container isn't given the `CAP_SYS_RESOURCE` privilege, operations inside the container cannot modify this limit either.
+
+Currently, Kubernetes officially doesn't provide a `ulimit` setting in the Pod Spec, see [Issue #3595](https://github.com/kubernetes/kubernetes/issues/3595). Therefore, it's necessary to handle it from the container runtime perspective.
+
+> Additionally, it's worth looking forward to the fact that the Kubernetes community has officially started a discussion on native support for Pod-level ulimit configuration in the v1.36 cycle, see [KEP-5758](https://github.com/kubernetes/enhancements/pull/5762).
+
+The `dockerd` runtime provides the corresponding configuration item `default-ulimits`, which can easily configure this limit at the node level, see [configuration file description](https://docs.docker.com/reference/cli/dockerd/#daemon-configuration-file) and [resource limit guide](https://docs.docker.com/engine/containers/resource_constraints/#set-default-ulimits-for-a-container).
+
+However, `containerd` is currently used in the cluster, and it doesn't provide a configuration item similar to `dockerd`, see [configuration file description](https://github.com/containerd/containerd/blob/main/docs/cri/config.md). Meanwhile, the developer explicitly refused to provide daemon-level configuration in [Issue #3150](https://github.com/containerd/containerd/issues/3150). Therefore, another way is needed to solve this problem.
+
+> Additionally, after trying, directly modifying `/etc/security/limits.conf` on the node to lift the limit, or only setting `LimitMEMLOCK=infinity` for the container runtime daemon also cannot release the limit inside the Pod. The root cause is speculated to be that the container executor `runc` will strictly follow the definition in the OCI specification blueprint and perform the `setrlimit` system call for the container at startup. This will forcibly override (usually pull down) the container's limit to the default value in the blueprint (e.g., 64KB), thus ignoring the daemon's own authority limit.
+
+### 2. Solution
+
+The core of this solution lies in modifying the **OCI Runtime Specification**. In the context of `containerd`, the JSON file specified by the `base_runtime_spec` parameter is considered the container's **base specification template**. It is the final authoritative source for defining container resource boundaries (such as `memlock` limit) (see [OCI Configuration Specification](https://github.com/opencontainers/runtime-spec/blob/main/config.md#posix-process)). The underlying OCI runtime (such as `runc`) will strictly follow the blueprint's definition to initialize the container process's resource limit through the `setrlimit` system call.
+
+#### Exporting and Modifying the Existing Configuration
+
+Since `containerd` doesn't support automatically merging this parameter with the system default configuration (Merge), but takes a full replacement strategy (Replace), we must first export a configuration template containing the current system's full definition, and then fine-tune on its basis. Run the following command on the node.
+
+```shell
+ctr oci spec > /etc/containerd/rdma-spec.json
+vim /etc/containerd/rdma-spec.json
+```
+
+Modify the following part of the configuration file (append `RLIMIT_MEMLOCK` to the `rlimits` array):
+
+```json
+        "rlimits": [
+            {
+                "type": "RLIMIT_NOFILE",
+                "hard": 1024,
+                "soft": 1024
+            },
+            {
+                "type": "RLIMIT_MEMLOCK",
+                "hard": 18446744073709551615,
+                "soft": 18446744073709551615
+            }
+        ],
+```
+
+#### Referencing the Modified Configuration
+
+Modify the `containerd` configuration.
+
+```toml
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+          # Modify to point to the absolute path of the above JSON template
+          base_runtime_spec = "/etc/containerd/rdma-spec.json"
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          privileged_without_host_devices_all_devices_allowed = false
+          runtime_engine = ""
+          runtime_path = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runc.v2"
+          sandbox_mode = "podsandbox"
+          snapshotter = ""
+```
+
+It needs to be modified according to the specific situation, with the goal of letting the corresponding Pod successfully apply the corresponding configuration.
+
+<Callout type="warn">
+After modifying the container runtime configuration and restarting the service, **it will not affect the Pods that are already running**. You must manually delete the old Pods, and have Kubernetes reschedule and trigger `containerd` to use the new OCI blueprint for initialization, then the configuration will truly take effect.
+</Callout>
+
+#### Lifting containerd's Own Limit (Optional)
+
+```shell
+EDITOR=vim systemctl edit containerd
+```
+
+Add the following content to the daemon configuration.
+
+```toml
+[Service]
+LimitMEMLOCK=infinity
+```
+
+Then use `systemctl restart containerd` to restart the service.
+
+Although experiments show that because `containerd` has `CAP_SYS_RESOURCE` privilege, only modifying the OCI blueprint can take effect, completing this item is to ensure the robustness of the daemon itself, and it is recommended as a best practice in production environments.
+
+#### Testing
+
+By now, the memory lock limit in the Pod should have been lifted, and we can run the RDMA bandwidth test command again, being able to see the following output on the master and worker respectively.
+
+**Master:**
+
+```bash
+root@pyt-liuyizhou-260206-2a3fe-master-0:/# ib_write_bw -s 1M -d mlx5_0 -F
+************************************
+* Waiting for client to connect... *
+************************************
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_0
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ TX depth        : 128
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ local address: LID 0x2c QPN 0x0087 PSN 0xcc6a4c RKey 0x1fcc bd VAddr 0x037f67d3b5030
+ remote address: LID 0x2c QPN 0x0088 PSN 0x6dc93a RKey 0x1fcf be VAddr 0x037f026db4030
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
+ 1048576    5000             11133.60            11129.09           0.011123
+---------------------------------------------------------------------------------------
+```
+
+**Worker:**
+
+```bash
+root@pyt-liuyizhou-260206-2a3fe-worker-0:/# ib_write_bw -s 1M -d mlx5_0 -F 10.244.44.139
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_0
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ TX depth        : 128
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ local address: LID 0x2c QPN 0x0088 PSN 0x6dc93a RKey 0x1fcf be VAddr 0x037f026db4030
+ remote address: LID 0x2c QPN 0x0087 PSN 0xcc6a4c RKey 0x1fcc bd VAddr 0x037f67d3b5030
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
+ 1048576    5000             11133.60            11129.09           0.011123
+---------------------------------------------------------------------------------------
+
+root@pyt-liuyizhou-260206-2a3fe-worker-0:/# ulimit -l
+unlimited
+```
+
+As can be seen, the memory lock limit inside the Pod has been lifted, and normal RDMA communication with large bandwidth can be performed.
+
+## Problem Records
+
+### 1. Error `Segmentation fault` when starting vLLM
+
+From the logs, the IB device has been successfully recognized, but a segmentation fault occurred.
+
+```bash
+[device-name]-master-0:528:528 [0] NCCL INFO Channel 00/02 :    0   1   2   3   4   5   6   7
+[device-name]-master-0:528:528 [0] NCCL INFO Channel 01/02 :    0   1   2   3   4   5   6   7
+[device-name]-master-0:528:528 [0] NCCL INFO Trees [0] 1/4/-1->0->-1 [1] 1/-1/-1->0->4
+    self.device_communicator = device_comm_cls(
+[device-name]-master-0:528:528 [0] NCCL INFO P2P Chunksize set to 131072
+[device-name]-master-0:528:528 [0] NCCL INFO Channel 00/0 : 7[3] -> 0[0] [receive] via NET/IB/0
+[device-name]-master-0:528:528 [0] NCCL INFO Channel 01/0 : 7[3] -> 0[0] [receive] via NET/IB/0
+[device-name]-master-0:528:528 [0] NCCL INFO Channel 00/0 : 0[0] -> 1[1] via P2P/IPC
+[device-name]-master-0:528:528 [0] NCCL INFO Channel 01/0 : 0[0] -> 1[1] via P2P/IPC
+[device-name]-master-0:528:5379 [0] misc/socket.cc:50 NCCL WARN socketProgress: Connection closed by remote peer [device-name]-worker-0.[hostname].svc.cluster.local<35396>
+[device-name]-master-0:528:5379 [0] NCCL INFO misc/socket.cc:752 -> 6
+[device-name]-master-0:528:5379 [0] NCCL INFO transport/net_ib.cc:1207 -> 6
+[device-name]-master-0:528:5379 [0] NCCL INFO transport/net.cc:837 -> 6
+[device-name]-master-0:528:528 [0] NCCL INFO transport/net.cc:405 -> 6
+[device-name]-master-0:528:528 [0] NCCL INFO transport.cc:183 -> 6
+                               ^^^^^^^^^^^^^^^^
+[device-name]-master-0:528:528 [0] NCCL INFO init.cc:1263 -> 6
+[device-name]-master-0:528:528 [0] NCCL INFO init.cc:1548 -> 6
+[device-name]-master-0:528:528 [0] NCCL INFO init.cc:1799 -> 6
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/cuda_communicator.py", line 39, in __init__
+[device-name]-master-0:528:5379 [0] misc/socket.cc:50 NCCL WARN socketProgress: Connection closed by remote peer [device-name]-worker-0.[hostname].svc.cluster.local<52144>
+    self.pynccl_comm = PyNcclCommunicator(
+                       ^^^^^^^^^^^^^^^^^^^
+[device-name]-master-0:528:5379 [0] NCCL INFO misc/socket.cc:752 -> 6
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[device-name]-master-0:528:5379 [0] NCCL INFO transport/net_ib.cc:1207 -> 6
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/pynccl.py", line 99, in __init__
+    self.comm: ncclComm_t = self.nccl.ncclCommInitRank(
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/pynccl_wrapper.py", line 277, in ncclCommInitRank
+    self.NCCL_CHECK(self._funcs["ncclCommInitRank"](ctypes.byref(comm),
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/pynccl_wrapper.py", line 256, in NCCL_CHECK
+    raise RuntimeError(f"NCCL error: {error_str}")
+RuntimeError: NCCL error: unhandled system error (run with NCCL_DEBUG=INFO for details)
+[device-name]-master-0:528:5379 [0] NCCL INFO transport/net.cc:837 -> 6
+[device-name]-master-0:528:528 [0] NCCL INFO init.cc:1837 -> 6
+*** SIGSEGV received at time=1745072123 on cpu 70 ***
+PC: @     0x7ff94e269506  (unknown)  ncclProxyServiceUDS()
+    @     0x7ffa0c242520       3384  (unknown)
+    @ ... and at least 1 more frames
+[2025-04-19 14:15:23,982 E 528 5383] logging.cc:484: *** SIGSEGV received at time=1745072123 on cpu 70 ***
+[2025-04-19 14:15:23,982 E 528 5383] logging.cc:484: PC: @     0x7ff94e269506  (unknown)  ncclProxyServiceUDS()
+[2025-04-19 14:15:23,983 E 528 5383] logging.cc:484:     @     0x7ffa0c242520       3384  (unknown)
+[2025-04-19 14:15:23,983 E 528 5383] logging.cc:484:     @ ... and at least 1 more frames
+Fatal Python error: Segmentation fault
+```
+
+Remember we mentioned before that we need to add `IPC_LOCK` in the Pod's security context? If not added, it will lead to the above problem.
+
+### 2. Failure of Multi-machine Inference on A100 Model
+
+First, run single-machine verification on the A100 model. If an Up network card is used, there seems to be no problem:
+
+```bash
+$ ib_write_bw -d mlx5_1 &
+[1] 1501
+
+************************************
+* Waiting for client to connect... *
+************************************
+
+
+$ ib_write_bw -d mlx5_1 127.0.0.1 --report_gbits
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_1
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_1
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ TX depth        : 128
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]
+Conflicting CPU frequency values detected: 863.109000 != 2300.000000. CPU Frequency is not max.
+ 65536      5000             183.66             183.61             0.350214
+---------------------------------------------------------------------------------------
+ 65536      5000             183.66             183.61             0.350214
+---------------------------------------------------------------------------------------
+
+$ ib_write_bw -d mlx5_0 &
+[1] 1618
+
+Port number 1 state is Down
+ Couldn't set the link layer
+ Couldn't get context for the device
+
+$ ib_write_bw -d mlx5_0 127.0.0.1 --report_gbits
+ Port number 1 state is Down
+ Couldn't set the link layer
+ Couldn't get context for the device
+
+$ ibstat
+CA 'mlx5_0'
+        CA type: MT4123
+        Port 1:
+                State: Down
+                Physical state: Disabled
+                Rate: 10
+                Base lid: 65535
+                LMC: 0
+                SM lid: 0
+                Link layer: InfiniBand
+CA 'mlx5_1'
+        CA type: MT4123
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 3
+                LMC: 0
+                SM lid: 1
+                Link layer: InfiniBand
+CA 'mlx5_bond_0'
+        CA type: MT4117
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 10
+                Link layer: Ethernet
+
+$ ib_write_bw -d mlx5_bond_0 &
+IB device mlx5_bond_0 not found
+ Unable to find the Infiniband/RoCE device
+```
+
+But when running vLLM, an error will occur, and it was later found that this problem is related to vLLM V1 and Ray[^8], and not related to IB. Since I happened to have vLLM multi-machine distributed inference code in hand, I used it for testing. Actually, running something like NCCL Test might be better to avoid some out-of-field interference factors.
+
+## Summary
+
+The above records the process of connecting RDMA in the local Kubernetes cluster. At present, the lack of relevant documents and the wide range of problem domains involved in the process are the main factors hindering learning in this area. Indeed, a relatively solid computer foundation is required.
+
+[^1]: [2 个 RoCE 网卡 Bond 聚合，实现带宽 X2-云社区 - 华为云](https://bbs.huaweicloud.com/blogs/412088)
+[^2]: [RDG for Accelerated K8s Cluster over NVIDIA DGX A100 Servers and 200Gbps Ethernet Network Fabric](https://docs.nvidia.com/networking/display/public/sol/rdg+for+accelerated+k8s+cluster+over+nvidia+dgx+a100+servers+and+200gbps+ethernet+network+fabric)
+[^3]: [Enhance documentaitons · Issue #54 · Mellanox/k8s-rdma-shared-dev-plugin](https://github.com/Mellanox/k8s-rdma-shared-dev-plugin/issues/54)
+[^4]: [Multus-CNI 与 whereabouts 的简单运用 - 剑轩的专栏 - TNBLOG](https://www.tnblog.net/aojiancc2/article/details/7929)
+[^5]: [hostdevice-network-pod1.yml](https://github.com/Mellanox/network-operator/tree/master/example)
+[^6]: [理想与现实  - Infiniband 和以太网的抉择   -  雪球](https://xueqiu.com/2448317325/292453176?md5__1038=eqAxgDyDuD0jQGXBDrDcQ8FKiIwx8iD)
+[^7]: [Distributed Inference and Serving](https://docs.vllm.ai/en/stable/serving/distributed_serving.html)
+[^8]: [[Bug]: 0.8.0(V1) Ray cannot find model pyarrow and pandas](https://github.com/vllm-project/vllm/issues/15100)

--- a/website/content/docs/admin/more/rdma.jp.mdx
+++ b/website/content/docs/admin/more/rdma.jp.mdx
@@ -4,12 +4,12 @@ description: "RDMA"
 ---
 
 > - [K8s test via Infiniband network - Adapters and Cables / InfiniBand/VPI Adapter Cards - NVIDIA Developer Forums](https://forums.developer.nvidia.com/t/k8s-test-via-infiniband-network/285610)
-> - [Running tightly coupled HPC/AI workloads with InfiniBand using NVIDIA Network Operator on AKS \| Microsoft Community Hub](https://techcommunity.microsoft.com/blog/azurehighperformancecomputingblog/running-tightly-coupled-hpcai-workloads-with-infiniband-using-nvidia-network-ope/4117209)
+> - [Running tightly coupled HPC/AI workloads with InfiniBand using NVIDIA Network Operator on AKS | Microsoft Community Hub](https://techcommunity.microsoft.com/blog/azurehighperformancecomputingblog/running-tightly-coupled-hpcai-workloads-with-infiniband-using-nvidia-network-ope/4117209)
 > - [Basic Knowledge and Differences of RoCE, IB, and TCP Networks](https://support.huawei.com/enterprise/en/doc/EDOC1100203339)
 
 正式に開始する前に、RDMA に関連する基礎知識を補足しておきます：
 
-- **RDMA**：これは、オペレーティングシステムのカーネルを迂回するネットワーク通信技術であり、その核心はネットワークカードを介してリモートメモリに直接アクセスすることにあり、従来の TCP/IP プロトコルスタックのデータコピーおよびコンテキストスイッチのオーバーヘッドを回避します。
+- **RDMA**：これは、オペレーティングシステムのカーネルを迂回する network 通信技術であり、その核心はネットワークカードを介してリモートメモリに直接アクセスすることにあり、従来の TCP/IP プロトコルスタックのデータコピーおよびコンテキストスイッチのオーバーヘッドを回避します。
 - **NVIDIA GPU Direct**[^2]：GPU のビデオメモリとネットワークカードの DMA エンジンを直接接続して実現します。GPU がリモートノードと通信する必要がある場合、データは InfiniBand または RoCE ネットワークカードを介して直接転送され、ホストメモリを経由することなくなります。
 - **ネットワーク仮想化**：Macvlan と SR-IOV は 2 つの一般的なネットワーク仮想化のソリューションです。Macvlan は、コンテナに仮想ネットワークインターフェースを作成して、物理ネットワーク上では独立したデバイスとして表示させます。SR-IOV は、物理ネットワークカードのハードウェア仮想化能力を用いて、単一の物理機能（PF）を複数の仮想機能（VF）に分割し、それぞれの VF が Pod に直接割り当てられることを可能にします。
 - **技術パス**：現在の RDMA には主に InfiniBand と RoCE の 2 つの実装方法があります[^6]。InfiniBand は原生的に RDMA プロトコルをサポートしており、専用のスイッチおよびサブネットマネージャーが必要で、独立ネットワークを構築するためコストが高くなります。RoCEv2 は、従来のイーサネットインフラストラクチャを基盤としており、PFC や ECN などのフローコントロールメカニズムを用いてノンロス伝送を保証し、インターネット企業で広く使用されています。
@@ -151,7 +151,7 @@ Deployment Examples（展開例）の章で、約 20 種類の展開方法が紹
 5. コンテナ内で RDMA ネットワークをテストするにはどうすればよいですか？
 6. 一般的なエラーとその解決策はどれですか？
 
-ドキュメントではこれらの質問に答えていません。そのため、私の試行錯誤も非常に困難でした。まず、この段階でこれらの質問に対する私の理解と参考資料を簡単にまとめます：
+ドキュメントではこれらの質問に答えていないため、私の試行錯誤も非常に困難でした。まず、この段階でこれらの質問に対する私の理解と参考資料を簡単にまとめます：
 
 - **性能差**：[IPoIB (IP over InfiniBand) vs. RDMA performance](https://serverfault.com/questions/876403/ipoib-ip-over-infiniband-vs-rdma-performance)、さらに Shared Device Plugin が 1 つの Pod がリソースを申請した場合、帯域幅はほぼ満たすことができます。複数の状況についてはまだテストしていません。
 - **展開方法**：現在は RDMA Shared Device Plugin の方法を採用しており、V100 上で正常に動作しています。ただし、この方法が結合されたネットワークカードを使用できるかは不明で、将来的には Host Network モードに切り替えるかもしれません。
@@ -634,9 +634,9 @@ ib_write_bw -a -F --report_gbits -q 2 <server-pod-default-network-IP>
 
 帯域幅値も`100Gb/s`に近づくため、複数マシン間の接続に問題がないことを示します。
 
-### 4. vLLM 複数マシン分散推論の実践
+### 4. vLLM 複数マシン分散推論の実戦
 
-最後に、Volcano Job を通じて vLLM 複数マシン分散推論 DeepSeek R1 Distill Qwen 32B モデルを実測します。モデルは PVC でマウントし、イメージは Envd で作成します。vLLM は専用の CUDA 12.4 をインストールするため、基本イメージには CUDA を含めません。
+最後に、Volcano Job を通じて vLLM 複数マシン分散推論 DeepSeek R1 Distill Qwen 32B モデルを実行する実測を行います。モデルは PVC を通じてマウントされ、イメージは Envd を通じて作成されます。vLLM は特製の CUDA 12.4 をインストールするため、ベースイメージには CUDA を含める必要はありません。
 
 ```python
 # syntax=v1
@@ -654,7 +654,7 @@ def build():
     config.jupyter()
 ```
 
-その後、Volcano Job を起動します：
+その後、Volcano Job を開始します：
 
 ```yaml
 apiVersion: batch.volcano.sh/v1alpha1
@@ -678,3 +678,491 @@ spec:
   schedulerName: volcano
   tasks:
     - maxRetry: 3
+      minAvailable: 1
+      name: master
+      policies:
+        - action: CompleteJob
+          event: TaskCompleted
+        - action: TerminateJob
+          event: PodFailed
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - command:
+                - sh
+                - -c
+                - |-
+                  ray start --head --port=6667 --disable-usage-stats;
+                  NCCL_DEBUG=TRACE python3 -m vllm.entrypoints.openai.api_server \
+                  --model=/models/DeepSeek-R1-Distill-Qwen-32B \
+                  --max-model-len 32768 \
+                  --tensor-parallel-size 4 \
+                  --pipeline-parallel-size 2 \
+                  --gpu-memory-utilization 0.90 \
+                  --max-num-seqs 128 \
+                  --trust-remote-code \
+                  --disable-custom-all-reduce \
+                  --port 6666 \
+                  --dtype=half;
+              image: xxx/envd-vllm:0.8.3-cu12.4-rdma-v1
+              name: master
+              resources:
+                limits:
+                  nvidia.com/v100: "4"
+                  rdma/rdma_v100: "1"
+                requests:
+                  nvidia.com/v100: "4"
+                  rdma/rdma_v100: "1"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                runAsGroup: 0
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+                - mountPath: /dev/shm
+                  name: crater-cache
+                - mountPath: /models/DeepSeek-R1-Distill-Qwen-32B
+                  name: crater-ro-storage
+                  readOnly: true
+                  subPath: LLM/deepseek/DeepSeek-R1-Distill-Qwen-32B
+              workingDir: /models
+          restartPolicy: Never
+          volumes:
+            - emptyDir:
+                medium: Memory
+              name: crater-cache
+            - name: crater-ro-storage
+              persistentVolumeClaim:
+                claimName: crater-ro-storage
+    - maxRetry: 3
+      minAvailable: 1
+      name: worker
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - command:
+                - sh
+                - -c
+                - |-
+                  ray start --address="$MASTER_ADDR:6667";
+                  sleep infinity;
+              image: xxx/envd-vllm:0.8.3-cu12.4-rdma-v1
+              name: worker
+              resources:
+                limits:
+                  nvidia.com/v100: "4"
+                  rdma/rdma_v100: "1"
+                requests:
+                  nvidia.com/v100: "4"
+                  rdma/rdma_v100: "1"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                runAsGroup: 0
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+                - mountPath: /dev/shm
+                  name: crater-cache
+                - mountPath: /models/DeepSeek-R1-Distill-Qwen-32B
+                  name: crater-ro-storage
+                  readOnly: true
+                  subPath: LLM/deepseek/DeepSeek-R1-Distill-Qwen-32B
+              workingDir: /models
+          restartPolicy: OnFailure
+          volumes:
+            - emptyDir:
+                medium: Memory
+              name: crater-cache
+            - name: crater-ro-storage
+              persistentVolumeClaim:
+                claimName: crater-ro-storage
+  ttlSecondsAfterFinished: 259200
+```
+
+vLLM の分散推論に関する説明[^7]を参照し、`NCCL_DEBUG=TRACE` を有効にしました。ログでは、NCCL が Socket 接続ではなく IB を使用していることがわかります。
+
+推論プロセス中、Kubernetes はマシン間の通信トラフィックを検出できなくなったため、デプロイが成功したことを示しています。
+
+## メモリロック上限の変更
+
+### 0. 問題の説明
+
+以下のエラーはすべて、メモリロックの制限が原因で発生します。
+
+接続テスト中に以下のエラーが発生します：
+
+```bash
+[host1] $ ib_read_bw -q 30
+
+************************************
+* Waiting for client to connect... *
+************************************
+---------------------------------------------------------------------------------------
+                    RDMA_Read BW Test
+ Dual-port       : OFF          Device         : mlx5_0
+ Number of qps   : 30           Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Outstand reads  : 16
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ethernet_read_keys: Couldn't read remote address
+ Unable to read to socket/rdma_cm
+Failed to exchange data between server and clients
+```
+
+```bash
+[host2] $ ib_read_bw -q 30 10.244.46.50
+Couldn't allocate MR
+failed to create mr
+Failed to create MR
+ Couldn't create IB resources
+```
+
+RDMA の帯域幅テストを行う際、小規模なデータ（1024 バイトなど）の転送は正常ですが、1M 以上のデータの転送に失敗します。具体的なエラーメッセージは上記と同様です。詳細は [Issue #339](https://github.com/raids-lab/crater/issues/339) を参照してください。
+
+`ulimit -l` を直接使用して制限を確認すると、システムデフォルトのメモリロック上限である 64KB が得られます。
+
+このとき、コンテナー内で `ulimit -l unlimited` を使用したり、`/etc/security/limits.conf` を変更したりしても、メモリロック上限を正常に変更することはできません。
+
+### 1. 問題の分析
+
+RDMA の核心は、ハードウェア（ネットワークカード HCA）が CPU をバイパスしてリモートメモリに直接アクセスできるようにすることです。通常、OS はメモリを最適化するために、いつでも「ページング」を行ったりデータを移動したりするため、仮想アドレスに対応する物理アドレスが変化します。ネットワークカードがデータを転送している間に、カーネルがそのメモリページをスワップアウトしたり移動したりすると、転送のクラッシュやシステムエラーにつながります。
+
+そのため、アドレスを完全に安定させるために、RDMA は転送前に「メモリ登録」（Memory Registration, MR）を実行する必要があります。この動作は、カーネルレベルで指定された仮想メモリページを物理メモリ内に「ロック」し、カーネルによる移動やディスクへのスワップを禁止します。
+
+Crater は、ジョブに `CAP_IPC_LOCK` を設定することでメモリロック操作の実行をすでに許可していますが、許可されるロック量の制限は変更していません。また、コンテナーに `CAP_SYS_RESOURCE` 特権が付与されていないため、コンテナー内部の操作ではこの上限を変更できません。
+
+現在、Kubernetes 公式は Pod Spec で `ulimit` の直接的な設定を提供していません（詳細は [Issue #3595](https://github.com/kubernetes/kubernetes/issues/3595) を参照）。そのため、コンテナーランタイムの観点から対処する必要があります。
+
+> また、期待すべき点として、Kubernetes コミュニティは v1.36 サイクルにおいて、Pod レベルの ulimit 設定のネイティブサポートに関する議論を正式に開始しました（詳細は [KEP-5758](https://github.com/kubernetes/enhancements/pull/5762) を参照）。
+
+`dockerd` ランタイムには対応する構成項目 `default-ulimits` があり、ノードレベルでこの制限を比較的容易に構成できます。詳細は [構成ファイルの説明](https://docs.docker.com/reference/cli/dockerd/#daemon-configuration-file) と [リソース制限ガイド](https://docs.docker.com/engine/containers/resource_constraints/#set-default-ulimits-for-a-container) を参照してください。
+
+しかし、現在クラスターで使用されているのは `containerd` であり、`dockerd` のような構成項目は提供されていません。詳細は [構成ファイルの説明](https://github.com/containerd/containerd/blob/main/docs/cri/config.md) を参照してください。一方、開発者は [Issue #3150](https://github.com/containerd/containerd/issues/3150) において、デーモンレベルの構成を提供することを明確に拒否しています。そのため、この問題を解決するために別の道を探す必要があります。
+
+> また、試行の結果、ノード上で直接 `/etc/security/limits.conf` を変更して制限を解除したり、コンテナーランタイムデーモンに対してのみ `LimitMEMLOCK=infinity` を設定したりしても、Pod 内の制限を解除することはできません。その根本原因は、コンテナー実行器 `runc` が OCI 仕様のブループリントの定義に厳格に従い、起動時にコンテナーに対して `setrlimit` システムコールを実行するためと考えられます。これにより、デーモン自身の権限上限に関係なく、コンテナーの制限がブループリント内のデフォルト値（例：64KB）で強制的に上書き（通常は引き下げ）されます。
+
+### 2. 解決策
+
+この解決策の核心は、**OCI Runtime Specification (OCI ランタイム仕様)** を変更することにあります。`containerd` の文脈では、`base_runtime_spec` パラメーターで指定された JSON ファイルが、コンテナーの**基礎仕様テンプレート**とみなされます。これはコンテナーの最終的な権威あるリソース境界（`memlock` 制限など）の情報源です（詳細は [OCI 構成仕様](https://github.com/opencontainers/runtime-spec/blob/main/config.md#posix-process) を参照）。基盤となる OCI ランタイム（`runc` など）は、ブループリントの定義に厳密に従い、`setrlimit` システムコールを通じてコンテナープロセスのリソース制限を初期化します。
+
+#### 既存の構成をエクスポートして変更する
+
+`containerd` は、このパラメーターをシステムのデフォルト構成と自動的にマージ（Merge）することをサポートしておらず、完全に置き換える（Replace）戦略をとっているため、まず現在のシステムの完全な定義を含む構成テンプレートをエクスポートし、その上で微調整を行う必要があります。ノード上で以下のコマンドを実行します。
+
+```shell
+ctr oci spec > /etc/containerd/rdma-spec.json
+vim /etc/containerd/rdma-spec.json
+```
+
+構成ファイルの以下の部分を変更します（`rlimits` 配列に `RLIMIT_MEMLOCK` を追加）：
+
+```json
+        "rlimits": [
+            {
+                "type": "RLIMIT_NOFILE",
+                "hard": 1024,
+                "soft": 1024
+            },
+            {
+                "type": "RLIMIT_MEMLOCK",
+                "hard": 18446744073709551615,
+                "soft": 18446744073709551615
+            }
+        ],
+```
+
+#### 変更した構成の参照
+
+`containerd` の構成を変更します。
+
+```toml
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+          # 上記の JSON テンプレートの絶対パスを指すように変更
+          base_runtime_spec = "/etc/containerd/rdma-spec.json"
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          privileged_without_host_devices_all_devices_allowed = false
+          runtime_engine = ""
+          runtime_path = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runc.v2"
+          sandbox_mode = "podsandbox"
+          snapshotter = ""
+```
+
+具体的な状況に応じて変更する必要があります。目標は、対応する Pod が対応する構成を正常に適用できるようにすることです。
+
+<Callout type="warn">
+コンテナーランタイムの構成を変更してサービスを再起動した後、**すでに実行中の Pod には影響しません**。古い Pod を手動で削除し、Kubernetes によって再スケジューリングと `containerd` による新しい OCI ブループリントを使用した初期化をトリガーする必要があります。そうして初めて、構成が真に有効になります。
+</Callout>
+
+#### containerd 自身の制限の解除 (任意)
+
+```shell
+EDITOR=vim systemctl edit containerd
+```
+
+デーモン構成に以下の内容を追加します。
+
+```toml
+[Service]
+LimitMEMLOCK=infinity
+```
+
+その後、`systemctl restart containerd` を使用してサービスを再起動します。
+
+実測の結果、`containerd` が `CAP_SYS_RESOURCE` 特権を持っているため、OCI ブループリントを変更するだけで有効になることが示されていますが、デーモン自身の堅牢性を確保するためにこの項目を補完することは、実稼働環境でのベストプラクティスとして推奨されます。
+
+#### テスト
+
+これで Pod 内のメモリロック上限が解除されているはずです。RDMA 帯域幅テストコマンドを再度実行すると、マスターとワーカーでそれぞれ以下のような出力が表示されます。
+
+**Master:**
+
+```bash
+root@pyt-liuyizhou-260206-2a3fe-master-0:/# ib_write_bw -s 1M -d mlx5_0 -F
+************************************
+* Waiting for client to connect... *
+************************************
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_0
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ TX depth        : 128
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ local address: LID 0x2c QPN 0x0087 PSN 0xcc6a4c RKey 0x1fcc bd VAddr 0x037f67d3b5030
+ remote address: LID 0x2c QPN 0x0088 PSN 0x6dc93a RKey 0x1fcf be VAddr 0x037f026db4030
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
+ 1048576    5000             11133.60            11129.09           0.011123
+---------------------------------------------------------------------------------------
+```
+
+**Worker:**
+
+```bash
+root@pyt-liuyizhou-260206-2a3fe-worker-0:/# ib_write_bw -s 1M -d mlx5_0 -F 10.244.44.139
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_0
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ TX depth        : 128
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ local address: LID 0x2c QPN 0x0088 PSN 0x6dc93a RKey 0x1fcf be VAddr 0x037f026db4030
+ remote address: LID 0x2c QPN 0x0087 PSN 0xcc6a4c RKey 0x1fcc bd VAddr 0x037f67d3b5030
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
+ 1048576    5000             11133.60            11129.09           0.011123
+---------------------------------------------------------------------------------------
+
+root@pyt-liuyizhou-260206-2a3fe-worker-0:/# ulimit -l
+unlimited
+```
+
+Pod 内のメモリロック上限が解除され、大きな帯域幅での RDMA 通信が正常に行えることがわかります。
+
+## 問題の記録
+
+### 1. vLLM 起動時に `Segmentation fault` エラーが発生する
+
+ログから、IB デバイスは正常に認識されていますが、セグメンテーションフォルトが発生しています。
+
+```bash
+[デバイス名]-master-0:528:528 [0] NCCL INFO Channel 00/02 :    0   1   2   3   4   5   6   7
+[デバイス名]-master-0:528:528 [0] NCCL INFO Channel 01/02 :    0   1   2   3   4   5   6   7
+[デバイス名]-master-0:528:528 [0] NCCL INFO Trees [0] 1/4/-1->0->-1 [1] 1/-1/-1->0->4
+    self.device_communicator = device_comm_cls(
+[デバイス名]-master-0:528:528 [0] NCCL INFO P2P Chunksize set to 131072
+[デバイス名]-master-0:528:528 [0] NCCL INFO Channel 00/0 : 7[3] -> 0[0] [receive] via NET/IB/0
+[デバイス名]-master-0:528:528 [0] NCCL INFO Channel 01/0 : 7[3] -> 0[0] [receive] via NET/IB/0
+[デバイス名]-master-0:528:528 [0] NCCL INFO Channel 00/0 : 0[0] -> 1[1] via P2P/IPC
+[デバイス名]-master-0:528:528 [0] NCCL INFO Channel 01/0 : 0[0] -> 1[1] via P2P/IPC
+[デバイス名]-master-0:528:5379 [0] misc/socket.cc:50 NCCL WARN socketProgress: Connection closed by remote peer [デバイス名]-worker-0.[ホスト名].svc.cluster.local<35396>
+[デバイス名]-master-0:528:5379 [0] NCCL INFO misc/socket.cc:752 -> 6
+[デバイス名]-master-0:528:5379 [0] NCCL INFO transport/net_ib.cc:1207 -> 6
+[デバイス名]-master-0:528:5379 [0] NCCL INFO transport/net.cc:837 -> 6
+[デバイス名]-master-0:528:528 [0] NCCL INFO transport/net.cc:405 -> 6
+[デバイス名]-master-0:528:528 [0] NCCL INFO transport.cc:183 -> 6
+                               ^^^^^^^^^^^^^^^^
+[デバイス名]-master-0:528:528 [0] NCCL INFO init.cc:1263 -> 6
+[デバイス名]-master-0:528:528 [0] NCCL INFO init.cc:1548 -> 6
+[デバイス名]-master-0:528:528 [0] NCCL INFO init.cc:1799 -> 6
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/cuda_communicator.py", line 39, in __init__
+[デバイス名]-master-0:528:5379 [0] misc/socket.cc:50 NCCL WARN socketProgress: Connection closed by remote peer [デバイス名]-worker-0.[ホスト名].svc.cluster.local<52144>
+    self.pynccl_comm = PyNcclCommunicator(
+                       ^^^^^^^^^^^^^^^^^^^
+[デバイス名]-master-0:528:5379 [0] NCCL INFO misc/socket.cc:752 -> 6
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[デバイス名]-master-0:528:5379 [0] NCCL INFO transport/net_ib.cc:1207 -> 6
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/pynccl.py", line 99, in __init__
+    self.comm: ncclComm_t = self.nccl.ncclCommInitRank(
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/pynccl_wrapper.py", line 277, in ncclCommInitRank
+    self.NCCL_CHECK(self._funcs["ncclCommInitRank"](ctypes.byref(comm),
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/pynccl_wrapper.py", line 256, in NCCL_CHECK
+    raise RuntimeError(f"NCCL error: {error_str}")
+RuntimeError: NCCL error: unhandled system error (run with NCCL_DEBUG=INFO for details)
+[デバイス名]-master-0:528:5379 [0] NCCL INFO transport/net.cc:837 -> 6
+[デバイス名]-master-0:528:528 [0] NCCL INFO init.cc:1837 -> 6
+*** SIGSEGV received at time=1745072123 on cpu 70 ***
+PC: @     0x7ff94e269506  (unknown)  ncclProxyServiceUDS()
+    @     0x7ffa0c242520       3384  (unknown)
+    @ ... and at least 1 more frames
+[2025-04-19 14:15:23,982 E 528 5383] logging.cc:484: *** SIGSEGV received at time=1745072123 on cpu 70 ***
+[2025-04-19 14:15:23,982 E 528 5383] logging.cc:484: PC: @     0x7ff94e269506  (unknown)  ncclProxyServiceUDS()
+[2025-04-19 14:15:23,983 E 528 5383] logging.cc:484:     @     0x7ffa0c242520       3384  (unknown)
+[2025-04-19 14:15:23,983 E 528 5383] logging.cc:484:     @ ... and at least 1 more frames
+Fatal Python error: Segmentation fault
+```
+
+以前、Pod のセキュアコンテキストに `IPC_LOCK` を追加する必要があると言ったのを覚えていますか？追加しないと、上記の問題が発生します。
+
+### 2. A100 モデルでの複数マシン推論の失敗
+
+まず、A100 モデルで単一マシンの検証を実行します。Up 状態のネットワークカードをちょうど使用した場合、問題ないようです：
+
+```bash
+$ ib_write_bw -d mlx5_1 &
+[1] 1501
+
+************************************
+* Waiting for client to connect... *
+************************************
+
+
+$ ib_write_bw -d mlx5_1 127.0.0.1 --report_gbits
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_1
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_1
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ TX depth        : 128
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]
+Conflicting CPU frequency values detected: 863.109000 != 2300.000000. CPU Frequency is not max.
+ 65536      5000             183.66             183.61             0.350214
+---------------------------------------------------------------------------------------
+ 65536      5000             183.66             183.61             0.350214
+---------------------------------------------------------------------------------------
+
+$ ib_write_bw -d mlx5_0 &
+[1] 1618
+
+Port number 1 state is Down
+ Couldn't set the link layer
+ Couldn't get context for the device
+
+$ ib_write_bw -d mlx5_0 127.0.0.1 --report_gbits
+ Port number 1 state is Down
+ Couldn't set the link layer
+ Couldn't get context for the device
+
+$ ibstat
+CA 'mlx5_0'
+        CA type: MT4123
+        Port 1:
+                State: Down
+                Physical state: Disabled
+                Rate: 10
+                Base lid: 65535
+                LMC: 0
+                SM lid: 0
+                Link layer: InfiniBand
+CA 'mlx5_1'
+        CA type: MT4123
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 3
+                LMC: 0
+                SM lid: 1
+                Link layer: InfiniBand
+CA 'mlx5_bond_0'
+        CA type: MT4117
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 10
+                Link layer: Ethernet
+
+$ ib_write_bw -d mlx5_bond_0 &
+IB device mlx5_bond_0 not found
+ Unable to find the Infiniband/RoCE device
+```
+
+しかし、vLLM を実行するとエラーが発生します。後に、この問題は vLLM V1 および Ray[^8] に関連しており、IB とは関係ないことが判明しました。たまたま手元に vLLM の複数マシン分散推論コードがあったのでテストに使用しましたが、外部の干渉要因を避けるためには NCCL Test などを実行したほうがよいかもしれません。
+
+## まとめ
+
+以上、ローカル Kubernetes クラスターにおける RDMA 接続のプロセスを記録しました。現在、関連ドキュメントの不足や、プロセスに含まれる問題領域の広さが、この分野の学習を妨げる主な要因となっています。確かに、比較的しっかりとしたコンピューターの基礎が必要です。
+
+[^1]: [2 个 RoCE 网卡 Bond 聚合，实现带宽 X2-云社区 - 华为云](https://bbs.huaweicloud.com/blogs/412088)
+[^2]: [RDG for Accelerated K8s Cluster over NVIDIA DGX A100 Servers and 200Gbps Ethernet Network Fabric](https://docs.nvidia.com/networking/display/public/sol/rdg+for+accelerated+k8s+cluster+over+nvidia+dgx+a100+servers+and+200gbps+ethernet+network+fabric)
+[^3]: [Enhance documentaitons · Issue #54 · Mellanox/k8s-rdma-shared-dev-plugin](https://github.com/Mellanox/k8s-rdma-shared-dev-plugin/issues/54)
+[^4]: [Multus-CNI 与 whereabouts 的简单运用 - 剑轩的专栏 - TNBLOG](https://www.tnblog.net/aojiancc2/article/details/7929)
+[^5]: [hostdevice-network-pod1.yml](https://github.com/Mellanox/network-operator/tree/master/example)
+[^6]: [理想与现实  - Infiniband 和以太网的抉择   -  雪球](https://xueqiu.com/2448317325/292453176?md5__1038=eqAxgDyDuD0jQGXBDrDcQ8FKiIwx8iD)
+[^7]: [Distributed Inference and Serving](https://docs.vllm.ai/en/stable/serving/distributed_serving.html)
+[^8]: [[Bug]: 0.8.0(V1) Ray cannot find model pyarrow and pandas](https://github.com/vllm-project/vllm/issues/15100)

--- a/website/content/docs/admin/more/rdma.ko.mdx
+++ b/website/content/docs/admin/more/rdma.ko.mdx
@@ -4,7 +4,7 @@ description: "RDMA"
 ---
 
 > - [K8s test via Infiniband network - Adapters and Cables / InfiniBand/VPI Adapter Cards - NVIDIA Developer Forums](https://forums.developer.nvidia.com/t/k8s-test-via-infiniband-network/285610)
-> - [Running tightly coupled HPC/AI workloads with InfiniBand using NVIDIA Network Operator on AKS \| Microsoft Community Hub](https://techcommunity.microsoft.com/blog/azurehighperformancecomputingblog/running-tightly-coupled-hpcai-workloads-with-infiniband-using-nvidia-network-ope/4117209)
+> - [Running tightly coupled HPC/AI workloads with InfiniBand using NVIDIA Network Operator on AKS | Microsoft Community Hub](https://techcommunity.microsoft.com/blog/azurehighperformancecomputingblog/running-tightly-coupled-hpcai-workloads-with-infiniband-using-nvidia-network-ope/4117209)
 > - [Basic Knowledge and Differences of RoCE, IB, and TCP Networks](https://support.huawei.com/enterprise/en/doc/EDOC1100203339)
 
 공식적으로 시작하기 전에 RDMA 와 관련된 기본 지식을 보완하겠습니다:
@@ -649,4 +649,520 @@ def build():
         "infiniband-diags", "perftest", "ibverbs-providers", "libibumad3",
         "libibverbs1", "libnl-3-200", "libnl-route-3-200", "librdmacm1"
     ])
-    config.pip_index(url = "https://pypi.tuna.tsinghua.edu
+    config.pip_index(url = "https://pypi.tuna.tsinghua.edu.cn/simple")
+    install.python_packages(name = ["vllm"])
+    config.jupyter()
+```
+
+그 후 Volcano Job 을 실행합니다:
+
+```yaml
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: vllm-rdma-test
+  namespace: crater-workspace
+spec:
+  maxRetry: 3
+  minAvailable: 2
+  plugins:
+    pytorch:
+      - --master=master
+      - --worker=worker
+      - --port=23456
+    svc: []
+  policies:
+    - action: RestartJob
+      event: PodEvicted
+  queue: default
+  schedulerName: volcano
+  tasks:
+    - maxRetry: 3
+      minAvailable: 1
+      name: master
+      policies:
+        - action: CompleteJob
+          event: TaskCompleted
+        - action: TerminateJob
+          event: PodFailed
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - command:
+                - sh
+                - -c
+                - |-
+                  ray start --head --port=6667 --disable-usage-stats;
+                  NCCL_DEBUG=TRACE python3 -m vllm.entrypoints.openai.api_server \
+                  --model=/models/DeepSeek-R1-Distill-Qwen-32B \
+                  --max-model-len 32768 \
+                  --tensor-parallel-size 4 \
+                  --pipeline-parallel-size 2 \
+                  --gpu-memory-utilization 0.90 \
+                  --max-num-seqs 128 \
+                  --trust-remote-code \
+                  --disable-custom-all-reduce \
+                  --port 6666 \
+                  --dtype=half;
+              image: xxx/envd-vllm:0.8.3-cu12.4-rdma-v1
+              name: master
+              resources:
+                limits:
+                  nvidia.com/v100: "4"
+                  rdma/rdma_v100: "1"
+                requests:
+                  nvidia.com/v100: "4"
+                  rdma/rdma_v100: "1"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                runAsGroup: 0
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+                - mountPath: /dev/shm
+                  name: crater-cache
+                - mountPath: /models/DeepSeek-R1-Distill-Qwen-32B
+                  name: crater-ro-storage
+                  readOnly: true
+                  subPath: LLM/deepseek/DeepSeek-R1-Distill-Qwen-32B
+              workingDir: /models
+          restartPolicy: Never
+          volumes:
+            - emptyDir:
+                medium: Memory
+              name: crater-cache
+            - name: crater-ro-storage
+              persistentVolumeClaim:
+                claimName: crater-ro-storage
+    - maxRetry: 3
+      minAvailable: 1
+      name: worker
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - command:
+                - sh
+                - -c
+                - |-
+                  ray start --address="$MASTER_ADDR:6667";
+                  sleep infinity;
+              image: xxx/envd-vllm:0.8.3-cu12.4-rdma-v1
+              name: worker
+              resources:
+                limits:
+                  nvidia.com/v100: "4"
+                  rdma/rdma_v100: "1"
+                requests:
+                  nvidia.com/v100: "4"
+                  rdma/rdma_v100: "1"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                runAsGroup: 0
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+                - mountPath: /dev/shm
+                  name: crater-cache
+                - mountPath: /models/DeepSeek-R1-Distill-Qwen-32B
+                  name: crater-ro-storage
+                  readOnly: true
+                  subPath: LLM/deepseek/DeepSeek-R1-Distill-Qwen-32B
+              workingDir: /models
+          restartPolicy: OnFailure
+          volumes:
+            - emptyDir:
+                medium: Memory
+              name: crater-cache
+            - name: crater-ro-storage
+              persistentVolumeClaim:
+                claimName: crater-ro-storage
+  ttlSecondsAfterFinished: 259200
+```
+
+vLLM 의 분산 추론에 관한 설명[^7]을 참고하여 `NCCL_DEBUG=TRACE`를 활성화했습니다. 로그에서 NCCL 이 Socket 연결 대신 IB 를 사용했음을 확인할 수 있습니다.
+
+추론 과정 중 Kubernetes 가 머신 간 통신 트래픽을 더 이상 감지하지 못하게 되었으며, 이는 배포가 성공했음을 나타냅니다.
+
+## 메모리 잠금 상한 수정
+
+### 0. 문제 설명
+
+다음의 오류들은 모두 메모리 잠금 제한으로 인해 발생합니다.
+
+연결 테스트 중에 다음과 같은 오류가 발생합니다:
+
+```bash
+[host1] $ ib_read_bw -q 30
+
+************************************
+* Waiting for client to connect... *
+************************************
+---------------------------------------------------------------------------------------
+                    RDMA_Read BW Test
+ Dual-port       : OFF          Device         : mlx5_0
+ Number of qps   : 30           Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Outstand reads  : 16
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ethernet_read_keys: Couldn't read remote address
+ Unable to read to socket/rdma_cm
+Failed to exchange data between server and clients
+```
+
+```bash
+[host2] $ ib_read_bw -q 30 10.244.46.50
+Couldn't allocate MR
+failed to create mr
+Failed to create MR
+ Couldn't create IB resources
+```
+
+RDMA 대역폭 테스트 시 작은 데이터(예: 1024 바이트) 전송은 정상이지만, 1M 이상의 데이터 전송은 실패합니다. 구체적인 오류 메시지는 위와 같습니다. 자세한 내용은 [Issue #339](https://github.com/raids-lab/crater/issues/339)를 참조하십시오.
+
+`ulimit -l`을 사용하여 직접 제한을 확인하면 시스템 기본 메모리 잠금 상한인 64KB 가 나타납니다.
+
+이때 컨테이너 내부에서 `ulimit -l unlimited`를 사용하거나 `/etc/security/limits.conf`를 수정해도 메모리 잠금 상한을 정상적으로 변경할 수 없습니다.
+
+### 1. 문제 분석
+
+RDMA 의 핵심은 하드웨어(네트워크 카드 HCA)가 CPU 를 우회하여 원격 메모리에 직접 액세스할 수 있도록 하는 것입니다. 일반적으로 운영체제는 메모리를 최적화하기 위해 언제든지 "페이징"을 수행하거나 데이터를 이동시켜 가상 주소에 대응하는 물리 주소를 변경할 수 있습니다. 네트워크 카드가 데이터를 전송하는 동안 커널이 해당 메모리 페이지를 스왑 아웃하거나 이동시키면 전송 중단이나 시스템 오류가 발생합니다.
+
+따라서 주소를 완전히 고정하기 위해 RDMA 는 전송 전에 "메모리 등록"(Memory Registration, MR)을 수행해야 합니다. 이 작업은 커널 수준에서 특정 가상 메모리 페이지를 물리 메모리에 "잠금"(Lock)하여 커널이 이를 이동시키거나 디스크로 스왑하는 것을 금지합니다.
+
+Crater 는 이미 작업에 `CAP_IPC_LOCK`을 설정하여 메모리 잠금 작업을 수행할 수 있도록 허용했지만, 잠글 수 있는 양에 대한 제한은 수정하지 않았습니다. 또한 컨테이너에 `CAP_SYS_RESOURCE` 특권이 없으므로 컨테이너 내부 작업으로는 이 상한을 변경할 수 없습니다.
+
+현재 Kubernetes 공식은 Pod Spec 에서 `ulimit`을 직접 설정하는 기능을 제공하지 않습니다(자세한 내용은 [Issue #3595](https://github.com/kubernetes/kubernetes/issues/3595) 참조). 따라서 컨테이너 런타임 차원에서 접근해야 합니다.
+
+> 기대해 볼 만한 점은, Kubernetes 커뮤니티가 v1.36 사이클에서 Pod 수준의 ulimit 설정에 대한 기본 지원 논의를 공식적으로 시작했다는 것입니다(자세한 내용은 [KEP-5758](https://github.com/kubernetes/enhancements/pull/5762) 참조).
+
+`dockerd` 런타임에는 해당하는 구성 항목인 `default-ulimits`가 있어 노드 수준에서 이 제한을 비교적 쉽게 구성할 수 있습니다. 자세한 내용은 [구성 파일 설명](https://docs.docker.com/reference/cli/dockerd/#daemon-configuration-file) 및 [리소스 제한 가이드](https://docs.docker.com/engine/containers/resource_constraints/#set-default-ulimits-for-a-container)를 참조하십시오.
+
+그러나 현재 클러스터에서 사용하는 것은 `containerd`이며, `dockerd`와 같은 구성 항목을 제공하지 않습니다. 자세한 내용은 [구성 파일 설명](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)을 참조하십시오. 반면 개발자들은 [Issue #3150](https://github.com/containerd/containerd/issues/3150)에서 데몬 수준의 구성을 제공하는 것을 명확히 거부했습니다. 따라서 이 문제를 해결하기 위해 다른 방법을 찾아야 합니다.
+
+> 또한 시도 결과, 노드에서 직접 `/etc/security/limits.conf`를 수정하여 제한을 해제하거나, 컨테이너 런타임 데몬에 대해서만 `LimitMEMLOCK=infinity`를 설정해도 Pod 내부의 제한을 해제할 수 없습니다. 그 근본 원인은 컨테이너 실행기인 `runc`가 OCI 사양 블루프린트의 정의를 엄격히 따르며 시작 시 컨테이너에 대해 `setrlimit` 시스템 호출을 수행하기 때문인 것으로 보입니다. 이로 인해 데몬 자체의 권한 상한과 관계없이 컨테이너의 제한이 블루프린트 내부의 기본값(예: 64KB)으로 강제 덮어쓰기(대개 하향 조정)됩니다.
+
+### 2. 해결 방법
+
+이 해결 방법의 핵심은 **OCI Runtime Specification (OCI 런타임 사양)**을 수정하는 데 있습니다. `containerd` 문맥에서 `base_runtime_spec` 파라미터로 지정된 JSON 파일은 컨테이너의 **기본 사양 템플릿**으로 간주됩니다. 이것이 컨테이너의 최종적이고 권위 있는 리소스 경계(예: `memlock` 제한)의 정보원입니다(자세한 내용은 [OCI 구성 사양](https://github.com/opencontainers/runtime-spec/blob/main/config.md#posix-process) 참조). 하부 OCI 런타임(예: `runc`)은 블루프린트 정의에 따라 `setrlimit` 시스템 호출을 통해 컨테이너 프로세스의 리소스 제한을 초기화합니다.
+
+#### 기존 구성 내보내기 및 수정
+
+`containerd`는 이 파라미터를 시스템 기본 구성과 자동으로 병합(Merge)하는 기능을 지원하지 않고 완전히 대체(Replace)하는 전략을 사용하므로, 먼저 현재 시스템의 전체 정의가 포함된 구성 템플릿을 내보낸 후 미세 조정을 수행해야 합니다. 노드에서 다음 명령을 실행하십시오:
+
+```shell
+ctr oci spec > /etc/containerd/rdma-spec.json
+vim /etc/containerd/rdma-spec.json
+```
+
+구성 파일의 다음 부분을 수정하십시오 (`rlimits` 배열에 `RLIMIT_MEMLOCK` 추가):
+
+```json
+        "rlimits": [
+            {
+                "type": "RLIMIT_NOFILE",
+                "hard": 1024,
+                "soft": 1024
+            },
+            {
+                "type": "RLIMIT_MEMLOCK",
+                "hard": 18446744073709551615,
+                "soft": 18446744073709551615
+            }
+        ],
+```
+
+#### 수정된 구성 참조
+
+`containerd` 구성을 수정하십시오.
+
+```toml
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+          # 위에서 생성한 JSON 템플릿의 절대 경로를 가리키도록 수정
+          base_runtime_spec = "/etc/containerd/rdma-spec.json"
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          privileged_without_host_devices_all_devices_allowed = false
+          runtime_engine = ""
+          runtime_path = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runc.v2"
+          sandbox_mode = "podsandbox"
+          snapshotter = ""
+```
+
+구체적인 상황에 맞게 수정해야 합니다. 목표는 해당 Pod 가 해당 구성을 정상적으로 적용할 수 있도록 하는 것입니다.
+
+<Callout type="warn">
+컨테이너 런타임 구성을 수정하고 서비스를 재시작한 후에도 **이미 실행 중인 Pod 에는 영향을 미치지 않습니다**. 기존 Pod 를 수동으로 삭제해야 Kubernetes 가 다시 스케줄링을 수행하고 `containerd`가 새로운 OCI 블루프린트를 사용하여 초기화하도록 트리거하여 구성이 실제로 적용됩니다.
+</Callout>
+
+#### containerd 자체 제한 해제 (선택 사항)
+
+```shell
+EDITOR=vim systemctl edit containerd
+```
+
+데몬 구성에 다음 내용을 추가하십시오:
+
+```toml
+[Service]
+LimitMEMLOCK=infinity
+```
+
+이후 `systemctl restart containerd`를 사용하여 서비스를 재시작하십시오.
+
+실제 테스트 결과, `containerd`가 `CAP_SYS_RESOURCE` 특권을 가지고 있어 OCI 블루프린트 수정만으로도 효과가 있는 것으로 나타났으나, 데몬 자체의 견고성을 보장하기 위해 이 항목을 보완하는 것이 프로덕션 환경에서의 모범 사례로 권장됩니다.
+
+#### 테스트
+
+이제 Pod 내부의 메모리 잠금 상한이 해제되었을 것입니다. RDMA 대역폭 테스트 명령을 다시 실행하면 마스터와 워커에서 각각 다음과 같은 출력이 표시됩니다.
+
+**Master:**
+
+```bash
+root@pyt-liuyizhou-260206-2a3fe-master-0:/# ib_write_bw -s 1M -d mlx5_0 -F
+************************************
+* Waiting for client to connect... *
+************************************
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_0
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ TX depth        : 128
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ local address: LID 0x2c QPN 0x0087 PSN 0xcc6a4c RKey 0x1fcc bd VAddr 0x037f67d3b5030
+ remote address: LID 0x2c QPN 0x0088 PSN 0x6dc93a RKey 0x1fcf be VAddr 0x037f026db4030
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
+ 1048576    5000             11133.60            11129.09           0.011123
+---------------------------------------------------------------------------------------
+```
+
+**Worker:**
+
+```bash
+root@pyt-liuyizhou-260206-2a3fe-worker-0:/# ib_write_bw -s 1M -d mlx5_0 -F 10.244.44.139
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_0
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ TX depth        : 128
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ local address: LID 0x2c QPN 0x0088 PSN 0x6dc93a RKey 0x1fcf be VAddr 0x037f026db4030
+ remote address: LID 0x2c QPN 0x0087 PSN 0xcc6a4c RKey 0x1fcc bd VAddr 0x037f67d3b5030
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
+ 1048576    5000             11133.60            11129.09           0.011123
+---------------------------------------------------------------------------------------
+
+root@pyt-liuyizhou-260206-2a3fe-worker-0:/# ulimit -l
+unlimited
+```
+
+Pod 내부의 메모리 잠금 상한이 해제되어 큰 대역폭에서도 RDMA 통신이 정상적으로 이루어지는 것을 확인할 수 있습니다.
+
+## 문제 기록
+
+### 1. vLLM 시작 시 `Segmentation fault` 오류 발생
+
+로그를 보면 IB 장치가 정상적으로 인식되었음에도 세그멘테이션 오류가 발생합니다.
+
+```bash
+[장치명]-master-0:528:528 [0] NCCL INFO Channel 00/02 :    0   1   2   3   4   5   6   7
+[장치명]-master-0:528:528 [0] NCCL INFO Channel 01/02 :    0   1   2   3   4   5   6   7
+[장치명]-master-0:528:528 [0] NCCL INFO Trees [0] 1/4/-1->0->-1 [1] 1/-1/-1->0->4
+    self.device_communicator = device_comm_cls(
+[장치명]-master-0:528:528 [0] NCCL INFO P2P Chunksize set to 131072
+[장치명]-master-0:528:528 [0] NCCL INFO Channel 00/0 : 7[3] -> 0[0] [receive] via NET/IB/0
+[장치명]-master-0:528:528 [0] NCCL INFO Channel 01/0 : 7[3] -> 0[0] [receive] via NET/IB/0
+[장치명]-master-0:528:528 [0] NCCL INFO Channel 00/0 : 0[0] -> 1[1] via P2P/IPC
+[장치명]-master-0:528:528 [0] NCCL INFO Channel 01/0 : 0[0] -> 1[1] via P2P/IPC
+[장치명]-master-0:528:5379 [0] misc/socket.cc:50 NCCL WARN socketProgress: Connection closed by remote peer [장치명]-worker-0.[호스트명].svc.cluster.local<35396>
+[장치명]-master-0:528:5379 [0] NCCL INFO misc/socket.cc:752 -> 6
+[장치명]-master-0:528:5379 [0] NCCL INFO transport/net_ib.cc:1207 -> 6
+[장치명]-master-0:528:5379 [0] NCCL INFO transport/net.cc:837 -> 6
+[장치명]-master-0:528:528 [0] NCCL INFO transport/net.cc:405 -> 6
+[장치명]-master-0:528:528 [0] NCCL INFO transport.cc:183 -> 6
+                               ^^^^^^^^^^^^^^^^
+[장치명]-master-0:528:528 [0] NCCL INFO init.cc:1263 -> 6
+[장치명]-master-0:528:528 [0] NCCL INFO init.cc:1548 -> 6
+[장치명]-master-0:528:528 [0] NCCL INFO init.cc:1799 -> 6
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/cuda_communicator.py", line 39, in __init__
+[장치명]-master-0:528:5379 [0] misc/socket.cc:50 NCCL WARN socketProgress: Connection closed by remote peer [장치명]-worker-0.[호스트명].svc.cluster.local<52144>
+    self.pynccl_comm = PyNcclCommunicator(
+                       ^^^^^^^^^^^^^^^^^^^
+[장치명]-master-0:528:5379 [0] NCCL INFO misc/socket.cc:752 -> 6
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[장치명]-master-0:528:5379 [0] NCCL INFO transport/net_ib.cc:1207 -> 6
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/pynccl.py", line 99, in __init__
+    self.comm: ncclComm_t = self.nccl.ncclCommInitRank(
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/pynccl_wrapper.py", line 277, in ncclCommInitRank
+    self.NCCL_CHECK(self._funcs["ncclCommInitRank"](ctypes.byref(comm),
+  File "/opt/conda/envs/envd/lib/python3.12/site-packages/vllm/distributed/device_communicators/pynccl_wrapper.py", line 256, in NCCL_CHECK
+    raise RuntimeError(f"NCCL error: {error_str}")
+RuntimeError: NCCL error: unhandled system error (run with NCCL_DEBUG=INFO for details)
+[장치명]-master-0:528:5379 [0] NCCL INFO transport/net.cc:837 -> 6
+[장치명]-master-0:528:528 [0] NCCL INFO init.cc:1837 -> 6
+*** SIGSEGV received at time=1745072123 on cpu 70 ***
+PC: @     0x7ff94e269506  (unknown)  ncclProxyServiceUDS()
+    @     0x7ffa0c242520       3384  (unknown)
+    @ ... and at least 1 more frames
+[2025-04-19 14:15:23,982 E 528 5383] logging.cc:484: *** SIGSEGV received at time=1745072123 on cpu 70 ***
+[2025-04-19 14:15:23,982 E 528 5383] logging.cc:484: PC: @     0x7ff94e269506  (unknown)  ncclProxyServiceUDS()
+[2025-04-19 14:15:23,983 E 528 5383] logging.cc:484:     @     0x7ffa0c242520       3384  (unknown)
+[2025-04-19 14:15:23,983 E 528 5383] logging.cc:484:     @ ... and at least 1 more frames
+Fatal Python error: Segmentation fault
+```
+
+이전에 Pod 의 보안 컨텍스트에 `IPC_LOCK`을 추가해야 한다고 말씀드린 것을 기억하시나요? 이를 추가하지 않으면 위와 같은 문제가 발생합니다.
+
+### 2. A100 기종에서 다중 머신 추론 실패
+
+먼저 A100 기종에서 단일 머신 검증을 수행했습니다. Up 상태인 네트워크 카드를 사용하면 문제없는 것으로 보입니다:
+
+```bash
+$ ib_write_bw -d mlx5_1 &
+[1] 1501
+
+************************************
+* Waiting for client to connect... *
+************************************
+
+
+$ ib_write_bw -d mlx5_1 127.0.0.1 --report_gbits
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_1
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_1
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ TX depth        : 128
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]
+Conflicting CPU frequency values detected: 863.109000 != 2300.000000. CPU Frequency is not max.
+ 65536      5000             183.66             183.61             0.350214
+---------------------------------------------------------------------------------------
+ 65536      5000             183.66             183.61             0.350214
+---------------------------------------------------------------------------------------
+
+$ ib_write_bw -d mlx5_0 &
+[1] 1618
+
+Port number 1 state is Down
+ Couldn't set the link layer
+ Couldn't get context for the device
+
+$ ib_write_bw -d mlx5_0 127.0.0.1 --report_gbits
+ Port number 1 state is Down
+ Couldn't set the link layer
+ Couldn't get context for the device
+
+$ ibstat
+CA 'mlx5_0'
+        CA type: MT4123
+        Port 1:
+                State: Down
+                Physical state: Disabled
+                Rate: 10
+                Base lid: 65535
+                LMC: 0
+                SM lid: 0
+                Link layer: InfiniBand
+CA 'mlx5_1'
+        CA type: MT4123
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 3
+                LMC: 0
+                SM lid: 1
+                Link layer: InfiniBand
+CA 'mlx5_bond_0'
+        CA type: MT4117
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 10
+                Link layer: Ethernet
+
+$ ib_write_bw -d mlx5_bond_0 &
+IB device mlx5_bond_0 not found
+ Unable to find the Infiniband/RoCE device
+```
+
+하지만 vLLM 실행 시 오류가 발생합니다. 조사 결과, 이 문제는 vLLM V1 및 Ray[^8]와 관련된 문제로 확인되었으며 IB 와는 무관합니다. 마침 vLLM 다중 머신 분산 추론 코드가 있어 테스트에 사용했지만, 외부 간섭 요인을 피하기 위해 NCCL Test 등을 사용하는 것이 좋습니다.
+
+## 요약
+
+이상으로 로컬 Kubernetes 클러스터에서 RDMA 연결을 구축하는 과정을 기록했습니다. 현재 관련 문서의 부족과 문제 영역의 방대함이 이 분야 학습의 주요 장애물입니다. 확실히 탄탄한 컴퓨터 기초 지식이 요구됩니다.
+
+[^1]: [2 个 RoCE 网卡 Bond 聚合，实现带宽 X2-云社区 - 华为云](https://bbs.huaweicloud.com/blogs/412088)
+[^2]: [RDG for Accelerated K8s Cluster over NVIDIA DGX A100 Servers and 200Gbps Ethernet Network Fabric](https://docs.nvidia.com/networking/display/public/sol/rdg+for+accelerated+k8s+cluster+over+nvidia+dgx+a100+servers+and+200gbps+ethernet+network+fabric)
+[^3]: [Enhance documentaitons · Issue #54 · Mellanox/k8s-rdma-shared-dev-plugin](https://github.com/Mellanox/k8s-rdma-shared-dev-plugin/issues/54)
+[^4]: [Multus-CNI 与 whereabouts 的简单运用 - 剑轩的专栏 - TNBLOG](https://www.tnblog.net/aojiancc2/article/details/7929)
+[^5]: [hostdevice-network-pod1.yml](https://github.com/Mellanox/network-operator/tree/master/example)
+[^6]: [理想与现实  - Infiniband 和以太网的抉择   -  雪球](https://xueqiu.com/2448317325/292453176?md5__1038=eqAxgDyDuD0jQGXBDrDcQ8FKiIwx8iD)
+[^7]: [Distributed Inference and Serving](https://docs.vllm.ai/en/stable/serving/distributed_serving.html)
+[^8]: [[Bug]: 0.8.0(V1) Ray cannot find model pyarrow and pandas](https://github.com/vllm-project/vllm/issues/15100)

--- a/website/content/docs/admin/more/rdma.mdx
+++ b/website/content/docs/admin/more/rdma.mdx
@@ -791,9 +791,13 @@ spec:
 
 推理过程，Kubernetes 也检测不到机间通信的流量了，说明我们的部署已经成功。
 
-## 问题记录
+## 修改内存锁定上限
 
-### 1. 进行联通性测试报错
+### 0. 问题描述
+
+以下的报错都是内存锁定限制引起的。
+
+联通性测试时产生以下报错：
 
 ```bash
 [host1] $ ib_read_bw -q 30
@@ -828,9 +832,176 @@ Failed to create MR
  Couldn't create IB resources
 ```
 
-这是因为申请 RDMA 资源后，不能给 Pod 设置 Memory 的 Limit。
+RDMA 进行带宽测试时，小数据量（如 1024 字节）传输正常，但 1M 及以上数据量传输失败，具体的报错信息与上面类似，详见 [Issue #339](https://github.com/raids-lab/crater/issues/339)。
 
-### 2. 启动 vLLM 时报错 `Segmentation fault`
+直接使用 `ulimit -l` 查看限制，得到的是 64KB，即系统默认的内存锁定上限。
+
+此时在容器中使用 `ulimit -l unlimited` 或者修改 `/etc/security/limits.conf` 均不能成功修改内存锁定上限。
+
+### 1. 问题分析
+
+RDMA 的核心是让 hardware（网卡 HCA）绕过 CPU 直接访问远程内存。在普通操作中，操作系统为了优化内存，会随时进行“换页” (Paging) 或移动数据，导致虚拟地址对应的物理地址发生变化。如果网卡正在传输数据时，内核将该页内存换出或移动，会导致传输崩溃甚至系统错误。
+
+所以，为了保证地址绝对稳定，RDMA 在传输前必须执行“内存注册” (Memory Registration, MR)。这一动作在内核层面将指定的虚拟内存页“锁死”在物理内存中，禁止内核对其进行移动或交换到磁盘。
+
+Crater 已经通过给作业设置 `CAP_IPC_LOCK` 允许其执行锁定内存的操作，但是没有修改允许锁定的量的限制。同时，由于没有给予容器 `CAP_SYS_RESOURCE` 的权限，容器内部的操作也无法修改这个上限。
+
+目前 Kubernetes 官方在 Pod Spec 中并未提供直接设置 `ulimit` 的配置项，详见 [Issue #3595](https://github.com/kubernetes/kubernetes/issues/3595)，因此需要从容器运行时的角度下手。
+
+> 另外，值得期待的是，Kubernetes 社区已经在 v1.36 周期内正式启动了关于原生支持 Pod 级 ulimit 配置的讨论，详见 [KEP-5758](https://github.com/kubernetes/enhancements/pull/5762)。
+
+`dockerd` 运行时提供了相应的配置项 `default-ulimits`，可以比较方便的在节点层面配置这个限制，详见[配置文件说明](https://docs.docker.com/reference/cli/dockerd/#daemon-configuration-file)和[资源限制指南](https://docs.docker.com/engine/containers/resource_constraints/#set-default-ulimits-for-a-container)。
+
+但目前集群中使用的是 `containerd`，它并不提供类似 `dockerd` 的配置项，详见[配置文件说明](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)，同时开发者在 [Issue #3150](https://github.com/containerd/containerd/issues/3150) 中明确拒绝提供守护进程级别的配置。因此需要另辟蹊径以解决这个问题。
+
+> 另外，经过尝试，直接在节点修改 `/etc/security/limits.conf` 解除限制，或者仅为容器运行时守护进程设置 `LimitMEMLOCK=infinity` 同样无法放开 Pod 内的限制。其根源推测在于容器执行器 `runc` 会严格按照 OCI 规范蓝图中的定义，在启动时为容器执行 `setrlimit` 系统调用，这会将容器的限制强制覆盖（通常是拉低）为蓝图中的默认值（如 64KB），从而无视了守护进程自身的权力上限。
+
+### 2. 解决方案
+
+该方案的核心在于修改 **OCI Runtime Specification (OCI 运行时规范)**。在 `containerd` 的语境下，通过 `base_runtime_spec` 参数指定的 JSON 文件被视为容器的**基础规范模板**。它是定义容器资源边界（如 `memlock` 限制）的最终权威来源（详见 [OCI 配置规范](https://github.com/opencontainers/runtime-spec/blob/main/config.md#posix-process)），底层的 OCI 运行时（如 `runc`）会严格按照该蓝图的定义，通过 `setrlimit` 系统调用来初始化容器进程的资源限额。
+
+#### 导出现有配置并修改
+
+由于 `containerd` 并不支持将该参数与系统默认配置进行自动合并（Merge），而是采取完全替换（Replace）策略，因此我们必须先导出一份包含当前系统完整定义的配置模板，再在其基础上进行微调。在节点上运行以下命令。
+
+```shell
+ctr oci spec > /etc/containerd/rdma-spec.json
+vim /etc/containerd/rdma-spec.json
+```
+
+修改配置文件的以下部分（在 `rlimits` 数组中追加 `RLIMIT_MEMLOCK`）：
+
+```json
+        "rlimits": [
+            {
+                "type": "RLIMIT_NOFILE",
+                "hard": 1024,
+                "soft": 1024
+            },
+            {
+                "type": "RLIMIT_MEMLOCK",
+                "hard": 18446744073709551615,
+                "soft": 18446744073709551615
+            }
+        ],
+```
+
+#### 引用修改后的配置
+
+修改 `containerd` 的配置。
+
+```toml
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+          # 修改为指向上述 JSON 模板的绝对路径
+          base_runtime_spec = "/etc/containerd/rdma-spec.json"
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          privileged_without_host_devices_all_devices_allowed = false
+          runtime_engine = ""
+          runtime_path = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runc.v2"
+          sandbox_mode = "podsandbox"
+          snapshotter = ""
+```
+
+需要根据具体情况修改，目标是让对应的 Pod 成功应用对应的配置。
+
+<Callout type="warn">
+修改容器运行时配置并重启服务后，**不会影响已经在运行的 Pod**。必须手动删除旧的 Pod，由 Kubernetes 重新调度并触发 `containerd` 使用新的 OCI 蓝图进行初始化，配置才会真正生效。
+</Callout>
+
+#### 解除 containerd 自身的限制（可选）
+
+```shell
+EDITOR=vim systemctl edit containerd
+```
+
+在守护进程配置中添加以下内容。
+
+```toml
+[Service]
+LimitMEMLOCK=infinity
+```
+
+然后使用 `systemctl restart containerd` 重启服务。
+
+虽然实测显示由于 `containerd` 拥有 `CAP_SYS_RESOURCE` 特权，仅修改 OCI 蓝图即可生效，但补全此项是为了确保守护进程自身的鲁棒性，作为生产环境的最佳实践推荐开启。
+
+#### 测试
+
+至此，Pod 中的内存锁定上限应该已被解除，我们可以再次运行 RDMA 带宽测试命令，分别能够在主机和从机上看到以下输出。
+
+**Master:**
+
+```bash
+root@pyt-liuyizhou-260206-2a3fe-master-0:/# ib_write_bw -s 1M -d mlx5_0 -F
+************************************
+* Waiting for client to connect... *
+************************************
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_0
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ TX depth        : 128
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ local address: LID 0x2c QPN 0x0087 PSN 0xcc6a4c RKey 0x1fcc bd VAddr 0x037f67d3b5030
+ remote address: LID 0x2c QPN 0x0088 PSN 0x6dc93a RKey 0x1fcf be VAddr 0x037f026db4030
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
+ 1048576    5000             11133.60            11129.09           0.011123
+---------------------------------------------------------------------------------------
+```
+
+**Worker:**
+
+```bash
+root@pyt-liuyizhou-260206-2a3fe-worker-0:/# ib_write_bw -s 1M -d mlx5_0 -F 10.244.44.139
+---------------------------------------------------------------------------------------
+                    RDMA_Write BW Test
+ Dual-port       : OFF          Device         : mlx5_0
+ Number of qps   : 1            Transport type : IB
+ Connection type : RC           Using SRQ      : OFF
+ PCIe relax order: ON
+ ibv_wr* API     : ON
+ TX depth        : 128
+ CQ Moderation   : 1
+ Mtu             : 4096[B]
+ Link type       : IB
+ Max inline data : 0[B]
+ rdma_cm QPs     : OFF
+ Data ex. method : Ethernet
+---------------------------------------------------------------------------------------
+ local address: LID 0x2c QPN 0x0088 PSN 0x6dc93a RKey 0x1fcf be VAddr 0x037f026db4030
+ remote address: LID 0x2c QPN 0x0087 PSN 0xcc6a4c RKey 0x1fcc bd VAddr 0x037f67d3b5030
+---------------------------------------------------------------------------------------
+ #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]
+ 1048576    5000             11133.60            11129.09           0.011123
+---------------------------------------------------------------------------------------
+
+root@pyt-liuyizhou-260206-2a3fe-worker-0:/# ulimit -l
+unlimited
+```
+
+可以看到 Pod 内的内存锁定上限已被解除，并且可以正常进行较大带宽的 RDMA 通信。
+
+## 问题记录
+
+### 1. 启动 vLLM 时报错 `Segmentation fault`
 
 从日志来看，IB 设备已经成功识别了，但出现了段错误。
 
@@ -883,7 +1054,7 @@ Fatal Python error: Segmentation fault
 
 还记得我们之前提到，需要在 Pod 的安全上下文中增加 `IPC_LOCK` 么？如果不增加，就会导致上述问题。
 
-### 3. A100 机型跑多机推理失败
+### 2. A100 机型跑多机推理失败
 
 首先在 A100 机型运行单机的验证，如果正好使用了 Up 的网卡，好像没有问题：
 


### PR DESCRIPTION
解决 RDMA 大数据量传输失败问题（Issue #339），新增了相关的技术文档。

### 修改

- **RDMA 文档更新**：在 `rdma.mdx` 及其多语言版本（EN, JP, KO）中新增了为 RDMA 解除内存锁定上限的文档，提供了基于 `base_runtime_spec` 的技术解决方案。

### 测试

- **文档检查**：对修改后的中文、英文、日语文档进行了阅读检查，确保技术描述准确、格式一致。韩语看不懂（

---

Resolve RDMA large data transfer failures (Issue #339) by adding relevant technical documentation.

### Changes

- **RDMA Documentation Update**: Added documentation for lifting the memory lock limit for RDMA in `rdma.mdx` and its translated versions (EN, JP, KO), providing a technical solution based on `base_runtime_spec`. Cannot read Korean.

### Testing

- **Documentation Review**: Conducted proofreading for the modified CN, EN, and JP documents to ensure technical accuracy and consistent formatting.

---

Resolve #339