### PR TITLE
perf(statistics): 降低统计查询 I/O 并优化时间桶遍历

### DIFF
--- a/backend/dao/model/job.go
+++ b/backend/dao/model/job.go
@@ -68,15 +68,18 @@ func (s *ScheduleData) Init(msg string) error {
 
 type Job struct {
 	gorm.Model
-	Name               string                              `gorm:"not null;type:varchar(256);comment:作业名称"`
-	JobName            string                              `gorm:"uniqueIndex;type:varchar(256);not null;comment:作业名称"`
-	UserID             uint                                `gorm:"primaryKey"`
-	User               User                                `gorm:"foreignKey:UserID"`
-	AccountID          uint                                `gorm:"primaryKey"`
-	Account            Account                             `gorm:"foreignKey:AccountID"`
-	JobType            JobType                             `gorm:"not null;comment:作业类型"`
-	Status             batch.JobPhase                      `gorm:"index:status;not null;comment:作业状态"`
-	CreationTimestamp  time.Time                           `gorm:"not null;comment:作业创建时间"`
+	Name              string         `gorm:"not null;type:varchar(256);comment:作业名称"`
+	JobName           string         `gorm:"uniqueIndex;type:varchar(256);not null;comment:作业名称"`
+	UserID            uint           `gorm:"primaryKey"`
+	User              User           `gorm:"foreignKey:UserID"`
+	AccountID         uint           `gorm:"primaryKey"`
+	Account           Account        `gorm:"foreignKey:AccountID"`
+	JobType           JobType        `gorm:"not null;comment:作业类型"`
+	Status            batch.JobPhase `gorm:"index:status;not null;comment:作业状态"`
+	CreationTimestamp time.Time      `gorm:"not null;comment:作业创建时间"`
+	// TODO(perf): Evaluate adding composite indexes for statistics queries:
+	// (user_id, running_timestamp), (account_id, running_timestamp),
+	// and potentially (running_timestamp, completed_timestamp).
 	RunningTimestamp   time.Time                           `gorm:"comment:作业开始运行时间"`
 	CompletedTimestamp time.Time                           `gorm:"comment:作业完成时间"`
 	Nodes              datatypes.JSONType[[]string]        `gorm:"comment:作业运行的节点"`

--- a/backend/internal/service/statistics.go
+++ b/backend/internal/service/statistics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -43,6 +44,7 @@ const (
 
 // GetResourceStatistics 获取资源统计信息 (主入口，负责编排)
 func (s *StatisticsService) GetResourceStatistics(ctx context.Context, req *payload.StatisticsReq) (*payload.StatisticsResp, error) {
+	// TODO(perf): Add short-TTL cache for resource metadata to avoid querying the resource table on every request.
 	// 1. 准备工作：加载资源元数据
 	resourceMap, err := s.loadResourceMetadata(ctx)
 	if err != nil {
@@ -51,6 +53,7 @@ func (s *StatisticsService) GetResourceStatistics(ctx context.Context, req *payl
 	}
 
 	// 2. 准备查询并获取作业数据
+	// TODO(perf): Replace full in-memory loading with FindInBatches and accumulate usage per batch to reduce memory footprint.
 	jobs, err := s.fetchStatsJobs(ctx, req)
 	if err != nil {
 		return nil, err
@@ -83,7 +86,13 @@ func (s *StatisticsService) GetResourceStatistics(ctx context.Context, req *payl
 // fetchStatsJobs 构建查询条件并获取作业列表
 func (s *StatisticsService) fetchStatsJobs(ctx context.Context, req *payload.StatisticsReq) ([]*model.Job, error) {
 	q := query.Job
-	jobDo := q.WithContext(ctx).Unscoped()
+	jobDo := q.WithContext(ctx).Unscoped().
+		Select(
+			q.RunningTimestamp,
+			q.CompletedTimestamp,
+			q.Resources,
+		)
+	// TODO(perf): Validate and add supporting DB indexes for this filter pattern (scope id + running/completed timestamps).
 
 	// 过滤范围 (Scope)
 	switch req.Scope {
@@ -138,6 +147,24 @@ func (s *StatisticsService) calculateJobUsage(
 	req *payload.StatisticsReq,
 ) map[string]float64 {
 	rawTotalUsage := make(map[string]float64)
+	if len(buckets) == 0 {
+		return rawTotalUsage
+	}
+
+	bucketCount := len(buckets)
+	bucketEnds := make([]time.Time, bucketCount)
+	for i := range buckets {
+		if i+1 < bucketCount {
+			bucketEnds[i] = buckets[i+1].Timestamp
+		} else {
+			bucketEnds[i] = req.EndTime
+		}
+	}
+
+	now := time.Now()
+	if now.After(req.EndTime) {
+		now = req.EndTime
+	}
 
 	for _, job := range jobs {
 		// 解析作业的资源配额
@@ -146,49 +173,78 @@ func (s *StatisticsService) calculateJobUsage(
 			continue
 		}
 
-		// 确定作业起止时间
-		jobStart := job.RunningTimestamp
-		jobEnd := job.CompletedTimestamp
-		if jobEnd.IsZero() {
-			jobEnd = time.Now()
-			if jobEnd.After(req.EndTime) {
-				jobEnd = req.EndTime
-			}
+		jobStart, jobEnd, ok := s.clampJobInterval(job, req, now)
+		if !ok {
+			continue
 		}
 
-		// 遍历每个时间桶
-		for i := range buckets {
+		startIdx, endExclusive, ok := s.findOverlappingBucketRange(buckets, bucketEnds, jobStart, jobEnd, bucketCount)
+		if !ok {
+			continue
+		}
+
+		for i := startIdx; i < endExclusive; i++ {
 			bucketStart := buckets[i].Timestamp
-			var bucketEnd time.Time
-			if req.Step == payload.StepWeek {
-				bucketEnd = bucketStart.AddDate(0, 0, DaysInWeek)
-			} else {
-				bucketEnd = bucketStart.AddDate(0, 0, 1)
-			}
+			bucketEnd := bucketEnds[i]
 
-			// 计算交集并累加
-			overlapDuration := s.calculateOverlapDuration(jobStart, jobEnd, bucketStart, bucketEnd)
-			if overlapDuration > 0 {
-				hours := overlapDuration.Hours()
-				for resName, amount := range jobRes {
-					usage := amount * hours
-
-					// 累加到 Bucket
-					if _, ok := buckets[i].Usage[resName]; !ok {
-						buckets[i].Usage[resName] = 0
-					}
-					buckets[i].Usage[resName] += usage
-
-					// 累加到 Total
-					if _, ok := rawTotalUsage[resName]; !ok {
-						rawTotalUsage[resName] = 0
-					}
-					rawTotalUsage[resName] += usage
-				}
-			}
+			s.accumulateBucketUsage(buckets[i].Usage, rawTotalUsage, jobRes, jobStart, jobEnd, bucketStart, bucketEnd)
 		}
 	}
 	return rawTotalUsage
+}
+
+func (s *StatisticsService) clampJobInterval(
+	job *model.Job,
+	req *payload.StatisticsReq,
+	now time.Time,
+) (jobStart, jobEnd time.Time, ok bool) {
+	jobStart = job.RunningTimestamp
+	jobEnd = job.CompletedTimestamp
+	if jobEnd.IsZero() {
+		jobEnd = now
+	}
+	if jobStart.Before(req.StartTime) {
+		jobStart = req.StartTime
+	}
+	if jobEnd.After(req.EndTime) {
+		jobEnd = req.EndTime
+	}
+	ok = jobEnd.After(jobStart)
+	return
+}
+
+func (s *StatisticsService) findOverlappingBucketRange(
+	buckets []payload.TimePointData,
+	bucketEnds []time.Time,
+	jobStart, jobEnd time.Time,
+	bucketCount int,
+) (startIdx, endExclusive int, ok bool) {
+	startIdx = sort.Search(bucketCount, func(i int) bool {
+		return bucketEnds[i].After(jobStart)
+	})
+	endExclusive = sort.Search(bucketCount, func(i int) bool {
+		return !buckets[i].Timestamp.Before(jobEnd)
+	})
+	ok = startIdx < endExclusive && startIdx < bucketCount
+	return
+}
+
+func (s *StatisticsService) accumulateBucketUsage(
+	bucketUsage map[string]float64,
+	totalUsage map[string]float64,
+	jobRes map[string]float64,
+	jobStart, jobEnd, bucketStart, bucketEnd time.Time,
+) {
+	overlapDuration := s.calculateOverlapDuration(jobStart, jobEnd, bucketStart, bucketEnd)
+	if overlapDuration <= 0 {
+		return
+	}
+	hours := overlapDuration.Hours()
+	for resName, amount := range jobRes {
+		usage := amount * hours
+		bucketUsage[resName] += usage
+		totalUsage[resName] += usage
+	}
 }
 
 // formatStatsUsage 格式化统计结果，注入 Label 和 Type


### PR DESCRIPTION
## 变更概述
本 PR 优化后端资源统计链路，目标是降低数据库读取开销和统计计算复杂度，同时补充后续性能优化的 TODO 标记。

## 主要改动
- 统计查询改为只读取必要字段：
  - `running_timestamp`
  - `completed_timestamp`
  - `resources`
- 优化 `calculateJobUsage` 的时间桶计算逻辑：
  - 预计算 bucket 结束时间
  - 将作业时间区间裁剪到请求区间
  - 使用二分定位作业实际重叠的 bucket 范围
  - 仅遍历重叠 bucket，避免全量 `jobs × buckets` 扫描
- 将部分逻辑拆分为私有 helper，降低圈复杂度，保证 lint 通过
- 按约定补充 TODO（暂不实现）：
  - 资源元数据 TTL 缓存
  - 分批拉取作业并边拉取边累加
  - 统计查询索引策略评估与落地

## 涉及文件
- `backend/internal/service/statistics.go`
- `backend/dao/model/job.go`

## 验证结果
- `make lint` 通过（full + diff）
- 提交前后端检查通过（包含 swagger 生成）

## 说明
- 本 PR 不包含数据库 schema / 索引变更
- 上述缓存与索引相关项目前仅记录为 TODO，后续单独 PR 落地
