### PR TITLE
feat(billing): 完善计费流程与展示控制，并修复 rebase 后 lint 回归

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ kubeconfig*
 # statistic files
 *.csv
 storage/etc/config.yaml
+.codex

--- a/backend/cmd/crater/helper/config.go
+++ b/backend/cmd/crater/helper/config.go
@@ -92,6 +92,7 @@ func (ci *ConfigInitializer) SetupManagerDependencies(registerConfig *handler.Re
 
 	registerConfig.ConfigService = service.NewConfigService(query.Q)
 	registerConfig.PrequeueService = service.NewPrequeueService(query.Q, registerConfig.ConfigService)
+	registerConfig.BillingService = service.NewBillingService(query.Q)
 
 	registerConfig.GpuAnalysisService = service.NewGpuAnalysisService(
 		query.Q,
@@ -106,9 +107,11 @@ func (ci *ConfigInitializer) SetupManagerDependencies(registerConfig *handler.Re
 		registerConfig.KubeClient,
 		registerConfig.PrometheusClient,
 		registerConfig.GpuAnalysisService,
+		registerConfig.BillingService,
 	)
 
 	registerConfig.ConfigService.SetCronJobManager(registerConfig.CronJobManager)
+	registerConfig.BillingService.SetCronJobManager(registerConfig.CronJobManager)
 
 	go registerConfig.CronJobManager.SyncCronJob()
 

--- a/backend/cmd/crater/helper/manager.go
+++ b/backend/cmd/crater/helper/manager.go
@@ -195,6 +195,7 @@ func (ms *ManagerSetup) setupVolcano(mgr manager.Manager, registerConfig *handle
 		mgr.GetScheme(),
 		registerConfig.PrometheusClient,
 		registerConfig.KubeClient,
+		registerConfig.BillingService,
 		registerConfig.PrequeueWatcher,
 	)
 	err := vcjobReconciler.SetupWithManager(mgr)

--- a/backend/cmd/gorm-gen/models/migrate.go
+++ b/backend/cmd/gorm-gen/models/migrate.go
@@ -799,6 +799,107 @@ func main() {
 			},
 		},
 		{
+			ID: "202603311930",
+			Migrate: func(tx *gorm.DB) error {
+				type Account struct {
+					BillingIssueAmount        *int64     `gorm:"comment:账户周期发放点数额度(内部微点, 为空表示未配置)"`
+					BillingIssuePeriodMinutes *int       `gorm:"comment:账户周期发放间隔分钟(<=0表示关闭, 为空表示未配置)"`
+					BillingLastIssuedAt       *time.Time `gorm:"comment:账户上次发放时间"`
+				}
+				type UserAccount struct {
+					BillingIssueAmountOverride *int64 `gorm:"comment:用户在账户内的周期发放额度覆盖(内部微点, 为空表示沿用账户配置)"`
+					PeriodFreeBalance          int64  `gorm:"not null;default:0;comment:用户在当前周期的免费额度剩余(内部微点)"`
+				}
+				type User struct {
+					ExtraBalance int64 `gorm:"type:bigint;not null;default:0;comment:用户额外点数余额(内部微点, 充值/奖励)"`
+				}
+				type Job struct {
+					LastSettledAt     *time.Time `gorm:"comment:作业上次结算时间"`
+					BilledPointsTotal int64      `gorm:"not null;default:0;comment:作业累计已结算点数(内部微点)"`
+				}
+				type Resource struct {
+					UnitPrice int64 `gorm:"not null;default:0;comment:资源单位价格(内部微点, 展示为点数/单位/小时)"`
+				}
+
+				if err := tx.Migrator().AddColumn(&Account{}, "BillingIssueAmount"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().AddColumn(&Account{}, "BillingIssuePeriodMinutes"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().AddColumn(&Account{}, "BillingLastIssuedAt"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().AddColumn(&UserAccount{}, "BillingIssueAmountOverride"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().AddColumn(&UserAccount{}, "PeriodFreeBalance"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().AddColumn(&User{}, "ExtraBalance"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().AddColumn(&Job{}, "LastSettledAt"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().AddColumn(&Job{}, "BilledPointsTotal"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().AddColumn(&Resource{}, "UnitPrice"); err != nil {
+					return err
+				}
+
+				return nil
+			},
+			Rollback: func(tx *gorm.DB) error {
+				type Account struct {
+					BillingIssueAmount        *int64     `gorm:"comment:账户周期发放点数额度(内部微点, 为空表示未配置)"`
+					BillingIssuePeriodMinutes *int       `gorm:"comment:账户周期发放间隔分钟(<=0表示关闭, 为空表示未配置)"`
+					BillingLastIssuedAt       *time.Time `gorm:"comment:账户上次发放时间"`
+				}
+				type UserAccount struct {
+					BillingIssueAmountOverride *int64 `gorm:"comment:用户在账户内的周期发放额度覆盖(内部微点, 为空表示沿用账户配置)"`
+					PeriodFreeBalance          int64  `gorm:"not null;default:0;comment:用户在当前周期的免费额度剩余(内部微点)"`
+				}
+				type User struct {
+					ExtraBalance int64 `gorm:"type:bigint;not null;default:0;comment:用户额外点数余额(内部微点, 充值/奖励)"`
+				}
+				type Job struct {
+					LastSettledAt     *time.Time `gorm:"comment:作业上次结算时间"`
+					BilledPointsTotal int64      `gorm:"not null;default:0;comment:作业累计已结算点数(内部微点)"`
+				}
+				type Resource struct {
+					UnitPrice int64 `gorm:"not null;default:0;comment:资源单位价格(内部微点, 展示为点数/单位/小时)"`
+				}
+
+				if err := tx.Migrator().DropColumn(&Account{}, "BillingIssueAmount"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().DropColumn(&Account{}, "BillingIssuePeriodMinutes"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().DropColumn(&Account{}, "BillingLastIssuedAt"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().DropColumn(&UserAccount{}, "BillingIssueAmountOverride"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().DropColumn(&UserAccount{}, "PeriodFreeBalance"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().DropColumn(&User{}, "ExtraBalance"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().DropColumn(&Job{}, "LastSettledAt"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().DropColumn(&Job{}, "BilledPointsTotal"); err != nil {
+					return err
+				}
+				return tx.Migrator().DropColumn(&Resource{}, "UnitPrice")
+			},
+		},
+		{
 			ID: "202603111300",
 			Migrate: func(tx *gorm.DB) error {
 				type Job struct {

--- a/backend/dao/model/account.go
+++ b/backend/dao/model/account.go
@@ -36,6 +36,10 @@ type Account struct {
 	ExpiredAt        *time.Time                      `gorm:"comment:账户过期时间"`
 	Quota            datatypes.JSONType[QueueQuota]  `gorm:"comment:账户对应队列的资源配额"`
 	UserDefaultQuota *datatypes.JSONType[QueueQuota] `gorm:"comment:账户中用户默认的资源配额模版"`
+	// Billing issue config (phase-2 persistent schema).
+	BillingIssueAmount        *int64     `gorm:"comment:账户周期发放点数额度(内部微点, 为空表示未配置)"`
+	BillingIssuePeriodMinutes *int       `gorm:"comment:账户周期发放间隔分钟(<=0表示关闭, 为空表示未配置)"`
+	BillingLastIssuedAt       *time.Time `gorm:"comment:账户上次发放时间"`
 
 	UserAccounts    []UserAccount
 	AccountDatasets []AccountDataset
@@ -49,4 +53,7 @@ type UserAccount struct {
 	AccessMode AccessMode `gorm:"not null;comment:用户在账户空间的访问模式 (na, ro, rw)"`
 
 	Quota datatypes.JSONType[QueueQuota] `gorm:"comment:用户在账户中的资源配额"`
+	// Billing issue state for current account cycle.
+	BillingIssueAmountOverride *int64 `gorm:"comment:用户在账户内的周期发放额度覆盖(内部微点, 为空表示沿用账户配置)"`
+	PeriodFreeBalance          int64  `gorm:"not null;default:0;comment:用户在当前周期的免费额度剩余(内部微点)"`
 }

--- a/backend/dao/model/job.go
+++ b/backend/dao/model/job.go
@@ -161,6 +161,9 @@ type Job struct {
 	// 定时策略相关
 	KeepWhenLowResourceUsage bool      `gorm:"comment:当资源利用率低时是否保留"`
 	LockedTimestamp          time.Time `gorm:"comment:作业锁定时间"`
+	// Billing settlement state.
+	LastSettledAt     *time.Time `gorm:"comment:作业上次结算时间"`
+	BilledPointsTotal int64      `gorm:"not null;default:0;comment:作业累计已结算点数(内部微点)"`
 
 	// 诊断数据收集
 	ProfileData      *datatypes.JSONType[*monitor.ProfileData]          `gorm:"comment:作业的性能数据"`

--- a/backend/dao/model/resource.go
+++ b/backend/dao/model/resource.go
@@ -29,6 +29,7 @@ type Resource struct {
 	Format          string `gorm:"type:varchar(255);not null;comment:资源格式" json:"format"`
 	Priority        int    `gorm:"not null;comment:优先级" json:"priority"`
 	Label           string `gorm:"type:varchar(255);not null;comment:用于显示的别名" json:"label"`
+	UnitPrice       int64  `gorm:"not null;default:0;comment:资源单位价格(内部微点, 展示为点数/单位/小时)" json:"unitPrice"`
 
 	// Resource relationship
 	Type     *CraterResourceType `gorm:"type:varchar(32);comment:资源类型" json:"type"`

--- a/backend/dao/model/system_config.go
+++ b/backend/dao/model/system_config.go
@@ -16,6 +16,17 @@ const (
 
 	// 功能开关配置键
 	ConfigKeyEnableGpuAnalysis = "ENABLE_GPU_ANALYSIS" // 值: "true" or "false"
+
+	// Billing 功能与调度配置键
+	ConfigKeyEnableBillingFeature                     = "ENABLE_BILLING_FEATURE"
+	ConfigKeyEnableBillingActive                      = "ENABLE_BILLING_ACTIVE"
+	ConfigKeyEnableRunningSettlement                  = "ENABLE_RUNNING_SETTLEMENT"
+	ConfigKeyRunningSettlementIntervalMinute          = "RUNNING_SETTLEMENT_INTERVAL_MINUTES"
+	ConfigKeyBillingJobFreeMinutes                    = "BILLING_JOB_FREE_MINUTES"
+	ConfigKeyBillingDefaultIssueAmount                = "BILLING_DEFAULT_ISSUE_AMOUNT"
+	ConfigKeyBillingDefaultIssuePeriodMinute          = "BILLING_DEFAULT_ISSUE_PERIOD_MINUTES"
+	ConfigKeyBillingAccountIssueAmountOverrideEnabled = "ENABLE_BILLING_ACCOUNT_ISSUE_AMOUNT_OVERRIDE"
+	ConfigKeyBillingAccountIssuePeriodOverrideEnabled = "ENABLE_BILLING_ACCOUNT_ISSUE_PERIOD_OVERRIDE"
 )
 
 // DefaultConfigKeys 定义了系统启动时必须存在的键
@@ -24,4 +35,13 @@ var DefaultConfigKeys = []string{
 	ConfigKeyLLMAPIKey,
 	ConfigKeyLLMModelName,
 	ConfigKeyEnableGpuAnalysis,
+	ConfigKeyEnableBillingFeature,
+	ConfigKeyEnableBillingActive,
+	ConfigKeyEnableRunningSettlement,
+	ConfigKeyRunningSettlementIntervalMinute,
+	ConfigKeyBillingJobFreeMinutes,
+	ConfigKeyBillingDefaultIssueAmount,
+	ConfigKeyBillingDefaultIssuePeriodMinute,
+	ConfigKeyBillingAccountIssueAmountOverrideEnabled,
+	ConfigKeyBillingAccountIssuePeriodOverrideEnabled,
 }

--- a/backend/dao/model/user.go
+++ b/backend/dao/model/user.go
@@ -53,6 +53,7 @@ type User struct {
 	Status              Status     `gorm:"index:status;not null;comment:用户状态 (pending, active, inactive)"`
 	Space               string     `gorm:"uniqueIndex;type:varchar(256);not null;comment:用户空间绝对路径"`
 	ImageQuota          int64      `gorm:"type:bigint;default:-1;comment:用户在镜像仓库的配额"`
+	ExtraBalance        int64      `gorm:"type:bigint;not null;default:0;comment:用户额外点数余额(内部微点, 充值/奖励)"`
 	LastEmailVerifiedAt *time.Time `gorm:"comment:最后一次邮箱验证时间"`
 
 	Attributes   datatypes.JSONType[UserAttribute] `gorm:"comment:用户的额外属性 (昵称、邮箱、电话、头像等)"`

--- a/backend/dao/query/accounts.gen.go
+++ b/backend/dao/query/accounts.gen.go
@@ -38,6 +38,9 @@ func newAccount(db *gorm.DB, opts ...gen.DOOption) account {
 	_account.ExpiredAt = field.NewTime(tableName, "expired_at")
 	_account.Quota = field.NewField(tableName, "quota")
 	_account.UserDefaultQuota = field.NewField(tableName, "user_default_quota")
+	_account.BillingIssueAmount = field.NewInt64(tableName, "billing_issue_amount")
+	_account.BillingIssuePeriodMinutes = field.NewInt(tableName, "billing_issue_period_minutes")
+	_account.BillingLastIssuedAt = field.NewTime(tableName, "billing_last_issued_at")
 	_account.UserAccounts = accountHasManyUserAccounts{
 		db: db.Session(&gorm.Session{}),
 
@@ -58,18 +61,21 @@ func newAccount(db *gorm.DB, opts ...gen.DOOption) account {
 type account struct {
 	accountDo accountDo
 
-	ALL              field.Asterisk
-	ID               field.Uint
-	CreatedAt        field.Time
-	UpdatedAt        field.Time
-	DeletedAt        field.Field
-	Name             field.String // 账户名称 (对应 Volcano Queue CRD)
-	Nickname         field.String // 账户别名 (用于显示)
-	Space            field.String // 账户空间绝对路径
-	ExpiredAt        field.Time   // 账户过期时间
-	Quota            field.Field  // 账户对应队列的资源配额
-	UserDefaultQuota field.Field  // 账户中用户默认的资源配额模版
-	UserAccounts     accountHasManyUserAccounts
+	ALL                       field.Asterisk
+	ID                        field.Uint
+	CreatedAt                 field.Time
+	UpdatedAt                 field.Time
+	DeletedAt                 field.Field
+	Name                      field.String // 账户名称 (对应 Volcano Queue CRD)
+	Nickname                  field.String // 账户别名 (用于显示)
+	Space                     field.String // 账户空间绝对路径
+	ExpiredAt                 field.Time   // 账户过期时间
+	Quota                     field.Field  // 账户对应队列的资源配额
+	UserDefaultQuota          field.Field  // 账户中用户默认的资源配额模版
+	BillingIssueAmount        field.Int64  // 账户周期发放点数额度(为空表示未配置)
+	BillingIssuePeriodMinutes field.Int    // 账户周期发放间隔分钟(<=0表示关闭, 为空表示未配置)
+	BillingLastIssuedAt       field.Time   // 账户上次发放时间
+	UserAccounts              accountHasManyUserAccounts
 
 	AccountDatasets accountHasManyAccountDatasets
 
@@ -98,6 +104,9 @@ func (a *account) updateTableName(table string) *account {
 	a.ExpiredAt = field.NewTime(table, "expired_at")
 	a.Quota = field.NewField(table, "quota")
 	a.UserDefaultQuota = field.NewField(table, "user_default_quota")
+	a.BillingIssueAmount = field.NewInt64(table, "billing_issue_amount")
+	a.BillingIssuePeriodMinutes = field.NewInt(table, "billing_issue_period_minutes")
+	a.BillingLastIssuedAt = field.NewTime(table, "billing_last_issued_at")
 
 	a.fillFieldMap()
 
@@ -122,7 +131,7 @@ func (a *account) GetFieldByName(fieldName string) (field.OrderExpr, bool) {
 }
 
 func (a *account) fillFieldMap() {
-	a.fieldMap = make(map[string]field.Expr, 12)
+	a.fieldMap = make(map[string]field.Expr, 15)
 	a.fieldMap["id"] = a.ID
 	a.fieldMap["created_at"] = a.CreatedAt
 	a.fieldMap["updated_at"] = a.UpdatedAt
@@ -133,6 +142,9 @@ func (a *account) fillFieldMap() {
 	a.fieldMap["expired_at"] = a.ExpiredAt
 	a.fieldMap["quota"] = a.Quota
 	a.fieldMap["user_default_quota"] = a.UserDefaultQuota
+	a.fieldMap["billing_issue_amount"] = a.BillingIssueAmount
+	a.fieldMap["billing_issue_period_minutes"] = a.BillingIssuePeriodMinutes
+	a.fieldMap["billing_last_issued_at"] = a.BillingLastIssuedAt
 
 }
 

--- a/backend/dao/query/resources.gen.go
+++ b/backend/dao/query/resources.gen.go
@@ -40,6 +40,7 @@ func newResource(db *gorm.DB, opts ...gen.DOOption) resource {
 	_resource.Format = field.NewString(tableName, "format")
 	_resource.Priority = field.NewInt(tableName, "priority")
 	_resource.Label = field.NewString(tableName, "label")
+	_resource.UnitPrice = field.NewInt64(tableName, "unit_price")
 	_resource.Type = field.NewString(tableName, "type")
 	_resource.Networks = resourceManyToManyNetworks{
 		db: db.Session(&gorm.Session{}),
@@ -73,6 +74,7 @@ type resource struct {
 	Format          field.String // 资源格式
 	Priority        field.Int    // 优先级
 	Label           field.String // 用于显示的别名
+	UnitPrice       field.Int64  // 资源单位价格(点数/单位/分钟)
 	Type            field.String // 资源类型
 	Networks        resourceManyToManyNetworks
 
@@ -103,6 +105,7 @@ func (r *resource) updateTableName(table string) *resource {
 	r.Format = field.NewString(table, "format")
 	r.Priority = field.NewInt(table, "priority")
 	r.Label = field.NewString(table, "label")
+	r.UnitPrice = field.NewInt64(table, "unit_price")
 	r.Type = field.NewString(table, "type")
 
 	r.fillFieldMap()
@@ -128,7 +131,7 @@ func (r *resource) GetFieldByName(fieldName string) (field.OrderExpr, bool) {
 }
 
 func (r *resource) fillFieldMap() {
-	r.fieldMap = make(map[string]field.Expr, 14)
+	r.fieldMap = make(map[string]field.Expr, 15)
 	r.fieldMap["id"] = r.ID
 	r.fieldMap["created_at"] = r.CreatedAt
 	r.fieldMap["updated_at"] = r.UpdatedAt
@@ -141,6 +144,7 @@ func (r *resource) fillFieldMap() {
 	r.fieldMap["format"] = r.Format
 	r.fieldMap["priority"] = r.Priority
 	r.fieldMap["label"] = r.Label
+	r.fieldMap["unit_price"] = r.UnitPrice
 	r.fieldMap["type"] = r.Type
 
 }

--- a/backend/dao/query/user_accounts.gen.go
+++ b/backend/dao/query/user_accounts.gen.go
@@ -37,6 +37,8 @@ func newUserAccount(db *gorm.DB, opts ...gen.DOOption) userAccount {
 	_userAccount.Role = field.NewUint8(tableName, "role")
 	_userAccount.AccessMode = field.NewUint8(tableName, "access_mode")
 	_userAccount.Quota = field.NewField(tableName, "quota")
+	_userAccount.BillingIssueAmountOverride = field.NewInt64(tableName, "billing_issue_amount_override")
+	_userAccount.PeriodFreeBalance = field.NewInt64(tableName, "period_free_balance")
 
 	_userAccount.fillFieldMap()
 
@@ -46,16 +48,18 @@ func newUserAccount(db *gorm.DB, opts ...gen.DOOption) userAccount {
 type userAccount struct {
 	userAccountDo userAccountDo
 
-	ALL        field.Asterisk
-	ID         field.Uint
-	CreatedAt  field.Time
-	UpdatedAt  field.Time
-	DeletedAt  field.Field
-	UserID     field.Uint
-	AccountID  field.Uint
-	Role       field.Uint8 // 用户在账户中的角色 (user, admin)
-	AccessMode field.Uint8 // 用户在账户空间的访问模式 (na, ro, rw)
-	Quota      field.Field // 用户在账户中的资源配额
+	ALL                        field.Asterisk
+	ID                         field.Uint
+	CreatedAt                  field.Time
+	UpdatedAt                  field.Time
+	DeletedAt                  field.Field
+	UserID                     field.Uint
+	AccountID                  field.Uint
+	Role                       field.Uint8 // 用户在账户中的角色 (user, admin)
+	AccessMode                 field.Uint8 // 用户在账户空间的访问模式 (na, ro, rw)
+	Quota                      field.Field // 用户在账户中的资源配额
+	BillingIssueAmountOverride field.Int64 // 用户在账户内的周期发放额度覆盖(为空表示沿用账户配置)
+	PeriodFreeBalance          field.Int64 // 用户在当前周期的免费额度剩余
 
 	fieldMap map[string]field.Expr
 }
@@ -81,6 +85,8 @@ func (u *userAccount) updateTableName(table string) *userAccount {
 	u.Role = field.NewUint8(table, "role")
 	u.AccessMode = field.NewUint8(table, "access_mode")
 	u.Quota = field.NewField(table, "quota")
+	u.BillingIssueAmountOverride = field.NewInt64(table, "billing_issue_amount_override")
+	u.PeriodFreeBalance = field.NewInt64(table, "period_free_balance")
 
 	u.fillFieldMap()
 
@@ -107,7 +113,7 @@ func (u *userAccount) GetFieldByName(fieldName string) (field.OrderExpr, bool) {
 }
 
 func (u *userAccount) fillFieldMap() {
-	u.fieldMap = make(map[string]field.Expr, 9)
+	u.fieldMap = make(map[string]field.Expr, 11)
 	u.fieldMap["id"] = u.ID
 	u.fieldMap["created_at"] = u.CreatedAt
 	u.fieldMap["updated_at"] = u.UpdatedAt
@@ -117,6 +123,8 @@ func (u *userAccount) fillFieldMap() {
 	u.fieldMap["role"] = u.Role
 	u.fieldMap["access_mode"] = u.AccessMode
 	u.fieldMap["quota"] = u.Quota
+	u.fieldMap["billing_issue_amount_override"] = u.BillingIssueAmountOverride
+	u.fieldMap["period_free_balance"] = u.PeriodFreeBalance
 }
 
 func (u userAccount) clone(db *gorm.DB) userAccount {

--- a/backend/dao/query/users.gen.go
+++ b/backend/dao/query/users.gen.go
@@ -39,6 +39,7 @@ func newUser(db *gorm.DB, opts ...gen.DOOption) user {
 	_user.Status = field.NewUint8(tableName, "status")
 	_user.Space = field.NewString(tableName, "space")
 	_user.ImageQuota = field.NewInt64(tableName, "image_quota")
+	_user.ExtraBalance = field.NewInt64(tableName, "extra_balance")
 	_user.LastEmailVerifiedAt = field.NewTime(tableName, "last_email_verified_at")
 	_user.Attributes = field.NewField(tableName, "attributes")
 	_user.UserAccounts = userHasManyUserAccounts{
@@ -73,6 +74,7 @@ type user struct {
 	Status              field.Uint8  // 用户状态 (pending, active, inactive)
 	Space               field.String // 用户空间绝对路径
 	ImageQuota          field.Int64  // 用户在镜像仓库的配额
+	ExtraBalance        field.Int64  // 用户额外点数余额(充值/奖励)
 	LastEmailVerifiedAt field.Time   // 最后一次邮箱验证时间
 	Attributes          field.Field  // 用户的额外属性 (昵称、邮箱、电话、头像等)
 	UserAccounts        userHasManyUserAccounts
@@ -105,6 +107,7 @@ func (u *user) updateTableName(table string) *user {
 	u.Status = field.NewUint8(table, "status")
 	u.Space = field.NewString(table, "space")
 	u.ImageQuota = field.NewInt64(table, "image_quota")
+	u.ExtraBalance = field.NewInt64(table, "extra_balance")
 	u.LastEmailVerifiedAt = field.NewTime(table, "last_email_verified_at")
 	u.Attributes = field.NewField(table, "attributes")
 
@@ -131,7 +134,7 @@ func (u *user) GetFieldByName(fieldName string) (field.OrderExpr, bool) {
 }
 
 func (u *user) fillFieldMap() {
-	u.fieldMap = make(map[string]field.Expr, 15)
+	u.fieldMap = make(map[string]field.Expr, 16)
 	u.fieldMap["id"] = u.ID
 	u.fieldMap["created_at"] = u.CreatedAt
 	u.fieldMap["updated_at"] = u.UpdatedAt
@@ -143,6 +146,7 @@ func (u *user) fillFieldMap() {
 	u.fieldMap["status"] = u.Status
 	u.fieldMap["space"] = u.Space
 	u.fieldMap["image_quota"] = u.ImageQuota
+	u.fieldMap["extra_balance"] = u.ExtraBalance
 	u.fieldMap["last_email_verified_at"] = u.LastEmailVerifiedAt
 	u.fieldMap["attributes"] = u.Attributes
 

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -464,7 +464,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handler.PutUserInProjectReq"
+                            "$ref": "#/definitions/internal_handler.UserPutUserInProjectReq"
                         }
                     }
                 ],
@@ -2339,6 +2339,54 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/admin/projects/{aid}/billing/reset": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "立即对指定账户执行一次免费额度发放，不影响 extra 点数",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Project"
+                ],
+                "summary": "立即重置账户免费额度",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "name": "aid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "重置成功",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-string"
+                        }
+                    },
+                    "400": {
+                        "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    },
+                    "500": {
+                        "description": "其他错误",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/admin/queue-quotas": {
             "get": {
                 "security": [
@@ -3424,6 +3472,64 @@ const docTemplate = `{
                         "description": "用户属性更新成功",
                         "schema": {
                             "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    },
+                    "400": {
+                        "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    },
+                    "500": {
+                        "description": "其他错误",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/admin/users/{name}/billing/extra-balance": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "管理员按增量调整用户 extraBalance（可正可负），使用行锁避免并发覆盖",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "调整用户额外点数",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "username",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "增量与原因",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.AdjustUserExtraBalanceReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "调整成功",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-internal_handler_AdjustUserExtraBalanceResp"
                         }
                     },
                     "400": {
@@ -10062,6 +10168,20 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_raids-lab_crater_internal_resputil.Response-internal_handler_AdjustUserExtraBalanceResp": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.ErrorCode"
+                },
+                "data": {
+                    "$ref": "#/definitions/internal_handler.AdjustUserExtraBalanceResp"
+                },
+                "msg": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_raids-lab_crater_internal_resputil.Response-internal_handler_ApprovalOrderResp": {
             "type": "object",
             "properties": {
@@ -10809,6 +10929,40 @@ const docTemplate = `{
                 },
                 "role": {
                     "$ref": "#/definitions/github_com_raids-lab_crater_dao_model.Role"
+                }
+            }
+        },
+        "internal_handler.AdjustUserExtraBalanceReq": {
+            "type": "object",
+            "required": [
+                "delta"
+            ],
+            "properties": {
+                "delta": {
+                    "type": "integer"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.AdjustUserExtraBalanceResp": {
+            "type": "object",
+            "properties": {
+                "afterBalance": {
+                    "type": "number"
+                },
+                "beforeBalance": {
+                    "type": "number"
+                },
+                "delta": {
+                    "type": "number"
+                },
+                "userId": {
+                    "type": "integer"
+                },
+                "username": {
+                    "type": "string"
                 }
             }
         },
@@ -11840,6 +11994,10 @@ const docTemplate = `{
                     "description": "创建时间",
                     "type": "string"
                 },
+                "extraBalance": {
+                    "description": "用户额外点数",
+                    "type": "number"
+                },
                 "group": {
                     "description": "课题组",
                     "type": "string"
@@ -11874,6 +12032,20 @@ const docTemplate = `{
                 },
                 "teacher": {
                     "description": "导师",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.UserPutUserInProjectReq": {
+            "type": "object",
+            "properties": {
+                "accessmode": {
+                    "type": "string"
+                },
+                "quota": {
+                    "$ref": "#/definitions/datatypes.JSONType-github_com_raids-lab_crater_dao_model_QueueQuota"
+                },
+                "role": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -456,7 +456,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handler.PutUserInProjectReq"
+                            "$ref": "#/definitions/internal_handler.UserPutUserInProjectReq"
                         }
                     }
                 ],
@@ -2331,6 +2331,54 @@
                 }
             }
         },
+        "/v1/admin/projects/{aid}/billing/reset": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "立即对指定账户执行一次免费额度发放，不影响 extra 点数",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Project"
+                ],
+                "summary": "立即重置账户免费额度",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "name": "aid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "重置成功",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-string"
+                        }
+                    },
+                    "400": {
+                        "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    },
+                    "500": {
+                        "description": "其他错误",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/admin/queue-quotas": {
             "get": {
                 "security": [
@@ -3416,6 +3464,64 @@
                         "description": "用户属性更新成功",
                         "schema": {
                             "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    },
+                    "400": {
+                        "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    },
+                    "500": {
+                        "description": "其他错误",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/admin/users/{name}/billing/extra-balance": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "管理员按增量调整用户 extraBalance（可正可负），使用行锁避免并发覆盖",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "调整用户额外点数",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "username",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "增量与原因",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.AdjustUserExtraBalanceReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "调整成功",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-internal_handler_AdjustUserExtraBalanceResp"
                         }
                     },
                     "400": {
@@ -10054,6 +10160,20 @@
                 }
             }
         },
+        "github_com_raids-lab_crater_internal_resputil.Response-internal_handler_AdjustUserExtraBalanceResp": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.ErrorCode"
+                },
+                "data": {
+                    "$ref": "#/definitions/internal_handler.AdjustUserExtraBalanceResp"
+                },
+                "msg": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_raids-lab_crater_internal_resputil.Response-internal_handler_ApprovalOrderResp": {
             "type": "object",
             "properties": {
@@ -10801,6 +10921,40 @@
                 },
                 "role": {
                     "$ref": "#/definitions/github_com_raids-lab_crater_dao_model.Role"
+                }
+            }
+        },
+        "internal_handler.AdjustUserExtraBalanceReq": {
+            "type": "object",
+            "required": [
+                "delta"
+            ],
+            "properties": {
+                "delta": {
+                    "type": "integer"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.AdjustUserExtraBalanceResp": {
+            "type": "object",
+            "properties": {
+                "afterBalance": {
+                    "type": "number"
+                },
+                "beforeBalance": {
+                    "type": "number"
+                },
+                "delta": {
+                    "type": "number"
+                },
+                "userId": {
+                    "type": "integer"
+                },
+                "username": {
+                    "type": "string"
                 }
             }
         },
@@ -11832,6 +11986,10 @@
                     "description": "创建时间",
                     "type": "string"
                 },
+                "extraBalance": {
+                    "description": "用户额外点数",
+                    "type": "number"
+                },
                 "group": {
                     "description": "课题组",
                     "type": "string"
@@ -11866,6 +12024,20 @@
                 },
                 "teacher": {
                     "description": "导师",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.UserPutUserInProjectReq": {
+            "type": "object",
+            "properties": {
+                "accessmode": {
+                    "type": "string"
+                },
+                "quota": {
+                    "$ref": "#/definitions/datatypes.JSONType-github_com_raids-lab_crater_dao_model_QueueQuota"
+                },
+                "role": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -540,6 +540,15 @@ definitions:
       msg:
         type: string
     type: object
+  github_com_raids-lab_crater_internal_resputil.Response-internal_handler_AdjustUserExtraBalanceResp:
+    properties:
+      code:
+        $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.ErrorCode'
+      data:
+        $ref: '#/definitions/internal_handler.AdjustUserExtraBalanceResp'
+      msg:
+        type: string
+    type: object
   github_com_raids-lab_crater_internal_resputil.Response-internal_handler_ApprovalOrderResp:
     properties:
       code:
@@ -1029,6 +1038,28 @@ definitions:
         type: string
       role:
         $ref: '#/definitions/github_com_raids-lab_crater_dao_model.Role'
+    type: object
+  internal_handler.AdjustUserExtraBalanceReq:
+    properties:
+      delta:
+        type: integer
+      reason:
+        type: string
+    required:
+    - delta
+    type: object
+  internal_handler.AdjustUserExtraBalanceResp:
+    properties:
+      afterBalance:
+        type: number
+      beforeBalance:
+        type: number
+      delta:
+        type: number
+      userId:
+        type: integer
+      username:
+        type: string
     type: object
   internal_handler.ApprovalOrderResp:
     properties:
@@ -1711,6 +1742,9 @@ definitions:
       createdAt:
         description: 创建时间
         type: string
+      extraBalance:
+        description: 用户额外点数
+        type: number
       group:
         description: 课题组
         type: string
@@ -1733,6 +1767,15 @@ definitions:
         description: 用户状态
       teacher:
         description: 导师
+        type: string
+    type: object
+  internal_handler.UserPutUserInProjectReq:
+    properties:
+      accessmode:
+        type: string
+      quota:
+        $ref: '#/definitions/datatypes.JSONType-github_com_raids-lab_crater_dao_model_QueueQuota'
+      role:
         type: string
     type: object
   internal_handler.VersionInfo:
@@ -2676,7 +2719,7 @@ paths:
         name: req
         required: true
         schema:
-          $ref: '#/definitions/internal_handler.PutUserInProjectReq'
+          $ref: '#/definitions/internal_handler.UserPutUserInProjectReq'
       produces:
       - application/json
       responses:
@@ -3639,6 +3682,36 @@ paths:
       summary: 更新配额
       tags:
       - Project
+  /v1/admin/projects/{aid}/billing/reset:
+    post:
+      consumes:
+      - application/json
+      description: 立即对指定账户执行一次免费额度发放，不影响 extra 点数
+      parameters:
+      - in: path
+        name: aid
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: 重置成功
+          schema:
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-string'
+        "400":
+          description: 请求参数错误
+          schema:
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any'
+        "500":
+          description: 其他错误
+          schema:
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any'
+      security:
+      - Bearer: []
+      summary: 立即重置账户免费额度
+      tags:
+      - Project
   /v1/admin/projects/add/{aid}/{uid}:
     post:
       consumes:
@@ -4533,6 +4606,43 @@ paths:
       security:
       - Bearer: []
       summary: 管理员更新用户属性
+      tags:
+      - User
+  /v1/admin/users/{name}/billing/extra-balance:
+    post:
+      consumes:
+      - application/json
+      description: 管理员按增量调整用户 extraBalance（可正可负），使用行锁避免并发覆盖
+      parameters:
+      - description: username
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: 增量与原因
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.AdjustUserExtraBalanceReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: 调整成功
+          schema:
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-internal_handler_AdjustUserExtraBalanceResp'
+        "400":
+          description: 请求参数错误
+          schema:
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any'
+        "500":
+          description: 其他错误
+          schema:
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any'
+      security:
+      - Bearer: []
+      summary: 调整用户额外点数
       tags:
       - User
   /v1/admin/users/{name}/role:

--- a/backend/internal/handler/account.go
+++ b/backend/internal/handler/account.go
@@ -1,10 +1,10 @@
 package handler
 
 import (
+	"context"
+	"errors"
 	"fmt"
-	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -12,7 +12,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	scheduling "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/raids-lab/crater/dao/query"
 	"github.com/raids-lab/crater/internal/payload"
 	"github.com/raids-lab/crater/internal/resputil"
+	"github.com/raids-lab/crater/internal/service"
 	"github.com/raids-lab/crater/internal/util"
 	"github.com/raids-lab/crater/pkg/config"
 	"github.com/raids-lab/crater/pkg/vcqueue"
@@ -32,33 +32,50 @@ const (
 	httpStatusForbidden = 403
 )
 
+var (
+	errBillingFeatureDisabled        = errors.New("billing feature is disabled")
+	errNoBillingConfigFieldsToUpdate = errors.New("no billing config fields to update")
+)
+
 //nolint:gochecknoinits // This is the standard way to register a gin handler.
 func init() {
 	Registers = append(Registers, NewAccountMgr)
 }
 
 type AccountMgr struct {
-	name   string
-	client client.Client
+	name           string
+	client         client.Client
+	billingService *service.BillingService
 }
 
 func NewAccountMgr(conf *RegisterConfig) Manager {
 	return &AccountMgr{
-		name:   "accounts",
-		client: conf.Client,
+		name:           "accounts",
+		client:         conf.Client,
+		billingService: conf.BillingService,
 	}
 }
 
 func (mgr *AccountMgr) GetName() string { return mgr.name }
 
-func (mgr *AccountMgr) RegisterPublic(_ *gin.RouterGroup) {
-
-}
+func (mgr *AccountMgr) RegisterPublic(_ *gin.RouterGroup) {}
 
 func (mgr *AccountMgr) RegisterProtected(g *gin.RouterGroup) {
 	g.GET("", mgr.UserListAccounts)              // Get accounts accessible by current user
 	g.GET("by-name/:name", mgr.GetAccountByName) // Get account by name (use specific path to avoid conflict with :aid routes)
-	// Account member management APIs (require account admin permission)
+	mgr.registerUserBillingRoutes(g)
+	mgr.registerUserMemberRoutes(g)
+}
+
+func (mgr *AccountMgr) registerUserBillingRoutes(g *gin.RouterGroup) {
+	g.GET(":aid/billing/config", mgr.UserGetAccountBillingConfig)
+	g.PUT(":aid/billing/config", mgr.UserUpdateAccountBillingConfig)
+	g.GET(":aid/billing/members", mgr.UserListAccountBillingMembers)
+	g.PUT(":aid/billing/members/:uid", mgr.UserUpdateAccountBillingMemberIssueAmount)
+	g.POST(":aid/billing/reset", mgr.UserResetAccountBillingBalance)
+}
+
+func (mgr *AccountMgr) registerUserMemberRoutes(g *gin.RouterGroup) {
 	g.POST(":aid/users/:uid", mgr.UserAddAccountMember)           // Add user to account
 	g.POST(":aid/users/:uid/update", mgr.UserUpdateAccountMember) // Update user in account
 	g.DELETE(":aid/users/:uid", mgr.UserRemoveAccountMember)      // Remove user from account
@@ -72,6 +89,11 @@ func (mgr *AccountMgr) RegisterAdmin(g *gin.RouterGroup) {
 	g.POST("", mgr.CreateAccount)
 	g.GET(":aid", mgr.GetAccountByID)
 	g.GET(":aid/quota", mgr.GetQuota)
+	g.GET(":aid/billing/config", mgr.GetAccountBillingConfig)
+	g.PUT(":aid/billing/config", mgr.UpdateAccountBillingConfig)
+	g.GET(":aid/billing/members", mgr.AdminListAccountBillingMembers)
+	g.PUT(":aid/billing/members/:uid", mgr.AdminUpdateAccountBillingMemberIssueAmount)
+	g.POST(":aid/billing/reset", mgr.AdminResetAccountBillingBalance)
 	g.PUT(":aid", mgr.UpdateAccount)
 	g.DELETE(":aid", mgr.DeleteAccount)
 	g.POST("add/:aid/:uid", mgr.AdminAddAccountMember)
@@ -140,7 +162,126 @@ type (
 		Quota     model.QueueQuota `json:"quota"`
 		ExpiredAt *time.Time       `json:"expiredAt"`
 	}
+
+	AccountBillingConfigResp struct {
+		IssueAmount                 float64    `json:"issueAmount"`
+		IssuePeriodMinutes          int        `json:"issuePeriodMinutes"`
+		EffectiveIssueAmount        float64    `json:"effectiveIssueAmount"`
+		EffectiveIssuePeriodMinutes int        `json:"effectiveIssuePeriodMinutes"`
+		LastIssuedAt                *time.Time `json:"lastIssuedAt"`
+	}
+
+	AccountBillingConfigUpdateReq struct {
+		IssueAmount        *service.BillingAmountInput `json:"issueAmount"`
+		IssuePeriodMinutes *int                        `json:"issuePeriodMinutes" binding:"omitempty,gte=0"`
+	}
 )
+
+func buildListAllResp(account *model.Account) ListAllResp {
+	if account == nil {
+		return ListAllResp{}
+	}
+	return ListAllResp{
+		ID:        account.ID,
+		Name:      account.Name,
+		Nickname:  account.Nickname,
+		Space:     account.Space,
+		Quota:     account.Quota.Data(),
+		ExpiredAt: account.ExpiredAt,
+	}
+}
+
+func (mgr *AccountMgr) respondAccountLookup(
+	c *gin.Context,
+	lookup func() (*model.Account, error),
+	notFoundMessage string,
+) {
+	account, err := lookup()
+	if err != nil {
+		resputil.Error(c, notFoundMessage, resputil.NotSpecified)
+		return
+	}
+
+	resputil.Success(c, buildListAllResp(account))
+}
+
+func (mgr *AccountMgr) isBillingFeatureEnabled(ctx context.Context) bool {
+	return mgr.billingService != nil && mgr.billingService.IsFeatureEnabled(ctx)
+}
+
+func (mgr *AccountMgr) isBillingUserFacingEnabled(ctx context.Context) bool {
+	return mgr.billingService != nil && mgr.billingService.IsUserFacingEnabled(ctx)
+}
+
+func (mgr *AccountMgr) getAccountIssueOverrideFlags(ctx context.Context) (amountEnabled, periodEnabled bool) {
+	if !mgr.isBillingFeatureEnabled(ctx) {
+		return false, false
+	}
+	return mgr.billingService.IsAccountIssueAmountOverrideEnabled(ctx),
+		mgr.billingService.IsAccountIssuePeriodOverrideEnabled(ctx)
+}
+
+func (mgr *AccountMgr) requireBillingEnabled(ctx context.Context) error {
+	if mgr.billingService == nil || !mgr.isBillingFeatureEnabled(ctx) {
+		return errBillingFeatureDisabled
+	}
+	return nil
+}
+
+func (mgr *AccountMgr) requireUserFacingBillingEnabled(ctx context.Context) error {
+	if mgr.billingService == nil || !mgr.isBillingUserFacingEnabled(ctx) {
+		return errBillingFeatureDisabled
+	}
+	return nil
+}
+
+func respondIfBillingFeatureDisabled(c *gin.Context, err error) bool {
+	if !errors.Is(err, errBillingFeatureDisabled) {
+		return false
+	}
+	resputil.Error(c, err.Error(), resputil.BusinessLogicError)
+	return true
+}
+
+func handleAccountBillingConfigUpdateErr(c *gin.Context, err error) {
+	if respondIfBillingFeatureDisabled(c, err) {
+		return
+	}
+	if errors.Is(err, errNoBillingConfigFieldsToUpdate) {
+		resputil.BadRequestError(c, err.Error())
+		return
+	}
+	resputil.Error(c, err.Error(), resputil.NotSpecified)
+}
+
+func (mgr *AccountMgr) writeAccountBillingConfigUpdateResp(
+	c *gin.Context,
+	accountID uint,
+	req *AccountBillingConfigUpdateReq,
+) {
+	resp, err := mgr.updateAccountBillingConfigCore(c, accountID, req)
+	if err != nil {
+		handleAccountBillingConfigUpdateErr(c, err)
+		return
+	}
+	resputil.Success(c, resp)
+}
+
+func (mgr *AccountMgr) writeAccountBillingMemberIssueAmountResp(
+	c *gin.Context,
+	accountID, userID uint,
+	req *UpdateAccountBillingMemberIssueAmountReq,
+) {
+	resp, err := mgr.updateAccountBillingMemberIssueAmount(c, accountID, userID, req)
+	if err != nil {
+		if respondIfBillingFeatureDisabled(c, err) {
+			return
+		}
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+	resputil.Success(c, resp)
+}
 
 // AdminListAccounts lists all accounts (admin API)
 //
@@ -184,6 +325,199 @@ type AccountIDReq struct {
 	ID uint `uri:"aid" binding:"required"`
 }
 
+func (mgr *AccountMgr) bindAccountID(c *gin.Context) (uint, bool) {
+	var uriReq AccountIDReq
+	if err := c.ShouldBindUri(&uriReq); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("invalid account ID parameter: %v", err))
+		return 0, false
+	}
+	return uriReq.ID, true
+}
+
+func (mgr *AccountMgr) requireUserManagedAccountID(c *gin.Context) (uint, bool) {
+	accountID, ok := mgr.bindAccountID(c)
+	if !ok {
+		return 0, false
+	}
+
+	token := util.GetToken(c)
+	if err := mgr.checkAccountAdmin(c, token.UserID, accountID); err != nil {
+		resputil.HTTPError(c, httpStatusForbidden, "Forbidden: User is not account admin", resputil.NotSpecified)
+		return 0, false
+	}
+
+	return accountID, true
+}
+
+func bindAccountName(c *gin.Context) (string, bool) {
+	var uriReq AccountNameReq
+	if err := c.ShouldBindUri(&uriReq); err != nil {
+		resputil.Error(c, fmt.Sprintf("invalid request, detail: %v", err), resputil.NotSpecified)
+		return "", false
+	}
+	return uriReq.Name, true
+}
+
+func (mgr *AccountMgr) buildAccountBillingConfigResp(
+	ctx context.Context,
+	account *model.Account,
+) AccountBillingConfigResp {
+	resp := AccountBillingConfigResp{}
+	if account == nil {
+		return resp
+	}
+	resp.LastIssuedAt = account.BillingLastIssuedAt
+	if !mgr.isBillingFeatureEnabled(ctx) {
+		return resp
+	}
+	if account.BillingIssueAmount != nil {
+		resp.IssueAmount = service.ToDisplayPoints(*account.BillingIssueAmount)
+	}
+	if account.BillingIssuePeriodMinutes != nil {
+		resp.IssuePeriodMinutes = *account.BillingIssuePeriodMinutes
+	}
+	effectiveIssueAmount, effectiveIssuePeriodMinutes := mgr.billingService.ResolveEffectiveIssueConfigForAccount(ctx, account)
+	resp.EffectiveIssueAmount = service.ToDisplayPoints(effectiveIssueAmount)
+	resp.EffectiveIssuePeriodMinutes = effectiveIssuePeriodMinutes
+	return resp
+}
+
+func (mgr *AccountMgr) loadAccountByID(c *gin.Context, accountID uint) (*model.Account, error) {
+	return query.Account.WithContext(c).Where(query.Account.ID.Eq(accountID)).First()
+}
+
+func (mgr *AccountMgr) getAccountBillingConfigResp(
+	c *gin.Context,
+	accountID uint,
+) (AccountBillingConfigResp, error) {
+	account, err := mgr.validateAccount(c, accountID)
+	if err != nil {
+		return AccountBillingConfigResp{}, err
+	}
+
+	return mgr.buildAccountBillingConfigResp(c.Request.Context(), account), nil
+}
+
+func (mgr *AccountMgr) updateAccountBillingConfigCore(
+	c *gin.Context,
+	accountID uint,
+	req *AccountBillingConfigUpdateReq,
+) (AccountBillingConfigResp, error) {
+	if err := mgr.requireBillingEnabled(c.Request.Context()); err != nil {
+		return AccountBillingConfigResp{}, err
+	}
+
+	if _, err := mgr.validateAccount(c, accountID); err != nil {
+		return AccountBillingConfigResp{}, err
+	}
+
+	updates := map[string]any{}
+	amountOverrideEnabled, periodOverrideEnabled := mgr.getAccountIssueOverrideFlags(c.Request.Context())
+	if amountOverrideEnabled && req != nil && req.IssueAmount != nil {
+		updates["billing_issue_amount"] = req.IssueAmount.MicroPoints()
+	}
+	if periodOverrideEnabled && req != nil && req.IssuePeriodMinutes != nil {
+		updates["billing_issue_period_minutes"] = *req.IssuePeriodMinutes
+	}
+	if len(updates) == 0 {
+		return AccountBillingConfigResp{}, errNoBillingConfigFieldsToUpdate
+	}
+
+	if _, err := query.Account.WithContext(c).Where(query.Account.ID.Eq(accountID)).Updates(updates); err != nil {
+		return AccountBillingConfigResp{}, fmt.Errorf("failed to update account billing config: %w", err)
+	}
+
+	account, err := mgr.loadAccountByID(c, accountID)
+	if err != nil {
+		return AccountBillingConfigResp{}, fmt.Errorf("failed to reload account billing config: %w", err)
+	}
+
+	return mgr.buildAccountBillingConfigResp(c.Request.Context(), account), nil
+}
+
+func (mgr *AccountMgr) resetAccountBillingBalanceCore(c *gin.Context, accountID uint) (string, error) {
+	if err := mgr.requireBillingEnabled(c.Request.Context()); err != nil {
+		return "", err
+	}
+
+	account, err := mgr.validateAccount(c, accountID)
+	if err != nil {
+		return "", err
+	}
+
+	if err := mgr.billingService.IssueAccountNow(c.Request.Context(), accountID); err != nil {
+		return "", fmt.Errorf("failed to reset billing balance for %s: %w", account.Name, err)
+	}
+
+	return fmt.Sprintf("billing balance reset for %s", account.Name), nil
+}
+
+func (mgr *AccountMgr) GetAccountBillingConfig(c *gin.Context) {
+	accountID, ok := mgr.bindAccountID(c)
+	if !ok {
+		return
+	}
+
+	resp, err := mgr.getAccountBillingConfigResp(c, accountID)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+
+	resputil.Success(c, resp)
+}
+
+func (mgr *AccountMgr) UpdateAccountBillingConfig(c *gin.Context) {
+	accountID, ok := mgr.bindAccountID(c)
+	if !ok {
+		return
+	}
+
+	var req AccountBillingConfigUpdateReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("invalid request body: %v", err))
+		return
+	}
+	mgr.writeAccountBillingConfigUpdateResp(c, accountID, &req)
+}
+
+func (mgr *AccountMgr) UserGetAccountBillingConfig(c *gin.Context) {
+	if err := mgr.requireUserFacingBillingEnabled(c.Request.Context()); err != nil {
+		handleAccountBillingConfigUpdateErr(c, err)
+		return
+	}
+	accountID, ok := mgr.requireUserManagedAccountID(c)
+	if !ok {
+		return
+	}
+
+	resp, err := mgr.getAccountBillingConfigResp(c, accountID)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+
+	resputil.Success(c, resp)
+}
+
+func (mgr *AccountMgr) UserUpdateAccountBillingConfig(c *gin.Context) {
+	var req AccountBillingConfigUpdateReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("invalid request body: %v", err))
+		return
+	}
+	if err := mgr.requireUserFacingBillingEnabled(c.Request.Context()); err != nil {
+		handleAccountBillingConfigUpdateErr(c, err)
+		return
+	}
+
+	accountID, ok := mgr.requireUserManagedAccountID(c)
+	if !ok {
+		return
+	}
+	mgr.writeAccountBillingConfigUpdateResp(c, accountID, &req)
+}
+
 // GetAccountByID godoc
 //
 //	@Summary		获取指定账户
@@ -197,32 +531,12 @@ type AccountIDReq struct {
 //	@Failure		400	{object}	resputil.Response[any]	"请求参数错误"
 //	@Failure		500	{object}	resputil.Response[any]	"其他错误"
 //	@Router			/v1/admin/accounts/{aid} [get]
-//
-//nolint:dupl// 重复代码
 func (mgr *AccountMgr) GetAccountByID(c *gin.Context) {
-	var uriReq AccountIDReq
-	if err := c.ShouldBindUri(&uriReq); err != nil {
-		resputil.Error(c, fmt.Sprintf("invalid request, detail: %v", err), resputil.NotSpecified)
+	accountID, ok := mgr.bindAccountID(c)
+	if !ok {
 		return
 	}
-	q := query.Account
-	queue, err := q.WithContext(c).Where(q.ID.Eq(uriReq.ID)).First()
-
-	if err != nil {
-		resputil.Error(c, fmt.Sprintf("account not found: account ID %d does not exist", uriReq.ID), resputil.NotSpecified)
-		return
-	}
-
-	resp := ListAllResp{
-		ID:        queue.ID,
-		Name:      queue.Name,
-		Nickname:  queue.Nickname,
-		Space:     queue.Space,
-		Quota:     queue.Quota.Data(),
-		ExpiredAt: queue.ExpiredAt,
-	}
-
-	resputil.Success(c, resp)
+	mgr.respondAccountByID(c, accountID)
 }
 
 type AccountNameReq struct {
@@ -242,35 +556,36 @@ type AccountNameReq struct {
 //	@Failure		400		{object}	resputil.Response[any]	"请求参数错误"
 //	@Failure		500		{object}	resputil.Response[any]	"其他错误"
 //	@Router			/v1/accounts/by-name/{name} [get]
-//
-//nolint:dupl// 重复代码
 func (mgr *AccountMgr) GetAccountByName(c *gin.Context) {
-	var uriReq AccountNameReq
-	if err := c.ShouldBindUri(&uriReq); err != nil {
-		resputil.Error(c, fmt.Sprintf("invalid request, detail: %v", err), resputil.NotSpecified)
+	accountName, ok := bindAccountName(c)
+	if !ok {
 		return
 	}
-	q := query.Account
-	queue, err := q.WithContext(c).Where(q.Name.Eq(uriReq.Name)).First()
-
-	if err != nil {
-		resputil.Error(c, fmt.Sprintf("account not found: account name '%s' does not exist", uriReq.Name), resputil.NotSpecified)
-		return
-	}
-
-	resp := ListAllResp{
-		ID:        queue.ID,
-		Name:      queue.Name,
-		Nickname:  queue.Nickname,
-		Space:     queue.Space,
-		Quota:     queue.Quota.Data(),
-		ExpiredAt: queue.ExpiredAt,
-	}
-
-	resputil.Success(c, resp)
+	mgr.respondAccountByName(c, accountName)
 }
 
-//nolint:gocyclo // TODO(liyilong): delete other duplicated code
+func (mgr *AccountMgr) respondAccountByID(c *gin.Context, accountID uint) {
+	q := query.Account
+	mgr.respondAccountLookup(
+		c,
+		func() (*model.Account, error) {
+			return q.WithContext(c).Where(q.ID.Eq(accountID)).First()
+		},
+		fmt.Sprintf("account not found: account ID %d does not exist", accountID),
+	)
+}
+
+func (mgr *AccountMgr) respondAccountByName(c *gin.Context, accountName string) {
+	q := query.Account
+	mgr.respondAccountLookup(
+		c,
+		func() (*model.Account, error) {
+			return q.WithContext(c).Where(q.Name.Eq(accountName)).First()
+		},
+		fmt.Sprintf("account not found: account name '%s' does not exist", accountName),
+	)
+}
+
 func (mgr *AccountMgr) GetQuota(c *gin.Context) {
 	var uriReq AccountIDReq
 	if err := c.ShouldBindUri(&uriReq); err != nil {
@@ -300,91 +615,29 @@ func (mgr *AccountMgr) GetQuota(c *gin.Context) {
 	deserved := queue.Spec.Deserved
 	capability := queue.Spec.Capability
 
-	// resources is a map, key is the resource name, value is the resource amount
-	resources := make(map[v1.ResourceName]payload.ResourceResp)
-
-	for name, quantity := range allocated {
-		if name == v1.ResourceCPU || name == v1.ResourceMemory || strings.Contains(string(name), "/") {
-			resources[name] = payload.ResourceResp{
-				Label: string(name),
-				Allocated: ptr.To(payload.ResourceBase{
-					Amount: quantity.Value(),
-					Format: string(quantity.Format),
-				}),
-			}
-		}
-	}
-	for name, quantity := range guarantee {
-		if v, ok := resources[name]; ok {
-			v.Guarantee = ptr.To(payload.ResourceBase{
-				Amount: quantity.Value(),
-				Format: string(quantity.Format),
-			})
-			resources[name] = v
-		}
-	}
-	for name, quantity := range deserved {
-		if v, ok := resources[name]; ok {
-			v.Deserved = ptr.To(payload.ResourceBase{
-				Amount: quantity.Value(),
-				Format: string(quantity.Format),
-			})
-			resources[name] = v
-		}
-	}
-	for name, quantity := range capability {
-		if v, ok := resources[name]; ok {
-			v.Capability = ptr.To(payload.ResourceBase{
-				Amount: quantity.Value(),
-				Format: string(quantity.Format),
-			})
-			resources[name] = v
-		}
-	}
+	resources := newAllocatedQuotaResources(allocated)
+	applyQuotaResourceList(resources, guarantee, setQuotaGuarantee)
+	applyQuotaResourceList(resources, deserved, setQuotaDeserved)
+	applyQuotaResourceList(resources, capability, setQuotaCapability)
 
 	// if capability is not set, read max from db
 	r := query.Resource
-	for name, resource := range resources {
-		if resource.Capability == nil {
-			resouece, err := r.WithContext(c).Where(r.ResourceName.Eq(string(name))).First()
-			if err != nil {
-				continue
-			}
-			resource.Capability = &payload.ResourceBase{
-				Amount: resouece.Amount,
-				Format: resouece.Format,
-			}
-			resources[name] = resource
+	for name, resourceResp := range resources {
+		if resourceResp.Capability != nil {
+			continue
 		}
+		resourceModel, err := r.WithContext(c).Where(r.ResourceName.Eq(string(name))).First()
+		if err != nil {
+			continue
+		}
+		resourceResp.Capability = &payload.ResourceBase{
+			Amount: resourceModel.Amount,
+			Format: resourceModel.Format,
+		}
+		resources[name] = resourceResp
 	}
 
-	// map contains cpu, memory, gpus, get them from the map
-	cpu := resources[v1.ResourceCPU]
-	cpu.Label = "cpu"
-	memory := resources[v1.ResourceMemory]
-	memory.Label = "mem"
-	var gpus []payload.ResourceResp
-	for name, resource := range resources {
-		if strings.Contains(string(name), "/") {
-			// convert nvidia.com/v100 to v100
-			split := strings.Split(string(name), "/")
-			if len(split) == 2 {
-				resourceType := split[1]
-				label := resourceType
-				resource.Label = label
-			}
-			gpus = append(gpus, resource)
-		}
-	}
-	sort.Slice(gpus, func(i, j int) bool {
-		return gpus[i].Label < gpus[j].Label
-	})
-
-	resputil.Success(c, payload.QuotaResp{
-		CPU:    cpu,
-		Memory: memory,
-		GPUs:   gpus,
-	})
+	resputil.Success(c, buildQuotaResp(resources))
 }
 
 type (
@@ -432,90 +685,15 @@ func (mgr *AccountMgr) CreateAccount(c *gin.Context) {
 		return
 	}
 
-	// Create a new project, and set the user as the admin in user_project
-	db := query.Use(query.GetDB())
-
-	var queueID uint
-	createdQueueNames := make([]string, 0)
-
-	err := db.Transaction(func(tx *query.Query) error {
-		q := tx.Account
-		uq := tx.UserAccount
-
-		// Create a queue Queue
-		queue := model.Account{
-			Nickname: req.Nickname,
-		}
-		if err := q.WithContext(c).Create(&queue); err != nil {
-			return err
-		}
-		queueID = queue.ID
-		// Create a space for the project, folder path is generated by uuid
-		quota := model.QueueQuota{
-			Guaranteed: req.Quota.Guaranteed,
-			Deserved:   req.Quota.Deserved,
-			Capability: req.Quota.Capability,
-		}
-		queue.Name = fmt.Sprintf("q-%d", queue.ID)
-		queue.Space = fmt.Sprintf("q-%d", queue.ID)
-		queue.Quota = datatypes.NewJSONType(quota)
-		if !req.ExpiredAt.IsZero() {
-			queue.ExpiredAt = &req.ExpiredAt
-		}
-		if _, err := q.WithContext(c).Where(q.ID.Eq(queue.ID)).Updates(&queue); err != nil {
-			return err
-		}
-
-		toCreateQueueNames := make([]string, 0)
-		parentQueueNames := make([]*string, 0)
-		queueQuotas := make([]*model.QueueQuota, 0)
-		logicQueueName := vcqueue.GetAccountLogicQueueName(queue.ID)
-		leafQueueName := vcqueue.GetAccountQueueName(queue.Name)
-		toCreateQueueNames = append(toCreateQueueNames, logicQueueName, leafQueueName)
-		parentQueueNames = append(parentQueueNames, nil, &logicQueueName)
-		queueQuotas = append(queueQuotas, &quota, nil)
-
-		// Create user-project relationship without quota limit
-		for _, adminID := range req.Admins {
-			userQueue := model.UserAccount{
-				UserID:     adminID,
-				AccountID:  queue.ID,
-				Role:       model.RoleAdmin, // Set the user as the admin
-				AccessMode: model.AccessModeRW,
-			}
-			if err := uq.WithContext(c).Create(&userQueue); err != nil {
-				return err
-			}
-			if !req.WithoutVolcano {
-				queueName := vcqueue.GetUserQueueName(queue.ID, adminID)
-				toCreateQueueNames = append(toCreateQueueNames, queueName)
-				parentQueueNames = append(parentQueueNames, &logicQueueName)
-				queueQuotas = append(queueQuotas, nil)
-			}
-		}
-
-		for i := 0; i < len(toCreateQueueNames); i++ {
-			queueName := toCreateQueueNames[i]
-			parentQueueName := parentQueueNames[i]
-			quota := queueQuotas[i]
-			if err := vcqueue.CreateQueue(c, mgr.client, token, queueName, parentQueueName, quota); err != nil {
-				return err
-			}
-			createdQueueNames = append(createdQueueNames, queueName)
-		}
-
-		return nil
-	})
+	queueID, createdQueueNames, createdAdminIDs, err := mgr.createAccountCore(c, token, &req)
 
 	if err != nil {
-		for _, queueName := range createdQueueNames {
-			_ = vcqueue.DeleteQueue(c, mgr.client, queueName)
-		}
+		mgr.cleanupCreatedQueues(c, createdQueueNames)
 		resputil.Error(c, err.Error(), resputil.NotSpecified)
 		return
-	} else {
-		resputil.Success(c, ProjectCreateResp{ID: queueID})
 	}
+	mgr.issueUserAccountNowForAdmins(c, queueID, createdAdminIDs)
+	resputil.Success(c, ProjectCreateResp{ID: queueID})
 }
 
 // UpdateAccount godoc
@@ -545,55 +723,268 @@ func (mgr *AccountMgr) UpdateAccount(c *gin.Context) {
 		return
 	}
 	token := util.GetToken(c)
-	err := query.Q.Transaction(func(tx *query.Query) error {
-		queue, err := tx.Account.WithContext(c).Where(tx.Account.ID.Eq(uriReq.ID)).First()
-		if err != nil {
-			resputil.Error(c, fmt.Sprintf("account not found: account ID %d does not exist", uriReq.ID), resputil.NotSpecified)
-			return err
-		}
-		queueName = queue.Name
+	err := mgr.updateAccountCore(c, token, uriReq.ID, &req, &queueName)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+	resputil.Success(c, fmt.Sprintf("update capability of %s", queueName))
+}
 
-		// update db
-		queue.Quota = datatypes.NewJSONType(model.QueueQuota{
-			Guaranteed: req.Quota.Guaranteed,
-			Deserved:   req.Quota.Deserved,
-			Capability: req.Quota.Capability,
-		})
-		if !req.ExpiredAt.IsZero() {
-			queue.ExpiredAt = &req.ExpiredAt
-		}
-		queue.Nickname = req.Nickname
-		if _, err := tx.Account.WithContext(c).Where(tx.Account.ID.Eq(queue.ID)).Updates(queue); err != nil {
-			resputil.Error(c, fmt.Sprintf("failed to update account %d: %v", queue.ID, err), resputil.NotSpecified)
-			return err
-		}
+// AdminResetAccountBillingBalance godoc
+//
+//	@Summary		立即重置账户免费额度
+//	@Description	立即对指定账户执行一次免费额度发放，不影响 extra 点数
+//	@Tags			Project
+//	@Accept			json
+//	@Produce		json
+//	@Security		Bearer
+//	@Param			aid	path		AccountIDReq				true	"account id"
+//	@Success		200	{object}	resputil.Response[string]	"重置成功"
+//	@Failure		400	{object}	resputil.Response[any]		"请求参数错误"
+//	@Failure		500	{object}	resputil.Response[any]		"其他错误"
+//	@Router			/v1/admin/projects/{aid}/billing/reset [post]
+func (mgr *AccountMgr) AdminResetAccountBillingBalance(c *gin.Context) {
+	accountID, ok := mgr.bindAccountID(c)
+	if !ok {
+		return
+	}
 
-		// update queue
-		if req.WithoutVolcano {
-			return nil
-		}
-
-		quota := model.QueueQuota{
-			Guaranteed: req.Quota.Guaranteed,
-			Deserved:   req.Quota.Deserved,
-			Capability: req.Quota.Capability,
-		}
-		if err := vcqueue.EnsureAccountQueueExists(c, mgr.client, token, queue.ID); err != nil {
-			return err
-		}
-		queueName := vcqueue.GetAccountLogicQueueName(queue.ID)
-		if err := vcqueue.UpdateQueue(c, mgr.client, queueName, quota); err != nil {
-			resputil.Error(c, fmt.Sprintf("failed to update Volcano queue for account %d: %v", queue.ID, err), resputil.NotSpecified)
-			return err
-		}
-		return nil
-	})
+	resp, err := mgr.resetAccountBillingBalanceCore(c, accountID)
 	if err != nil {
 		resputil.Error(c, err.Error(), resputil.NotSpecified)
 		return
 	}
 
-	resputil.Success(c, fmt.Sprintf("update capability of %s", queueName))
+	resputil.Success(c, resp)
+}
+
+func (mgr *AccountMgr) UserResetAccountBillingBalance(c *gin.Context) {
+	if err := mgr.requireUserFacingBillingEnabled(c.Request.Context()); err != nil {
+		handleAccountBillingConfigUpdateErr(c, err)
+		return
+	}
+	accountID, ok := mgr.requireUserManagedAccountID(c)
+	if !ok {
+		return
+	}
+
+	resp, err := mgr.resetAccountBillingBalanceCore(c, accountID)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+
+	resputil.Success(c, resp)
+}
+
+func (mgr *AccountMgr) createAccountCore(
+	c *gin.Context,
+	token util.JWTMessage,
+	req *AccountCreateOrUpdateReq,
+) (queueID uint, createdQueueNames []string, createdAdminIDs []uint, err error) {
+	db := query.Use(query.GetDB())
+	createdQueueNames = make([]string, 0)
+	createdAdminIDs = make([]uint, 0)
+	err = db.Transaction(func(tx *query.Query) error {
+		queue, quota, createErr := mgr.createAccountRecord(c, tx, req)
+		if createErr != nil {
+			return createErr
+		}
+		queueID = queue.ID
+		adminIDs, queueNames, parentNames, queueQuotas, createErr := mgr.createAccountMembers(c, tx, req, queue, quota)
+		if createErr != nil {
+			return createErr
+		}
+		createdAdminIDs = adminIDs
+		createdQueueNames, createErr = mgr.createVolcanoQueues(c, token, queueNames, parentNames, queueQuotas)
+		return createErr
+	})
+	return queueID, createdQueueNames, createdAdminIDs, err
+}
+
+func (mgr *AccountMgr) createAccountRecord(
+	c *gin.Context,
+	tx *query.Query,
+	req *AccountCreateOrUpdateReq,
+) (*model.Account, *model.QueueQuota, error) {
+	q := tx.Account
+	queue := &model.Account{Nickname: req.Nickname}
+	if err := q.WithContext(c).Create(queue); err != nil {
+		return nil, nil, err
+	}
+	quota := &model.QueueQuota{
+		Guaranteed: req.Quota.Guaranteed,
+		Deserved:   req.Quota.Deserved,
+		Capability: req.Quota.Capability,
+	}
+	queue.Name = fmt.Sprintf("q-%d", queue.ID)
+	queue.Space = fmt.Sprintf("q-%d", queue.ID)
+	queue.Quota = datatypes.NewJSONType(*quota)
+	if !req.ExpiredAt.IsZero() {
+		queue.ExpiredAt = &req.ExpiredAt
+	}
+	if _, err := q.WithContext(c).Where(q.ID.Eq(queue.ID)).Updates(queue); err != nil {
+		return nil, nil, err
+	}
+	return queue, quota, nil
+}
+
+func (mgr *AccountMgr) createAccountMembers(
+	c *gin.Context,
+	tx *query.Query,
+	req *AccountCreateOrUpdateReq,
+	queue *model.Account,
+	quota *model.QueueQuota,
+) (adminIDs []uint, queueNames []string, parentNames []*string, queueQuotas []*model.QueueQuota, err error) {
+	uq := tx.UserAccount
+	adminIDs = make([]uint, 0, len(req.Admins))
+	queueNames = make([]string, 0)
+	parentNames = make([]*string, 0)
+	queueQuotas = make([]*model.QueueQuota, 0)
+	logicQueueName := vcqueue.GetAccountLogicQueueName(queue.ID)
+	leafQueueName := vcqueue.GetAccountQueueName(queue.Name)
+	queueNames = append(queueNames, logicQueueName, leafQueueName)
+	parentNames = append(parentNames, nil, &logicQueueName)
+	queueQuotas = append(queueQuotas, quota, nil)
+
+	for _, adminID := range req.Admins {
+		userQueue := model.UserAccount{
+			UserID:     adminID,
+			AccountID:  queue.ID,
+			Role:       model.RoleAdmin,
+			AccessMode: model.AccessModeRW,
+		}
+		if err := uq.WithContext(c).Create(&userQueue); err != nil {
+			return nil, nil, nil, nil, err
+		}
+		adminIDs = append(adminIDs, adminID)
+		if !req.WithoutVolcano {
+			queueName := vcqueue.GetUserQueueName(queue.ID, adminID)
+			queueNames = append(queueNames, queueName)
+			parentNames = append(parentNames, &logicQueueName)
+			queueQuotas = append(queueQuotas, nil)
+		}
+	}
+	return adminIDs, queueNames, parentNames, queueQuotas, nil
+}
+
+func (mgr *AccountMgr) createVolcanoQueues(
+	c *gin.Context,
+	token util.JWTMessage,
+	queueNames []string,
+	parentQueueNames []*string,
+	queueQuotas []*model.QueueQuota,
+) ([]string, error) {
+	created := make([]string, 0, len(queueNames))
+	for i := 0; i < len(queueNames); i++ {
+		queueName := queueNames[i]
+		parentQueueName := parentQueueNames[i]
+		quota := queueQuotas[i]
+		if err := vcqueue.CreateQueue(c, mgr.client, token, queueName, parentQueueName, quota); err != nil {
+			return created, err
+		}
+		created = append(created, queueName)
+	}
+	return created, nil
+}
+
+func (mgr *AccountMgr) cleanupCreatedQueues(c *gin.Context, queueNames []string) {
+	for _, queueName := range queueNames {
+		_ = vcqueue.DeleteQueue(c, mgr.client, queueName)
+	}
+}
+
+func (mgr *AccountMgr) issueUserAccountNowForAdmins(c *gin.Context, accountID uint, adminIDs []uint) {
+	if mgr.billingService == nil ||
+		!shouldIssueInitialAccountBalance(
+			mgr.isBillingFeatureEnabled(c.Request.Context()),
+			mgr.billingService.IsActive(c.Request.Context()),
+			len(adminIDs),
+		) {
+		return
+	}
+	if issueErr := mgr.billingService.IssueAccountNow(c.Request.Context(), accountID); issueErr != nil {
+		klog.Warningf(
+			"immediate billing issue after account create failed, accountID=%d, err=%v",
+			accountID,
+			issueErr,
+		)
+	}
+}
+
+func shouldIssueInitialAccountBalance(featureEnabled, active bool, adminCount int) bool {
+	return featureEnabled && active && adminCount > 0
+}
+
+func (mgr *AccountMgr) updateAccountCore(
+	c *gin.Context,
+	token util.JWTMessage,
+	accountID uint,
+	req *AccountCreateOrUpdateReq,
+	queueName *string,
+) error {
+	return query.Q.Transaction(func(tx *query.Query) error {
+		queue, err := tx.Account.WithContext(c).Where(tx.Account.ID.Eq(accountID)).First()
+		if err != nil {
+			resputil.Error(c, fmt.Sprintf("account not found: account ID %d does not exist", accountID), resputil.NotSpecified)
+			return err
+		}
+		*queueName = queue.Name
+		if err := mgr.updateAccountRecord(c, tx, queue.ID, req); err != nil {
+			return err
+		}
+		if req.WithoutVolcano {
+			return nil
+		}
+		return mgr.updateAccountVolcanoQueue(c, token, queue.ID, req)
+	})
+}
+
+func (mgr *AccountMgr) updateAccountRecord(
+	c *gin.Context,
+	tx *query.Query,
+	accountID uint,
+	req *AccountCreateOrUpdateReq,
+) error {
+	updates := map[string]any{
+		"nickname": req.Nickname,
+		"quota": datatypes.NewJSONType(model.QueueQuota{
+			Guaranteed: req.Quota.Guaranteed,
+			Deserved:   req.Quota.Deserved,
+			Capability: req.Quota.Capability,
+		}),
+	}
+	if !req.ExpiredAt.IsZero() {
+		updates["expired_at"] = req.ExpiredAt
+	}
+	if _, err := tx.Account.WithContext(c).Where(tx.Account.ID.Eq(accountID)).Updates(updates); err != nil {
+		resputil.Error(c, fmt.Sprintf("failed to update account %d: %v", accountID, err), resputil.NotSpecified)
+		return err
+	}
+	return nil
+}
+
+func (mgr *AccountMgr) updateAccountVolcanoQueue(
+	c *gin.Context,
+	token util.JWTMessage,
+	accountID uint,
+	req *AccountCreateOrUpdateReq,
+) error {
+	quota := model.QueueQuota{
+		Guaranteed: req.Quota.Guaranteed,
+		Deserved:   req.Quota.Deserved,
+		Capability: req.Quota.Capability,
+	}
+	if err := vcqueue.EnsureAccountQueueExists(c, mgr.client, token, accountID); err != nil {
+		return err
+	}
+	queueName := vcqueue.GetAccountLogicQueueName(accountID)
+	if err := vcqueue.UpdateQueue(c, mgr.client, queueName, quota); err != nil {
+		resputil.Error(c, fmt.Sprintf("failed to update Volcano queue for account %d: %v", accountID, err), resputil.NotSpecified)
+		return err
+	}
+	return nil
 }
 
 type DeleteProjectReq struct {
@@ -847,6 +1238,24 @@ type UserProjectGetResp struct {
 	Quota      datatypes.JSONType[model.QueueQuota]    `json:"quota"`
 }
 
+type AccountBillingMemberResp struct {
+	IssueAmountOverride         *float64   `json:"issueAmountOverride,omitempty"`
+	UserID                      uint       `json:"userId"`
+	Username                    string     `json:"username"`
+	Nickname                    string     `json:"nickname"`
+	PeriodFreeBalance           float64    `json:"periodFreeBalance"`
+	ExtraBalance                float64    `json:"extraBalance"`
+	TotalAvailable              float64    `json:"totalAvailable"`
+	LastIssuedAt                *time.Time `json:"lastIssuedAt"`
+	NextIssueAt                 *time.Time `json:"nextIssueAt"`
+	EffectiveIssueAmount        float64    `json:"effectiveIssueAmount"`
+	EffectiveIssuePeriodMinutes int        `json:"effectiveIssuePeriodMinutes"`
+}
+
+type UpdateAccountBillingMemberIssueAmountReq struct {
+	IssueAmountOverride *service.BillingAmountInput `json:"issueAmountOverride"`
+}
+
 // AdminListAccountMembers gets list of users in account (admin API)
 //
 //	@Summary		Get users in account
@@ -884,12 +1293,58 @@ func (mgr *AccountMgr) AdminListAccountMembers(c *gin.Context) {
 	resputil.Success(c, resp)
 }
 
+func (mgr *AccountMgr) AdminListAccountBillingMembers(c *gin.Context) {
+	var req ProjectGetReq
+	if err := c.ShouldBindUri(&req); err != nil {
+		resputil.Error(c, fmt.Sprintf("validate UserProject parameters failed, detail: %v", err), resputil.NotSpecified)
+		return
+	}
+
+	if _, err := mgr.validateAccount(c, req.ID); err != nil {
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+
+	resp, err := mgr.getBillingMembersInAccount(c, req.ID)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+
+	resputil.Success(c, resp)
+}
+
+func (mgr *AccountMgr) AdminUpdateAccountBillingMemberIssueAmount(c *gin.Context) {
+	var uriReq struct {
+		AccountID uint `uri:"aid" binding:"required"`
+		UserID    uint `uri:"uid" binding:"required"`
+	}
+	var req UpdateAccountBillingMemberIssueAmountReq
+
+	if err := c.ShouldBindUri(&uriReq); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("invalid uri params: %v", err))
+		return
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("invalid request body: %v", err))
+		return
+	}
+
+	mgr.writeAccountBillingMemberIssueAmountResp(c, uriReq.AccountID, uriReq.UserID, &req)
+}
+
 type PutUserInProjectUriReq struct {
 	AccountId uint `uri:"aid" binding:"required"`
 }
 
 type PutUserInProjectReq struct {
 	UserId     uint                                  `json:"uid" binding:"required"`
+	Role       *string                               `json:"role"`
+	AccessMode *string                               `json:"accessmode" gorm:"access_mode"`
+	Quota      *datatypes.JSONType[model.QueueQuota] `json:"quota"`
+}
+
+type UserPutUserInProjectReq struct {
 	Role       *string                               `json:"role"`
 	AccessMode *string                               `json:"accessmode" gorm:"access_mode"`
 	Quota      *datatypes.JSONType[model.QueueQuota] `json:"quota"`
@@ -1211,6 +1666,16 @@ func (mgr *AccountMgr) createUserAccount(
 	if err != nil {
 		return err
 	}
+	if mgr.billingService != nil && mgr.isBillingFeatureEnabled(c.Request.Context()) {
+		if issueErr := mgr.billingService.IssueUserAccountNow(c.Request.Context(), userID, accountID); issueErr != nil {
+			klog.Warningf(
+				"immediate billing issue after user-account create failed, accountID=%d, userID=%d, err=%v",
+				accountID,
+				userID,
+				issueErr,
+			)
+		}
+	}
 	return nil
 }
 
@@ -1344,11 +1809,153 @@ func (mgr *AccountMgr) getUsersInAccount(c *gin.Context, accountID uint) ([]User
 
 	var resp []UserProjectGetResp
 	exec := u.WithContext(c).Join(uq, uq.UserID.EqCol(u.ID)).Where(uq.DeletedAt.IsNull())
-	exec = exec.Select(u.ID, u.Name, uq.Role, uq.AccessMode, uq.AccountID, u.Attributes, uq.Quota)
+	exec = exec.Select(u.ID, u.Name, uq.Role, uq.AccessMode, u.Attributes, uq.Quota)
 	if err := exec.Where(uq.AccountID.Eq(accountID)).Distinct().Scan(&resp); err != nil {
 		return nil, fmt.Errorf("get userProject failed, detail: %w", err)
 	}
 	return resp, nil
+}
+
+func (mgr *AccountMgr) getBillingMembersInAccount(c *gin.Context, accountID uint) ([]AccountBillingMemberResp, error) {
+	if mgr.billingService == nil || !mgr.isBillingFeatureEnabled(c.Request.Context()) {
+		return []AccountBillingMemberResp{}, nil
+	}
+
+	account, err := mgr.validateAccount(c, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	ua := query.UserAccount
+	u := query.User
+
+	userAccounts, err := ua.WithContext(c).
+		Where(ua.AccountID.Eq(accountID), ua.DeletedAt.IsNull()).
+		Order(ua.UserID).
+		Find()
+	if err != nil {
+		return nil, fmt.Errorf("failed to query account billing members: %w", err)
+	}
+
+	userIDs := make([]uint, 0, len(userAccounts))
+	for i := range userAccounts {
+		userIDs = append(userIDs, userAccounts[i].UserID)
+	}
+
+	usersByID := make(map[uint]*model.User, len(userIDs))
+	if len(userIDs) > 0 {
+		users, err := u.WithContext(c).
+			Where(u.ID.In(userIDs...), u.DeletedAt.IsNull()).
+			Find()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load billing member users: %w", err)
+		}
+		for i := range users {
+			usersByID[users[i].ID] = users[i]
+		}
+	}
+
+	resp := make([]AccountBillingMemberResp, 0, len(userAccounts))
+	for i := range userAccounts {
+		userAccount := userAccounts[i]
+		user := usersByID[userAccount.UserID]
+		if user == nil {
+			continue
+		}
+		resp = append(resp, mgr.buildAccountBillingMemberResp(c, account, userAccount, user))
+	}
+	return resp, nil
+}
+
+func (mgr *AccountMgr) buildAccountBillingMemberResp(
+	c *gin.Context,
+	account *model.Account,
+	userAccount *model.UserAccount,
+	user *model.User,
+) AccountBillingMemberResp {
+	issueAmount, issuePeriod := mgr.billingService.ResolveEffectiveIssueConfigForUserAccount(
+		c.Request.Context(),
+		userAccount,
+		account,
+	)
+	nextIssueAt := mgr.billingService.ComputeNextIssueAt(account.BillingLastIssuedAt, issuePeriod, time.Now())
+
+	var issueAmountOverride *float64
+	if userAccount.BillingIssueAmountOverride != nil {
+		override := service.ToDisplayPoints(*userAccount.BillingIssueAmountOverride)
+		issueAmountOverride = &override
+	}
+
+	return AccountBillingMemberResp{
+		IssueAmountOverride:         issueAmountOverride,
+		UserID:                      user.ID,
+		Username:                    user.Name,
+		Nickname:                    user.Attributes.Data().Nickname,
+		PeriodFreeBalance:           service.ToDisplayPoints(userAccount.PeriodFreeBalance),
+		ExtraBalance:                service.ToDisplayPoints(user.ExtraBalance),
+		TotalAvailable:              service.ToDisplayPoints(userAccount.PeriodFreeBalance + user.ExtraBalance),
+		LastIssuedAt:                account.BillingLastIssuedAt,
+		NextIssueAt:                 nextIssueAt,
+		EffectiveIssueAmount:        service.ToDisplayPoints(issueAmount),
+		EffectiveIssuePeriodMinutes: issuePeriod,
+	}
+}
+
+func (mgr *AccountMgr) updateAccountBillingMemberIssueAmount(
+	c *gin.Context,
+	accountID, userID uint,
+	req *UpdateAccountBillingMemberIssueAmountReq,
+) (*AccountBillingMemberResp, error) {
+	if err := mgr.requireBillingEnabled(c.Request.Context()); err != nil {
+		return nil, err
+	}
+
+	account, err := mgr.validateAccount(c, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	u := query.User
+	user, err := u.WithContext(c).
+		Where(u.ID.Eq(userID), u.DeletedAt.IsNull()).
+		First()
+	if err != nil {
+		return nil, fmt.Errorf("user not found: %w", err)
+	}
+
+	ua := query.UserAccount
+	userAccount, err := ua.WithContext(c).
+		Where(ua.AccountID.Eq(accountID), ua.UserID.Eq(userID), ua.DeletedAt.IsNull()).
+		First()
+	if err != nil {
+		return nil, fmt.Errorf("user %d is not in account %d", userID, accountID)
+	}
+
+	if req != nil && req.IssueAmountOverride != nil && req.IssueAmountOverride.MicroPoints() < 0 {
+		return nil, fmt.Errorf("issue amount override must be non-negative")
+	}
+
+	updateValue := any(nil)
+	if req != nil && req.IssueAmountOverride != nil {
+		updateValue = req.IssueAmountOverride.MicroPoints()
+	}
+
+	if _, err := ua.WithContext(c).
+		Where(ua.AccountID.Eq(accountID), ua.UserID.Eq(userID), ua.DeletedAt.IsNull()).
+		Updates(map[string]any{
+			"billing_issue_amount_override": updateValue,
+		}); err != nil {
+		return nil, fmt.Errorf("failed to update billing issue amount override: %w", err)
+	}
+
+	userAccount.BillingIssueAmountOverride = nil
+	if req != nil && req.IssueAmountOverride != nil {
+		override := req.IssueAmountOverride.MicroPoints()
+		userAccount.BillingIssueAmountOverride = &override
+	}
+
+	resp := mgr.buildAccountBillingMemberResp(c, account, userAccount, user)
+	return &resp, nil
 }
 
 // getUsersOutOfAccount gets list of users not in account
@@ -1400,6 +2007,8 @@ func (mgr *AccountMgr) buildUserAccountUpdates(
 	role *string,
 	accessMode *string,
 	quota *datatypes.JSONType[model.QueueQuota],
+	account *model.Account,
+	isDefault bool,
 ) (map[string]any, error) {
 	updates := make(map[string]any)
 
@@ -1420,16 +2029,21 @@ func (mgr *AccountMgr) buildUserAccountUpdates(
 	}
 
 	if quota != nil {
-		if err := checkResource(c, quota.Data().Guaranteed); err != nil {
+		finalQuota := quota.Data()
+		if !isDefault && len(finalQuota.Capability) == 0 && account != nil && account.UserDefaultQuota != nil {
+			finalQuota.Capability = account.UserDefaultQuota.Data().Capability
+		}
+
+		if err := checkResource(c, finalQuota.Guaranteed); err != nil {
 			return nil, fmt.Errorf("invalid quota guaranteed resources: %w", err)
 		}
-		if err := checkResource(c, quota.Data().Deserved); err != nil {
+		if err := checkResource(c, finalQuota.Deserved); err != nil {
 			return nil, fmt.Errorf("invalid quota deserved resources: %w", err)
 		}
-		if err := checkResource(c, quota.Data().Capability); err != nil {
+		if err := checkResource(c, finalQuota.Capability); err != nil {
 			return nil, fmt.Errorf("invalid quota capability resources: %w", err)
 		}
-		updates["quota"] = *quota
+		updates["quota"] = datatypes.NewJSONType(finalQuota)
 	}
 
 	return updates, nil
@@ -1442,6 +2056,8 @@ func (mgr *AccountMgr) putUserInAccount(
 	accessMode *string,
 	quota *datatypes.JSONType[model.QueueQuota],
 ) error {
+	token := util.GetToken(c)
+
 	// Check if trying to modify role in default account
 	isDefault, err := mgr.isDefaultAccount(c, accountID)
 	if err != nil {
@@ -1453,19 +2069,99 @@ func (mgr *AccountMgr) putUserInAccount(
 		}
 	}
 
-	updates, err := mgr.buildUserAccountUpdates(c, role, accessMode, quota)
+	return query.Q.Transaction(func(tx *query.Query) error {
+		userQueue, err := mgr.getUserAccountForUpdate(c, tx, accountID, userID)
+		if err != nil {
+			return err
+		}
+
+		account, err := mgr.loadAccountForPartialUserUpdate(c, accountID, quota)
+		if err != nil {
+			return err
+		}
+
+		updates, err := mgr.buildUserAccountUpdates(c, role, accessMode, quota, account, isDefault)
+		if err != nil {
+			return err
+		}
+		if len(updates) == 0 {
+			return nil
+		}
+
+		finalQuota, err := mgr.applyPartialUserAccountUpdates(c, tx, accountID, userID, userQueue, updates)
+		if err != nil {
+			return err
+		}
+
+		return mgr.syncPartialUserQueueQuota(c, token, accountID, userID, finalQuota, quota, isDefault)
+	})
+}
+
+func (mgr *AccountMgr) getUserAccountForUpdate(c *gin.Context, tx *query.Query, accountID, userID uint) (*model.UserAccount, error) {
+	uq := tx.UserAccount
+	userQueue, err := uq.WithContext(c).
+		Where(uq.AccountID.Eq(accountID), uq.UserID.Eq(userID)).
+		First()
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("user %d is not in account %d", userID, accountID)
+	}
+	return userQueue, nil
+}
+
+func (mgr *AccountMgr) loadAccountForPartialUserUpdate(
+	c *gin.Context,
+	accountID uint,
+	quota *datatypes.JSONType[model.QueueQuota],
+) (*model.Account, error) {
+	if quota == nil {
+		return nil, nil
+	}
+	return mgr.validateAccount(c, accountID)
+}
+
+func (mgr *AccountMgr) applyPartialUserAccountUpdates(
+	c *gin.Context,
+	tx *query.Query,
+	accountID, userID uint,
+	userQueue *model.UserAccount,
+	updates map[string]any,
+) (model.QueueQuota, error) {
+	uq := tx.UserAccount
+	if _, err := uq.WithContext(c).
+		Where(uq.AccountID.Eq(accountID), uq.UserID.Eq(userID)).
+		Updates(updates); err != nil {
+		return model.QueueQuota{}, fmt.Errorf("failed to update user-account relationship: %w", err)
 	}
 
-	if len(updates) == 0 {
-		return nil // No updates to apply
+	finalQuota := userQueue.Quota.Data()
+	if updatedQuota, ok := updates["quota"].(datatypes.JSONType[model.QueueQuota]); ok {
+		finalQuota = updatedQuota.Data()
+	}
+	return finalQuota, nil
+}
+
+func (mgr *AccountMgr) syncPartialUserQueueQuota(
+	c *gin.Context,
+	token util.JWTMessage,
+	accountID, userID uint,
+	finalQuota model.QueueQuota,
+	quota *datatypes.JSONType[model.QueueQuota],
+	isDefault bool,
+) error {
+	if quota == nil || isDefault {
+		return nil
 	}
 
-	uq := query.UserAccount
-	_, err = uq.WithContext(c).Where(uq.AccountID.Eq(accountID), uq.UserID.Eq(userID)).Updates(updates)
-	if err != nil {
-		return fmt.Errorf("failed to update user-account relationship: %w", err)
+	if err := vcqueue.EnsureAccountQueueExists(c, mgr.client, token, accountID); err != nil {
+		return fmt.Errorf("failed to ensure account queue exists: %w", err)
+	}
+	if err := vcqueue.EnsureUserQueueExists(c, mgr.client, token, accountID, userID); err != nil {
+		return fmt.Errorf("failed to ensure user queue exists: %w", err)
+	}
+
+	queueName := vcqueue.GetUserQueueName(accountID, userID)
+	if err := vcqueue.UpdateQueue(c, mgr.client, queueName, finalQuota); err != nil {
+		return fmt.Errorf("failed to update volcano queue for user %d in account %d: %w", userID, accountID, err)
 	}
 	return nil
 }
@@ -1706,6 +2402,32 @@ func (mgr *AccountMgr) UserListAccountMembers(c *gin.Context) {
 	resputil.Success(c, resp)
 }
 
+func (mgr *AccountMgr) UserListAccountBillingMembers(c *gin.Context) {
+	if err := mgr.requireUserFacingBillingEnabled(c.Request.Context()); err != nil {
+		handleAccountBillingConfigUpdateErr(c, err)
+		return
+	}
+	var req ProjectGetReq
+	if err := c.ShouldBindUri(&req); err != nil {
+		resputil.Error(c, fmt.Sprintf("validate UserProject parameters failed, detail: %v", err), resputil.NotSpecified)
+		return
+	}
+
+	token := util.GetToken(c)
+	if err := mgr.checkAccountAdmin(c, token.UserID, req.ID); err != nil {
+		resputil.HTTPError(c, httpStatusForbidden, "Forbidden: User is not account admin", resputil.NotSpecified)
+		return
+	}
+
+	resp, err := mgr.getBillingMembersInAccount(c, req.ID)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+
+	resputil.Success(c, resp)
+}
+
 // UserListUsersOutOfAccount gets list of users not in account (user API)
 //
 //	@Summary		Get users not in account
@@ -1761,7 +2483,7 @@ func (mgr *AccountMgr) UserListUsersOutOfAccount(c *gin.Context) {
 //	@Security		Bearer
 //	@Param			aid	path		uint					true	"aid"
 //	@Param			uid	path		uint					true	"uid"
-//	@Param			req	body		PutUserInProjectReq	true	"Update data"
+//	@Param			req	body		UserPutUserInProjectReq	true	"Update data"
 //	@Success		200	{object}	resputil.Response[PutUserInProjectResp]	"Update result"
 //	@Failure		400	{object}	resputil.Response[any]	"Request parameter error"
 //	@Failure		403	{object}	resputil.Response[any]	"Forbidden - not account admin"
@@ -1772,7 +2494,7 @@ func (mgr *AccountMgr) UserUpdateAccountMemberPartial(c *gin.Context) {
 		AccountId uint `uri:"aid" binding:"required"`
 		UserID    uint `uri:"uid" binding:"required"`
 	}
-	req := &PutUserInProjectReq{}
+	req := &UserPutUserInProjectReq{}
 
 	if err := c.ShouldBindUri(&uriReq); err != nil {
 		resputil.Error(c, fmt.Sprintf("validate PutUserInProject parameters failed, detail: %v", err), resputil.NotSpecified)
@@ -1808,4 +2530,33 @@ func (mgr *AccountMgr) UserUpdateAccountMemberPartial(c *gin.Context) {
 		UserId:    uriReq.UserID,
 	}
 	resputil.Success(c, ret)
+}
+
+func (mgr *AccountMgr) UserUpdateAccountBillingMemberIssueAmount(c *gin.Context) {
+	var uriReq struct {
+		AccountID uint `uri:"aid" binding:"required"`
+		UserID    uint `uri:"uid" binding:"required"`
+	}
+	var req UpdateAccountBillingMemberIssueAmountReq
+
+	if err := mgr.requireUserFacingBillingEnabled(c.Request.Context()); err != nil {
+		handleAccountBillingConfigUpdateErr(c, err)
+		return
+	}
+	if err := c.ShouldBindUri(&uriReq); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("invalid uri params: %v", err))
+		return
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("invalid request body: %v", err))
+		return
+	}
+
+	token := util.GetToken(c)
+	if err := mgr.checkAccountAdmin(c, token.UserID, uriReq.AccountID); err != nil {
+		resputil.HTTPError(c, httpStatusForbidden, "Forbidden: User is not account admin", resputil.NotSpecified)
+		return
+	}
+
+	mgr.writeAccountBillingMemberIssueAmountResp(c, uriReq.AccountID, uriReq.UserID, &req)
 }

--- a/backend/internal/handler/context.go
+++ b/backend/internal/handler/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/exp/rand"
@@ -18,7 +19,6 @@ import (
 
 	"github.com/raids-lab/crater/dao/model"
 	"github.com/raids-lab/crater/dao/query"
-	"github.com/raids-lab/crater/internal/payload"
 	"github.com/raids-lab/crater/internal/resputil"
 	"github.com/raids-lab/crater/internal/service"
 	"github.com/raids-lab/crater/internal/util"
@@ -37,18 +37,20 @@ func init() {
 }
 
 type ContextMgr struct {
-	name          string
-	client        client.Client
-	configService *service.ConfigService
-	queueQuotaSvc *service.PrequeueService
+	name           string
+	client         client.Client
+	configService  *service.ConfigService
+	queueQuotaSvc  *service.PrequeueService
+	billingService *service.BillingService
 }
 
 func NewContextMgr(conf *RegisterConfig) Manager {
 	return &ContextMgr{
-		name:          "context",
-		client:        conf.Client,
-		configService: conf.ConfigService,
-		queueQuotaSvc: conf.PrequeueService,
+		name:           "context",
+		client:         conf.Client,
+		configService:  conf.ConfigService,
+		queueQuotaSvc:  conf.PrequeueService,
+		billingService: conf.BillingService,
 	}
 }
 
@@ -61,6 +63,7 @@ func (mgr *ContextMgr) RegisterProtected(g *gin.RouterGroup) {
 	g.GET("quota", mgr.GetQuota)
 	g.GET("job-resource-summary", mgr.GetJobResourceSummary)
 	g.POST("resource-limit-check", mgr.CheckResourceLimit)
+	g.GET("billing/summary", mgr.GetBillingSummary)
 	g.PUT("attributes", mgr.UpdateUserAttributes)
 	g.POST("email/code", mgr.SendUserVerificationCode)
 	g.POST("email/update", mgr.UpdateUserEmail)
@@ -172,21 +175,7 @@ func (mgr *ContextMgr) GetQuota(c *gin.Context) {
 		}
 	}
 
-	// Query resource limits from user database
-	resources := make(map[v1.ResourceName]payload.ResourceResp)
-
-	// Process allocated resources
-	for name, quantity := range allocated {
-		if name == v1.ResourceCPU || name == v1.ResourceMemory || strings.Contains(string(name), "/") {
-			resources[name] = payload.ResourceResp{
-				Label: string(name),
-				Allocated: ptr.To(payload.ResourceBase{
-					Amount: quantity.Value(),
-					Format: string(quantity.Format),
-				}),
-			}
-		}
-	}
+	resources := newAllocatedQuotaResources(allocated)
 
 	// Get resource limits from database user
 	ua := query.UserAccount
@@ -196,43 +185,9 @@ func (mgr *ContextMgr) GetQuota(c *gin.Context) {
 		return
 	}
 	capability := userAccount.Quota.Data().Capability
-	for name := range resources {
-		v, exists := capability[name]
-		if !exists {
-			continue
-		}
-		resource := resources[name]
-		resource.Capability = ptr.To(payload.ResourceBase{
-			Amount: v.Value(),
-			Format: string(v.Format),
-		})
-		resources[name] = resource
-	}
+	applyQuotaResourceList(resources, capability, setQuotaCapability)
 
-	// Extract CPU, memory and GPU resources
-	cpu := resources[v1.ResourceCPU]
-	cpu.Label = "cpu"
-	memory := resources[v1.ResourceMemory]
-	memory.Label = "mem"
-	var gpus []payload.ResourceResp
-	for name, resource := range resources {
-		if strings.Contains(string(name), "/") {
-			split := strings.Split(string(name), "/")
-			if len(split) == 2 {
-				resource.Label = split[1]
-			}
-			gpus = append(gpus, resource)
-		}
-	}
-	sort.Slice(gpus, func(i, j int) bool {
-		return gpus[i].Label < gpus[j].Label
-	})
-
-	resputil.Success(c, payload.QuotaResp{
-		CPU:    cpu,
-		Memory: memory,
-		GPUs:   gpus,
-	})
+	resputil.Success(c, buildQuotaResp(resources))
 }
 
 // GetJobResourceSummary godoc
@@ -384,6 +339,73 @@ type (
 		Attribute datatypes.JSONType[model.UserAttribute] `json:"attributes"`
 	}
 )
+
+type BillingSummaryResp struct {
+	PeriodFreeBalance          float64    `json:"periodFreeBalance"`
+	ExtraBalance               float64    `json:"extraBalance"`
+	TotalAvailable             float64    `json:"totalAvailable"`
+	LastIssuedAt               *time.Time `json:"lastIssuedAt"`
+	NextIssueAt                *time.Time `json:"nextIssueAt"`
+	EffectiveIssueAmount       float64    `json:"effectiveIssueAmount"`
+	EffectiveIssuePeriodMinute int        `json:"effectiveIssuePeriodMinutes"`
+}
+
+func (mgr *ContextMgr) GetBillingSummary(c *gin.Context) {
+	resp := BillingSummaryResp{}
+	if mgr.billingService == nil || !mgr.billingService.IsUserFacingEnabled(c.Request.Context()) {
+		resputil.Success(c, resp)
+		return
+	}
+
+	token := util.GetToken(c)
+	u := query.User
+	a := query.Account
+	uaQuery := query.UserAccount
+
+	user, err := u.WithContext(c).
+		Where(u.ID.Eq(token.UserID), u.DeletedAt.IsNull()).
+		First()
+	if err != nil {
+		resputil.Error(c, fmt.Sprintf("failed to load user: %v", err), resputil.NotSpecified)
+		return
+	}
+	account, err := a.WithContext(c).
+		Where(a.ID.Eq(token.AccountID), a.DeletedAt.IsNull()).
+		First()
+	if err != nil {
+		resputil.Error(c, fmt.Sprintf("failed to load account: %v", err), resputil.NotSpecified)
+		return
+	}
+	ua, err := uaQuery.WithContext(c).
+		Where(
+			uaQuery.UserID.Eq(token.UserID),
+			uaQuery.AccountID.Eq(token.AccountID),
+			uaQuery.DeletedAt.IsNull(),
+		).
+		First()
+	if err != nil {
+		resputil.Error(c, fmt.Sprintf("failed to load user-account relation: %v", err), resputil.NotSpecified)
+		return
+	}
+
+	issueAmount, periodMinutes := mgr.billingService.ResolveEffectiveIssueConfigForUserAccount(
+		c.Request.Context(),
+		ua,
+		account,
+	)
+	nextIssueAt := mgr.billingService.ComputeNextIssueAt(account.BillingLastIssuedAt, periodMinutes, time.Now())
+
+	resp = BillingSummaryResp{
+		PeriodFreeBalance:          service.ToDisplayPoints(ua.PeriodFreeBalance),
+		ExtraBalance:               service.ToDisplayPoints(user.ExtraBalance),
+		TotalAvailable:             service.ToDisplayPoints(ua.PeriodFreeBalance + user.ExtraBalance),
+		LastIssuedAt:               account.BillingLastIssuedAt,
+		NextIssueAt:                nextIssueAt,
+		EffectiveIssueAmount:       service.ToDisplayPoints(issueAmount),
+		EffectiveIssuePeriodMinute: periodMinutes,
+	}
+	resputil.Success(c, resp)
+}
 
 // UpdateUserAttributes godoc
 //

--- a/backend/internal/handler/interface.go
+++ b/backend/internal/handler/interface.go
@@ -56,6 +56,7 @@ type RegisterConfig struct {
 	// services
 	ConfigService      *service.ConfigService
 	PrequeueService    *service.PrequeueService
+	BillingService     *service.BillingService
 	GpuAnalysisService *service.GpuAnalysisService
 }
 

--- a/backend/internal/handler/operations/cronjob.go
+++ b/backend/internal/handler/operations/cronjob.go
@@ -34,12 +34,42 @@ func (mgr *OperationsMgr) UpdateCronjobConfig(c *gin.Context) {
 		resputil.Error(c, err.Error(), resputil.InvalidRequest)
 		return
 	}
-	var (
-		jobTypePtr *model.CronJobType
-		specPtr    *string
-		statusPtr  *model.CronJobConfigStatus
-		configPtr  *string
-	)
+
+	jobTypePtr, specPtr, statusPtr, configPtr, err := buildCronUpdateParams(&req)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.ServiceError)
+		return
+	}
+
+	if err := mgr.validateCronEnableGate(c, &req); err != nil {
+		resputil.Error(c, err.Error(), resputil.InvalidRequest)
+		return
+	}
+
+	if err := mgr.cronJobManager.UpdateJobConfig(c, req.Name, jobTypePtr, specPtr, statusPtr, configPtr); err != nil {
+		resputil.Error(c, err.Error(), resputil.ServiceError)
+		return
+	}
+	if req.Name == patrol.TRIGGER_BILLING_BASE_LOOP_JOB &&
+		req.Status == model.CronJobConfigStatusSuspended &&
+		mgr.billingService != nil {
+		if err := mgr.billingService.HandleBaseLoopCronSuspended(c.Request.Context()); err != nil {
+			resputil.Error(c, err.Error(), resputil.ServiceError)
+			return
+		}
+	}
+	resputil.Success(c, "Successfully update cronjob config")
+}
+
+func buildCronUpdateParams(
+	req *model.CronJobConfig,
+) (
+	jobTypePtr *model.CronJobType,
+	specPtr *string,
+	statusPtr *model.CronJobConfigStatus,
+	configPtr *string,
+	err error,
+) {
 	if req.Type != "" {
 		jobTypePtr = ptr.To(req.Type)
 	}
@@ -50,28 +80,35 @@ func (mgr *OperationsMgr) UpdateCronjobConfig(c *gin.Context) {
 		statusPtr = ptr.To(req.Status)
 	}
 	if len(req.Config) > 0 {
-		configJson, err := json.Marshal(req.Config)
+		var configJSON []byte
+		configJSON, err = json.Marshal(req.Config)
 		if err != nil {
-			resputil.Error(c, err.Error(), resputil.ServiceError)
+			return nil, nil, nil, nil, err
 		}
-		configPtr = ptr.To(string(configJson))
+		configPtr = ptr.To(string(configJSON))
 	}
+	return jobTypePtr, specPtr, statusPtr, configPtr, nil
+}
 
-	if req.Name == patrol.TRIGGER_GPU_ANALYSIS_JOB && req.Status != "" && req.Status != model.CronJobConfigStatusSuspended {
-		isFeatureEnabled := mgr.configService.IsGpuAnalysisEnabled(c.Request.Context())
-		if !isFeatureEnabled {
-			// 如果主功能是关闭的，则禁止启用定时任务，并返回错误
-			errMsg := "Cannot enable the GPU analysis cron job because the main GPU analysis feature is disabled in system settings."
-			resputil.Error(c, errMsg, resputil.InvalidRequest)
-			return
+func (mgr *OperationsMgr) validateCronEnableGate(c *gin.Context, req *model.CronJobConfig) error {
+	if req.Status == "" || req.Status == model.CronJobConfigStatusSuspended {
+		return nil
+	}
+	if req.Name == patrol.TRIGGER_GPU_ANALYSIS_JOB {
+		if !mgr.configService.IsGpuAnalysisEnabled(c.Request.Context()) {
+			return fmt.Errorf("cannot enable the GPU analysis cron job because the main GPU analysis feature is disabled in system settings")
+		}
+		return nil
+	}
+	if req.Name == patrol.TRIGGER_BILLING_BASE_LOOP_JOB {
+		if mgr.billingService == nil || !mgr.billingService.IsFeatureEnabled(c.Request.Context()) {
+			return fmt.Errorf("cannot enable billing cron job because billing feature is disabled in system settings")
+		}
+		if !mgr.billingService.IsActive(c.Request.Context()) {
+			return fmt.Errorf("cannot enable billing cron job because billing active is disabled in system settings")
 		}
 	}
-
-	if err := mgr.cronJobManager.UpdateJobConfig(c, req.Name, jobTypePtr, specPtr, statusPtr, configPtr); err != nil {
-		resputil.Error(c, err.Error(), resputil.ServiceError)
-		return
-	}
-	resputil.Success(c, "Successfully update cronjob config")
+	return nil
 }
 
 // GetCronjobConfigs godoc

--- a/backend/internal/handler/operations/operations.go
+++ b/backend/internal/handler/operations/operations.go
@@ -28,6 +28,7 @@ type OperationsMgr struct {
 	// cron
 	cronJobManager *cronjob.CronJobManager
 	configService  *service.ConfigService
+	billingService *service.BillingService
 }
 
 func NewOperationsMgr(conf *handler.RegisterConfig) handler.Manager {
@@ -40,6 +41,7 @@ func NewOperationsMgr(conf *handler.RegisterConfig) handler.Manager {
 		taskController: conf.AITaskCtrl,
 		cronJobManager: conf.CronJobManager,
 		configService:  conf.ConfigService,
+		billingService: conf.BillingService,
 	}
 	return instance
 }

--- a/backend/internal/handler/quota.go
+++ b/backend/internal/handler/quota.go
@@ -1,0 +1,91 @@
+package handler
+
+import (
+	"sort"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+
+	"github.com/raids-lab/crater/internal/payload"
+)
+
+func isQuotaResourceName(name v1.ResourceName) bool {
+	return name == v1.ResourceCPU || name == v1.ResourceMemory || strings.Contains(string(name), "/")
+}
+
+func newQuotaResourceBase(quantity resource.Quantity) *payload.ResourceBase {
+	return ptr.To(payload.ResourceBase{
+		Amount: quantity.Value(),
+		Format: string(quantity.Format),
+	})
+}
+
+func newAllocatedQuotaResources(allocated v1.ResourceList) map[v1.ResourceName]payload.ResourceResp {
+	resources := make(map[v1.ResourceName]payload.ResourceResp)
+	for name, quantity := range allocated {
+		if !isQuotaResourceName(name) {
+			continue
+		}
+		resources[name] = payload.ResourceResp{
+			Label:     string(name),
+			Allocated: newQuotaResourceBase(quantity),
+		}
+	}
+	return resources
+}
+
+func applyQuotaResourceList(
+	resources map[v1.ResourceName]payload.ResourceResp,
+	values v1.ResourceList,
+	apply func(*payload.ResourceResp, *payload.ResourceBase),
+) {
+	for name, quantity := range values {
+		resourceResp, ok := resources[name]
+		if !ok {
+			continue
+		}
+		apply(&resourceResp, newQuotaResourceBase(quantity))
+		resources[name] = resourceResp
+	}
+}
+
+func setQuotaGuarantee(resp *payload.ResourceResp, base *payload.ResourceBase) {
+	resp.Guarantee = base
+}
+
+func setQuotaDeserved(resp *payload.ResourceResp, base *payload.ResourceBase) {
+	resp.Deserved = base
+}
+
+func setQuotaCapability(resp *payload.ResourceResp, base *payload.ResourceBase) {
+	resp.Capability = base
+}
+
+func buildQuotaResp(resources map[v1.ResourceName]payload.ResourceResp) payload.QuotaResp {
+	cpu := resources[v1.ResourceCPU]
+	cpu.Label = "cpu"
+	memory := resources[v1.ResourceMemory]
+	memory.Label = "mem"
+
+	var gpus []payload.ResourceResp
+	for name, resourceResp := range resources {
+		if !strings.Contains(string(name), "/") {
+			continue
+		}
+		if split := strings.Split(string(name), "/"); len(split) == 2 {
+			resourceResp.Label = split[1]
+		}
+		gpus = append(gpus, resourceResp)
+	}
+	sort.Slice(gpus, func(i, j int) bool {
+		return gpus[i].Label < gpus[j].Label
+	})
+
+	return payload.QuotaResp{
+		CPU:    cpu,
+		Memory: memory,
+		GPUs:   gpus,
+	}
+}

--- a/backend/internal/handler/resource.go
+++ b/backend/internal/handler/resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/raids-lab/crater/dao/model"
 	"github.com/raids-lab/crater/dao/query"
 	"github.com/raids-lab/crater/internal/resputil"
+	"github.com/raids-lab/crater/internal/service"
 )
 
 //nolint:gochecknoinits // This is the standard way to register a gin handler.
@@ -22,15 +23,25 @@ func init() {
 }
 
 type ResourceMgr struct {
-	name       string
-	kubeClient kubernetes.Interface
+	name           string
+	kubeClient     kubernetes.Interface
+	billingService *service.BillingService
 }
 
 func NewResourceMgr(conf *RegisterConfig) Manager {
 	return &ResourceMgr{
-		name:       "resources",
-		kubeClient: conf.KubeClient,
+		name:           "resources",
+		kubeClient:     conf.KubeClient,
+		billingService: conf.BillingService,
 	}
+}
+
+func (mgr *ResourceMgr) isBillingFeatureEnabled(c *gin.Context) bool {
+	return mgr.billingService != nil && mgr.billingService.IsFeatureEnabled(c.Request.Context())
+}
+
+func (mgr *ResourceMgr) isBillingUserFacingEnabled(c *gin.Context) bool {
+	return mgr.billingService != nil && mgr.billingService.IsUserFacingEnabled(c.Request.Context())
 }
 
 func (mgr *ResourceMgr) GetName() string { return mgr.name }
@@ -39,6 +50,7 @@ func (mgr *ResourceMgr) RegisterPublic(_ *gin.RouterGroup) {}
 
 func (mgr *ResourceMgr) RegisterProtected(g *gin.RouterGroup) {
 	g.GET("", mgr.ListResource)
+	g.GET("/billing/prices", mgr.ListBillingPrices)
 	g.GET("/:id/networks", mgr.GetGPUNetworks)
 	g.GET(":id/vgpu", mgr.GetGPUVGPUResources)
 }
@@ -46,6 +58,7 @@ func (mgr *ResourceMgr) RegisterProtected(g *gin.RouterGroup) {
 func (mgr *ResourceMgr) RegisterAdmin(g *gin.RouterGroup) {
 	g.POST("/sync", mgr.SyncResource)
 	g.PUT("/:id", mgr.UpdateResource) // 注意这里改为新的方法名
+	g.PUT("/:id/billing/unit-price", mgr.UpdateResourceUnitPrice)
 	g.DELETE("/:id", mgr.DeleteResource)
 	g.POST("/:id/networks", mgr.LinkGPUToRDMA)
 	g.GET("/:id/networks", mgr.GetGPUNetworks)
@@ -63,7 +76,47 @@ type (
 		WithVendorDomain bool    `form:"withVendorDomain"`
 		DomainPrefix     *string `form:"domainPrefix" binding:"omitempty,hostname_rfc1123"`
 	}
+
+	ResourceResp struct {
+		ID              uint                      `json:"ID"`
+		Name            string                    `json:"name"`
+		VendorDomain    *string                   `json:"vendorDomain"`
+		ResourceType    string                    `json:"resourceType"`
+		Amount          int64                     `json:"amount"`
+		AmountSingleMax int64                     `json:"amountSingleMax"`
+		Format          string                    `json:"format"`
+		Priority        int                       `json:"priority"`
+		Label           string                    `json:"label"`
+		Type            *model.CraterResourceType `json:"type"`
+		Networks        []*model.Resource         `json:"networks"`
+	}
+
+	ResourceBillingPriceResp struct {
+		ID        uint    `json:"id"`
+		Name      string  `json:"name"`
+		Label     string  `json:"label"`
+		UnitPrice float64 `json:"unitPrice"`
+	}
 )
+
+func buildResourceResp(modelResource *model.Resource) ResourceResp {
+	if modelResource == nil {
+		return ResourceResp{}
+	}
+	return ResourceResp{
+		ID:              modelResource.ID,
+		Name:            modelResource.ResourceName,
+		VendorDomain:    modelResource.VendorDomain,
+		ResourceType:    modelResource.ResourceType,
+		Amount:          modelResource.Amount,
+		AmountSingleMax: modelResource.AmountSingleMax,
+		Format:          modelResource.Format,
+		Priority:        modelResource.Priority,
+		Label:           modelResource.Label,
+		Type:            modelResource.Type,
+		Networks:        modelResource.Networks,
+	}
+}
 
 // ListResource godoc
 //
@@ -96,7 +149,36 @@ func (mgr *ResourceMgr) ListResource(c *gin.Context) {
 		resputil.Error(c, fmt.Sprintf("failed to list resources: %v", err), resputil.NotSpecified)
 		return
 	}
-	resputil.Success(c, resources)
+
+	resp := make([]ResourceResp, 0, len(resources))
+	for i := range resources {
+		resp = append(resp, buildResourceResp(resources[i]))
+	}
+	resputil.Success(c, resp)
+}
+
+func (mgr *ResourceMgr) ListBillingPrices(c *gin.Context) {
+	r := query.Resource
+	resources, err := r.WithContext(c).Order(r.Priority.Desc()).Find()
+	if err != nil {
+		resputil.Error(c, fmt.Sprintf("failed to list billing prices: %v", err), resputil.NotSpecified)
+		return
+	}
+
+	resp := make([]ResourceBillingPriceResp, 0, len(resources))
+	for i := range resources {
+		unitPrice := 0.0
+		if mgr.isBillingUserFacingEnabled(c) {
+			unitPrice = service.ToDisplayPoints(resources[i].UnitPrice)
+		}
+		resp = append(resp, ResourceBillingPriceResp{
+			ID:        resources[i].ID,
+			Name:      resources[i].ResourceName,
+			Label:     resources[i].Label,
+			UnitPrice: unitPrice,
+		})
+	}
+	resputil.Success(c, resp)
 }
 
 type (
@@ -314,6 +396,10 @@ type (
 	ResourcePathReq struct {
 		ID uint `uri:"id" binding:"required"`
 	}
+
+	UpdateResourceUnitPriceReq struct {
+		UnitPrice service.BillingAmountInput `json:"unitPrice"`
+	}
 )
 
 // UpdateResource godoc
@@ -362,6 +448,36 @@ func (mgr *ResourceMgr) UpdateResource(c *gin.Context) {
 	_, err := r.WithContext(c).Where(r.ID.Eq(param.ID)).Updates(updates)
 	if err != nil {
 		resputil.Error(c, fmt.Sprintf("failed to update resource: %v", err), resputil.NotSpecified)
+		return
+	}
+	resputil.Success(c, nil)
+}
+
+func (mgr *ResourceMgr) UpdateResourceUnitPrice(c *gin.Context) {
+	if mgr.billingService == nil || !mgr.isBillingFeatureEnabled(c) {
+		resputil.Error(c, "billing feature is disabled", resputil.BusinessLogicError)
+		return
+	}
+
+	var param ResourcePathReq
+	if err := c.ShouldBindUri(&param); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("failed to bind request: %v", err))
+		return
+	}
+
+	var req UpdateResourceUnitPriceReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("failed to bind request: %v", err))
+		return
+	}
+	unitPrice := req.UnitPrice.MicroPoints()
+	if unitPrice < 0 {
+		resputil.BadRequestError(c, "unitPrice must be >= 0")
+		return
+	}
+
+	if err := mgr.billingService.UpdateResourceUnitPrice(c.Request.Context(), param.ID, unitPrice); err != nil {
+		resputil.Error(c, fmt.Sprintf("failed to update resource unit price: %v", err), resputil.NotSpecified)
 		return
 	}
 	resputil.Success(c, nil)

--- a/backend/internal/handler/system_config.go
+++ b/backend/internal/handler/system_config.go
@@ -1,10 +1,16 @@
 package handler
 
 import (
+	"fmt"
+	"time"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"k8s.io/klog/v2"
 
 	"strings"
 
+	"github.com/raids-lab/crater/dao/query"
 	"github.com/raids-lab/crater/internal/resputil"
 	"github.com/raids-lab/crater/internal/service"
 	"github.com/raids-lab/crater/pkg/cronjob"
@@ -19,6 +25,7 @@ func init() {
 type SystemConfigMgr struct {
 	name           string
 	service        *service.ConfigService
+	billingService *service.BillingService
 	cronjobManager *cronjob.CronJobManager
 	watcher        *prequeuewatcher.PrequeueWatcher
 }
@@ -27,14 +34,17 @@ func NewSystemConfigMgr(conf *RegisterConfig) Manager {
 	return &SystemConfigMgr{
 		name:           "system-config",
 		service:        conf.ConfigService,
+		billingService: conf.BillingService,
 		cronjobManager: conf.CronJobManager,
 		watcher:        conf.PrequeueWatcher,
 	}
 }
 
-func (mgr *SystemConfigMgr) GetName() string                      { return mgr.name }
-func (mgr *SystemConfigMgr) RegisterPublic(_ *gin.RouterGroup)    {}
-func (mgr *SystemConfigMgr) RegisterProtected(_ *gin.RouterGroup) {}
+func (mgr *SystemConfigMgr) GetName() string                   { return mgr.name }
+func (mgr *SystemConfigMgr) RegisterPublic(_ *gin.RouterGroup) {}
+func (mgr *SystemConfigMgr) RegisterProtected(g *gin.RouterGroup) {
+	g.GET("/billing", mgr.GetBillingStatus)
+}
 
 func (mgr *SystemConfigMgr) RegisterAdmin(g *gin.RouterGroup) {
 	// 路由组: /v1/admin/system-config
@@ -47,6 +57,11 @@ func (mgr *SystemConfigMgr) RegisterAdmin(g *gin.RouterGroup) {
 	g.PUT("/gpu-analysis", mgr.SetGpuAnalysisStatus)
 	g.GET("/prequeue", mgr.GetPrequeueConfig)
 	g.PUT("/prequeue", mgr.UpdatePrequeueConfig)
+	g.GET("/billing", mgr.GetBillingStatus)
+	g.PUT("/billing", mgr.SetBillingStatus)
+	g.POST("/billing/reconcile", mgr.TriggerBillingBaseLoop)
+	g.POST("/billing/reset-all", mgr.ResetAllBillingBalances)
+	g.POST("/billing/extra-balance-all", mgr.GrantAllUsersExtraBalance)
 }
 
 // --- DTOs ---
@@ -86,6 +101,50 @@ type UpdatePrequeueConfigReq struct {
 	NormalJobWaitingToleranceSeconds *int64 `json:"normalJobWaitingToleranceSeconds" binding:"required,gt=0"`
 	ActivateTickerIntervalSeconds    *int64 `json:"activateTickerIntervalSeconds" binding:"required,gt=0"`
 	MaxTotalActivationsPerRound      *int64 `json:"maxTotalActivationsPerRound" binding:"required,gt=0"`
+}
+
+type BillingStatusResp struct {
+	FeatureEnabled                    bool    `json:"featureEnabled"`
+	Active                            bool    `json:"active"`
+	RunningSettlementEnabled          bool    `json:"runningSettlementEnabled"`
+	RunningSettlementIntervalMinutes  int     `json:"runningSettlementIntervalMinutes"`
+	JobFreeMinutes                    int     `json:"jobFreeMinutes"`
+	DefaultIssueAmount                float64 `json:"defaultIssueAmount"`
+	DefaultIssuePeriodMinutes         int     `json:"defaultIssuePeriodMinutes"`
+	AccountIssueAmountOverrideEnabled bool    `json:"accountIssueAmountOverrideEnabled"`
+	AccountIssuePeriodOverrideEnabled bool    `json:"accountIssuePeriodOverrideEnabled"`
+	BaseLoopCronStatus                string  `json:"baseLoopCronStatus"`
+	BaseLoopCronEnabled               bool    `json:"baseLoopCronEnabled"`
+}
+
+type SetBillingStatusReq struct {
+	FeatureEnabled                    *bool                       `json:"featureEnabled"`
+	Active                            *bool                       `json:"active"`
+	RunningSettlementEnabled          *bool                       `json:"runningSettlementEnabled"`
+	RunningSettlementIntervalMinutes  *int                        `json:"runningSettlementIntervalMinutes"`
+	JobFreeMinutes                    *int                        `json:"jobFreeMinutes"`
+	DefaultIssueAmount                *service.BillingAmountInput `json:"defaultIssueAmount"`
+	DefaultIssuePeriodMinutes         *int                        `json:"defaultIssuePeriodMinutes"`
+	AccountIssueAmountOverrideEnabled *bool                       `json:"accountIssueAmountOverrideEnabled"`
+	AccountIssuePeriodOverrideEnabled *bool                       `json:"accountIssuePeriodOverrideEnabled"`
+}
+
+type ResetAllBillingBalancesResp struct {
+	AccountsAffected     int       `json:"accountsAffected"`
+	UserAccountsAffected int       `json:"userAccountsAffected"`
+	IssuedAt             time.Time `json:"issuedAt"`
+}
+
+type GrantAllUsersExtraBalanceReq struct {
+	Delta  service.BillingAmountInput `json:"delta" binding:"required"`
+	Reason string                     `json:"reason"`
+}
+
+type GrantAllUsersExtraBalanceResp struct {
+	UsersAffected int       `json:"usersAffected"`
+	Delta         float64   `json:"delta"`
+	Reason        string    `json:"reason"`
+	IssuedAt      time.Time `json:"issuedAt"`
 }
 
 // --- Handlers ---
@@ -286,4 +345,167 @@ func (mgr *SystemConfigMgr) UpdatePrequeueConfig(c *gin.Context) {
 	}
 
 	resputil.Success(c, "Prequeue configuration updated successfully")
+}
+
+func (mgr *SystemConfigMgr) GetBillingStatus(c *gin.Context) {
+	if mgr.billingService == nil {
+		resputil.Error(c, "billing service is not initialized", resputil.ServiceError)
+		return
+	}
+
+	status := mgr.billingService.GetStatus(c.Request.Context())
+	if !status.FeatureEnabled {
+		resputil.Success(c, BillingStatusResp{
+			FeatureEnabled:      false,
+			BaseLoopCronStatus:  status.BaseLoopCronStatus,
+			BaseLoopCronEnabled: status.BaseLoopCronEnabled,
+		})
+		return
+	}
+
+	resputil.Success(c, BillingStatusResp{
+		FeatureEnabled:                    status.FeatureEnabled,
+		Active:                            status.Active,
+		RunningSettlementEnabled:          status.RunningSettlementEnabled,
+		RunningSettlementIntervalMinutes:  status.RunningSettlementIntervalMinutes,
+		JobFreeMinutes:                    status.JobFreeMinutes,
+		DefaultIssueAmount:                status.DefaultIssueAmount,
+		DefaultIssuePeriodMinutes:         status.DefaultIssuePeriodMinutes,
+		AccountIssueAmountOverrideEnabled: status.AccountIssueAmountOverrideEnabled,
+		AccountIssuePeriodOverrideEnabled: status.AccountIssuePeriodOverrideEnabled,
+		BaseLoopCronStatus:                status.BaseLoopCronStatus,
+		BaseLoopCronEnabled:               status.BaseLoopCronEnabled,
+	})
+}
+
+func (mgr *SystemConfigMgr) SetBillingStatus(c *gin.Context) {
+	if mgr.billingService == nil {
+		resputil.Error(c, "billing service is not initialized", resputil.ServiceError)
+		return
+	}
+
+	var req SetBillingStatusReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		resputil.BadRequestError(c, err.Error())
+		return
+	}
+
+	var defaultIssueAmount *int64
+	if req.DefaultIssueAmount != nil {
+		v := req.DefaultIssueAmount.MicroPoints()
+		defaultIssueAmount = &v
+	}
+
+	if err := mgr.billingService.UpdateStatus(c.Request.Context(), service.BillingUpdate{
+		FeatureEnabled:                    req.FeatureEnabled,
+		Active:                            req.Active,
+		RunningSettlementEnabled:          req.RunningSettlementEnabled,
+		RunningSettlementIntervalMinutes:  req.RunningSettlementIntervalMinutes,
+		JobFreeMinutes:                    req.JobFreeMinutes,
+		DefaultIssueAmount:                defaultIssueAmount,
+		DefaultIssuePeriodMinutes:         req.DefaultIssuePeriodMinutes,
+		AccountIssueAmountOverrideEnabled: req.AccountIssueAmountOverrideEnabled,
+		AccountIssuePeriodOverrideEnabled: req.AccountIssuePeriodOverrideEnabled,
+	}); err != nil {
+		resputil.Error(c, err.Error(), resputil.BusinessLogicError)
+		return
+	}
+
+	resputil.Success(c, "Billing configuration updated")
+}
+
+func (mgr *SystemConfigMgr) TriggerBillingBaseLoop(c *gin.Context) {
+	if mgr.billingService == nil {
+		resputil.Error(c, "billing service is not initialized", resputil.ServiceError)
+		return
+	}
+
+	result, err := mgr.billingService.RunBaseLoopOnce(c.Request.Context())
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.ServiceError)
+		return
+	}
+
+	resputil.Success(c, result)
+}
+
+func (mgr *SystemConfigMgr) ResetAllBillingBalances(c *gin.Context) {
+	if mgr.billingService == nil {
+		resputil.Error(c, "billing service is not initialized", resputil.ServiceError)
+		return
+	}
+	if !mgr.billingService.IsFeatureEnabled(c.Request.Context()) {
+		resputil.Error(c, "billing feature is disabled", resputil.BusinessLogicError)
+		return
+	}
+
+	result, err := mgr.billingService.ResetAllPeriodFreeBalances(c.Request.Context())
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.ServiceError)
+		return
+	}
+
+	resputil.Success(c, ResetAllBillingBalancesResp{
+		AccountsAffected:     result.AccountsAffected,
+		UserAccountsAffected: result.UserAccountsAffected,
+		IssuedAt:             result.IssuedAt,
+	})
+}
+
+func (mgr *SystemConfigMgr) GrantAllUsersExtraBalance(c *gin.Context) {
+	var req GrantAllUsersExtraBalanceReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		resputil.BadRequestError(c, err.Error())
+		return
+	}
+
+	delta := req.Delta.MicroPoints()
+	if delta <= 0 {
+		resputil.BadRequestError(c, "delta must be > 0")
+		return
+	}
+
+	issuedAt := time.Now()
+	usersAffected := 0
+	err := query.GetDB().WithContext(c).Transaction(func(tx *gorm.DB) error {
+		txQuery := query.Use(tx)
+		u := txQuery.User
+		users, err := u.WithContext(c).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where(u.DeletedAt.IsNull()).
+			Find()
+		if err != nil {
+			return err
+		}
+
+		for i := range users {
+			user := users[i]
+			after := user.ExtraBalance + delta
+			if _, err := u.WithContext(c).
+				Where(u.ID.Eq(user.ID), u.DeletedAt.IsNull()).
+				Update(u.ExtraBalance, after); err != nil {
+				return err
+			}
+			usersAffected++
+		}
+		return nil
+	})
+	if err != nil {
+		resputil.Error(c, fmt.Sprintf("grant extra balance to all users failed: %v", err), resputil.NotSpecified)
+		return
+	}
+
+	klog.Infof(
+		"grant extra balance to all users success, usersAffected=%d delta=%d reason=%s",
+		usersAffected,
+		delta,
+		req.Reason,
+	)
+
+	resputil.Success(c, GrantAllUsersExtraBalanceResp{
+		UsersAffected: usersAffected,
+		Delta:         service.ToDisplayPoints(delta),
+		Reason:        req.Reason,
+		IssuedAt:      issuedAt,
+	})
 }

--- a/backend/internal/handler/system_config.go
+++ b/backend/internal/handler/system_config.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"fmt"
 	"time"
+
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -6,12 +6,15 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"k8s.io/klog/v2"
 
 	"github.com/raids-lab/crater/dao/model"
 	"github.com/raids-lab/crater/dao/query"
 
 	"github.com/raids-lab/crater/internal/resputil"
+	"github.com/raids-lab/crater/internal/service"
 	"github.com/raids-lab/crater/internal/util"
 	"github.com/raids-lab/crater/pkg/utils"
 )
@@ -22,12 +25,14 @@ func init() {
 }
 
 type UserMgr struct {
-	name string
+	name           string
+	billingService *service.BillingService
 }
 
-func NewUserMgr(_ *RegisterConfig) Manager {
+func NewUserMgr(conf *RegisterConfig) Manager {
 	return &UserMgr{
-		name: "users",
+		name:           "users",
+		billingService: conf.BillingService,
 	}
 }
 
@@ -42,30 +47,61 @@ func (mgr *UserMgr) RegisterProtected(g *gin.RouterGroup) {
 
 func (mgr *UserMgr) RegisterAdmin(g *gin.RouterGroup) {
 	g.GET("", mgr.ListUser)
+	g.GET("/billing/summary", mgr.ListUserBillingSummary)
 	g.GET("/baseinfo", mgr.ListUserBaseInfo)
 	g.DELETE("/:name", mgr.DeleteUser)
 	g.PUT("/:name/role", mgr.UpdateRole)
 	g.PUT("/:name/attributes", mgr.UpdateUserAttributesByAdmin)
+	g.POST("/:name/billing/extra-balance", mgr.AdjustUserExtraBalance)
+	g.GET("/:name/billing/accounts", mgr.GetUserBillingAccounts)
 }
 
 type UserResp struct {
-	ID         uint                                    `json:"id"`         // 用户ID
-	Name       string                                  `json:"name"`       // 用户名称
-	Role       model.Role                              `json:"role"`       // 用户角色
-	Status     model.Status                            `json:"status"`     // 用户状态
-	Attributes datatypes.JSONType[model.UserAttribute] `json:"attributes"` // 用户额外属性
+	ID           uint                                    `json:"id"`           // 用户ID
+	Name         string                                  `json:"name"`         // 用户名称
+	Role         model.Role                              `json:"role"`         // 用户角色
+	Status       model.Status                            `json:"status"`       // 用户状态
+	ExtraBalance float64                                 `json:"extraBalance"` // 用户额外点数
+	Attributes   datatypes.JSONType[model.UserAttribute] `json:"attributes"`   // 用户额外属性
 }
 
 type UserDetailResp struct {
-	ID        uint         `json:"id"`        // 用户ID
-	Name      string       `json:"name"`      // 用户名称
-	Nickname  string       `json:"nickname"`  // 用户昵称
-	Role      model.Role   `json:"role"`      // 用户角色
-	Status    model.Status `json:"status"`    // 用户状态
-	CreatedAt time.Time    `json:"createdAt"` // 创建时间
-	Teacher   *string      `json:"teacher"`   // 导师
-	Group     *string      `json:"group"`     // 课题组
-	Avatar    *string      `json:"avatar"`    // 头像
+	ID           uint         `json:"id"`           // 用户ID
+	Name         string       `json:"name"`         // 用户名称
+	Nickname     string       `json:"nickname"`     // 用户昵称
+	Role         model.Role   `json:"role"`         // 用户角色
+	Status       model.Status `json:"status"`       // 用户状态
+	CreatedAt    time.Time    `json:"createdAt"`    // 创建时间
+	Teacher      *string      `json:"teacher"`      // 导师
+	Group        *string      `json:"group"`        // 课题组
+	Avatar       *string      `json:"avatar"`       // 头像
+	ExtraBalance float64      `json:"extraBalance"` // 用户额外点数
+}
+
+type UserBillingAccountResp struct {
+	AccountID                   uint       `json:"accountId"`
+	AccountName                 string     `json:"accountName"`
+	AccountNickname             string     `json:"accountNickname"`
+	PeriodFreeBalance           float64    `json:"periodFreeBalance"`
+	ExtraBalance                float64    `json:"extraBalance"`
+	TotalAvailable              float64    `json:"totalAvailable"`
+	LastIssuedAt                *time.Time `json:"lastIssuedAt"`
+	NextIssueAt                 *time.Time `json:"nextIssueAt"`
+	EffectiveIssueAmount        float64    `json:"effectiveIssueAmount"`
+	EffectiveIssuePeriodMinutes int        `json:"effectiveIssuePeriodMinutes"`
+}
+
+type UserBillingSummaryResp struct {
+	UserID           uint    `json:"userId"`
+	Username         string  `json:"username"`
+	ExtraBalance     float64 `json:"extraBalance"`
+	PeriodFreeTotal  float64 `json:"periodFreeTotal"`
+	TotalIssueAmount float64 `json:"totalIssueAmount"`
+	TotalAvailable   float64 `json:"totalAvailable"`
+}
+
+func (mgr *UserMgr) isBillingFeatureEnabled(c *gin.Context) bool {
+	return mgr.billingService != nil && mgr.billingService.IsFeatureEnabled(c.Request.Context())
 }
 
 type UpdateRoleReq struct {
@@ -80,6 +116,19 @@ type UserBaseInfoResp struct {
 	Name     string `json:"name"`     // 用户名称
 	Nickname string `json:"nickname"` // 用户昵称
 	Space    string `json:"space"`
+}
+
+type AdjustUserExtraBalanceReq struct {
+	Delta  service.BillingAmountInput `json:"delta" binding:"required"`
+	Reason string                     `json:"reason"`
+}
+
+type AdjustUserExtraBalanceResp struct {
+	UserID        uint    `json:"userId"`
+	Username      string  `json:"username"`
+	BeforeBalance float64 `json:"beforeBalance"`
+	Delta         float64 `json:"delta"`
+	AfterBalance  float64 `json:"afterBalance"`
 }
 
 // DeleteUser godoc
@@ -122,18 +171,112 @@ func (mgr *UserMgr) DeleteUser(c *gin.Context) {
 //	@Failure		500	{object}	resputil.Response[any]	"其他错误"
 //	@Router			/v1/admin/users [get]
 func (mgr *UserMgr) ListUser(c *gin.Context) {
-	var users []UserResp
 	u := query.User
-	err := u.WithContext(c).
-		Select(u.ID, u.Name, u.Role, u.Status, u.Attributes).
+	users, err := u.WithContext(c).
+		Select(u.ID, u.Name, u.Role, u.Status, u.ExtraBalance, u.Attributes).
 		Order(u.ID.Desc()).
-		Scan(&users)
+		Find()
 	if err != nil {
 		resputil.Error(c, fmt.Sprintf("list users failed, detail: %v", err), resputil.NotSpecified)
 		return
 	}
-	klog.Infof("list users success, count: %d", len(users))
-	resputil.Success(c, users)
+	resp := make([]UserResp, 0, len(users))
+	for i := range users {
+		extraBalance := 0.0
+		if mgr.isBillingFeatureEnabled(c) {
+			extraBalance = service.ToDisplayPoints(users[i].ExtraBalance)
+		}
+		resp = append(resp, UserResp{
+			ID:           users[i].ID,
+			Name:         users[i].Name,
+			Role:         users[i].Role,
+			Status:       users[i].Status,
+			ExtraBalance: extraBalance,
+			Attributes:   users[i].Attributes,
+		})
+	}
+	klog.Infof("list users success, count: %d", len(resp))
+	resputil.Success(c, resp)
+}
+
+func (mgr *UserMgr) ListUserBillingSummary(c *gin.Context) {
+	if !mgr.isBillingFeatureEnabled(c) {
+		resputil.Success(c, []UserBillingSummaryResp{})
+		return
+	}
+
+	u := query.User
+	ua := query.UserAccount
+	a := query.Account
+
+	users, err := u.WithContext(c).
+		Where(u.DeletedAt.IsNull()).
+		Order(u.ID.Desc()).
+		Select(u.ID, u.Name, u.ExtraBalance).
+		Find()
+	if err != nil {
+		resputil.Error(c, fmt.Sprintf("list user billing summary failed, detail: %v", err), resputil.NotSpecified)
+		return
+	}
+
+	userAccounts, err := ua.WithContext(c).
+		Where(ua.DeletedAt.IsNull()).
+		Select(ua.UserID, ua.AccountID, ua.BillingIssueAmountOverride, ua.PeriodFreeBalance).
+		Find()
+	if err != nil {
+		resputil.Error(c, fmt.Sprintf("list user billing summary failed, detail: %v", err), resputil.NotSpecified)
+		return
+	}
+
+	accountIDs := make([]uint, 0, len(userAccounts))
+	for i := range userAccounts {
+		accountIDs = append(accountIDs, userAccounts[i].AccountID)
+	}
+
+	accountsByID := make(map[uint]*model.Account, len(accountIDs))
+	if len(accountIDs) > 0 {
+		accounts, err := a.WithContext(c).
+			Where(a.ID.In(accountIDs...), a.DeletedAt.IsNull()).
+			Find()
+		if err != nil {
+			resputil.Error(c, fmt.Sprintf("list user billing summary failed, detail: %v", err), resputil.NotSpecified)
+			return
+		}
+		for i := range accounts {
+			account := accounts[i]
+			accountsByID[account.ID] = account
+		}
+	}
+
+	periodFreeByUserID := make(map[uint]int64, len(userAccounts))
+	totalIssueByUserID := make(map[uint]int64, len(userAccounts))
+	for i := range userAccounts {
+		userAccount := userAccounts[i]
+		periodFreeByUserID[userAccount.UserID] += userAccount.PeriodFreeBalance
+		if account := accountsByID[userAccount.AccountID]; account != nil {
+			issueAmount, _ := mgr.billingService.ResolveEffectiveIssueConfigForUserAccount(
+				c.Request.Context(),
+				userAccount,
+				account,
+			)
+			totalIssueByUserID[userAccount.UserID] += issueAmount
+		}
+	}
+
+	resp := make([]UserBillingSummaryResp, 0, len(users))
+	for i := range users {
+		user := users[i]
+		periodFreeTotal := periodFreeByUserID[user.ID]
+		resp = append(resp, UserBillingSummaryResp{
+			UserID:           user.ID,
+			Username:         user.Name,
+			ExtraBalance:     service.ToDisplayPoints(user.ExtraBalance),
+			PeriodFreeTotal:  service.ToDisplayPoints(periodFreeTotal),
+			TotalIssueAmount: service.ToDisplayPoints(totalIssueByUserID[user.ID]),
+			TotalAvailable:   service.ToDisplayPoints(user.ExtraBalance + periodFreeTotal),
+		})
+	}
+	resputil.Success(c, resp)
 }
 
 // ListUserBaseInfo godoc
@@ -177,6 +320,7 @@ func (mgr *UserMgr) ListUserBaseInfo(c *gin.Context) {
 //	@Router			/v1/users/{name} [get]
 func (mgr *UserMgr) GetUser(c *gin.Context) {
 	name := c.Param("name")
+	token := util.GetToken(c)
 	u := query.User
 	user, err := u.WithContext(c).
 		Where(u.Name.Eq(name)).
@@ -189,12 +333,16 @@ func (mgr *UserMgr) GetUser(c *gin.Context) {
 
 	// 创建用户详情响应对象
 	userResp := UserDetailResp{
-		ID:        user.ID,
-		Name:      user.Name,
-		Nickname:  user.Nickname,
-		Role:      user.Role,
-		Status:    user.Status,
-		CreatedAt: user.CreatedAt,
+		ID:           user.ID,
+		Name:         user.Name,
+		Nickname:     user.Nickname,
+		Role:         user.Role,
+		Status:       user.Status,
+		CreatedAt:    user.CreatedAt,
+		ExtraBalance: service.ToDisplayPoints(user.ExtraBalance),
+	}
+	if !mgr.isBillingFeatureEnabled(c) || !canViewUserExtraBalance(token, user) {
+		userResp.ExtraBalance = 0
 	}
 
 	// 从 Attributes 中获取需要的字段
@@ -205,6 +353,13 @@ func (mgr *UserMgr) GetUser(c *gin.Context) {
 
 	klog.Infof("get user success, username: %s", name)
 	resputil.Success(c, userResp)
+}
+
+func canViewUserExtraBalance(token util.JWTMessage, user *model.User) bool {
+	if user == nil {
+		return false
+	}
+	return token.RolePlatform == model.RoleAdmin || token.UserID == user.ID
 }
 
 // UpdateRole godoc
@@ -328,4 +483,160 @@ func (mgr *UserMgr) UpdateUserAttributesByAdmin(c *gin.Context) {
 
 	klog.Infof("update user attributes success by admin, username: %s", name)
 	resputil.Success(c, "用户属性更新成功")
+}
+
+// AdjustUserExtraBalance godoc
+//
+//	@Summary		调整用户额外点数
+//	@Description	管理员按增量调整用户 extraBalance（可正可负），使用行锁避免并发覆盖
+//	@Tags			User
+//	@Accept			json
+//	@Produce		json
+//	@Security		Bearer
+//	@Param			name	path		string									true	"username"
+//	@Param			body	body		AdjustUserExtraBalanceReq				true	"增量与原因"
+//	@Success		200		{object}	resputil.Response[AdjustUserExtraBalanceResp]	"调整成功"
+//	@Failure		400		{object}	resputil.Response[any]					"请求参数错误"
+//	@Failure		500		{object}	resputil.Response[any]					"其他错误"
+//	@Router			/v1/admin/users/{name}/billing/extra-balance [post]
+func (mgr *UserMgr) AdjustUserExtraBalance(c *gin.Context) {
+	var (
+		nameReq UserNameReq
+		req     AdjustUserExtraBalanceReq
+		resp    AdjustUserExtraBalanceResp
+	)
+	if err := c.ShouldBindUri(&nameReq); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("invalid uri params: %v", err))
+		return
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("invalid request body: %v", err))
+		return
+	}
+
+	err := query.GetDB().WithContext(c).Transaction(func(tx *gorm.DB) error {
+		txQuery := query.Use(tx)
+		u := txQuery.User
+		user, err := u.WithContext(c).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where(u.Name.Eq(nameReq.Name), u.DeletedAt.IsNull()).
+			First()
+		if err != nil {
+			return err
+		}
+
+		before := user.ExtraBalance
+		delta := req.Delta.MicroPoints()
+		after := before + delta
+		if after < 0 {
+			return fmt.Errorf("extraBalance would be negative: before=%d delta=%d", before, delta)
+		}
+		if _, err := u.WithContext(c).
+			Where(u.ID.Eq(user.ID), u.DeletedAt.IsNull()).
+			Update(u.ExtraBalance, after); err != nil {
+			return err
+		}
+		resp = AdjustUserExtraBalanceResp{
+			UserID:        user.ID,
+			Username:      user.Name,
+			BeforeBalance: service.ToDisplayPoints(before),
+			Delta:         service.ToDisplayPoints(delta),
+			AfterBalance:  service.ToDisplayPoints(after),
+		}
+		return nil
+	})
+	if err != nil {
+		resputil.Error(c, fmt.Sprintf("adjust user extra balance failed: %v", err), resputil.NotSpecified)
+		return
+	}
+
+	klog.Infof(
+		"adjust user extra balance success, user=%s delta=%.2f before=%.2f after=%.2f reason=%s",
+		resp.Username,
+		resp.Delta,
+		resp.BeforeBalance,
+		resp.AfterBalance,
+		req.Reason,
+	)
+	resputil.Success(c, resp)
+}
+
+func (mgr *UserMgr) GetUserBillingAccounts(c *gin.Context) {
+	if !mgr.isBillingFeatureEnabled(c) {
+		resputil.Success(c, []UserBillingAccountResp{})
+		return
+	}
+	var nameReq UserNameReq
+	if err := c.ShouldBindUri(&nameReq); err != nil {
+		resputil.BadRequestError(c, fmt.Sprintf("invalid uri params: %v", err))
+		return
+	}
+
+	u := query.User
+	user, err := u.WithContext(c).
+		Where(u.Name.Eq(nameReq.Name), u.DeletedAt.IsNull()).
+		First()
+	if err != nil {
+		resputil.Error(c, fmt.Sprintf("failed to load user: %v", err), resputil.NotSpecified)
+		return
+	}
+
+	ua := query.UserAccount
+	a := query.Account
+	userAccounts, err := ua.WithContext(c).
+		Where(ua.UserID.Eq(user.ID), ua.DeletedAt.IsNull()).
+		Order(ua.AccountID).
+		Find()
+	if err != nil {
+		resputil.Error(c, fmt.Sprintf("failed to query user billing accounts: %v", err), resputil.NotSpecified)
+		return
+	}
+
+	accountIDs := make([]uint, 0, len(userAccounts))
+	for i := range userAccounts {
+		accountIDs = append(accountIDs, userAccounts[i].AccountID)
+	}
+
+	accountsByID := make(map[uint]*model.Account, len(accountIDs))
+	if len(accountIDs) > 0 {
+		accounts, err := a.WithContext(c).
+			Where(a.ID.In(accountIDs...), a.DeletedAt.IsNull()).
+			Find()
+		if err != nil {
+			resputil.Error(c, fmt.Sprintf("failed to query user billing accounts: %v", err), resputil.NotSpecified)
+			return
+		}
+		for i := range accounts {
+			accountsByID[accounts[i].ID] = accounts[i]
+		}
+	}
+
+	resp := make([]UserBillingAccountResp, 0, len(userAccounts))
+	for i := range userAccounts {
+		row := userAccounts[i]
+		account := accountsByID[row.AccountID]
+		if account == nil {
+			continue
+		}
+		issueAmount, issuePeriod := mgr.billingService.ResolveEffectiveIssueConfigForUserAccount(
+			c.Request.Context(),
+			row,
+			account,
+		)
+		nextIssueAt := mgr.billingService.ComputeNextIssueAt(account.BillingLastIssuedAt, issuePeriod, time.Now())
+		resp = append(resp, UserBillingAccountResp{
+			AccountID:                   account.ID,
+			AccountName:                 account.Name,
+			AccountNickname:             account.Nickname,
+			PeriodFreeBalance:           service.ToDisplayPoints(row.PeriodFreeBalance),
+			ExtraBalance:                service.ToDisplayPoints(user.ExtraBalance),
+			TotalAvailable:              service.ToDisplayPoints(row.PeriodFreeBalance + user.ExtraBalance),
+			LastIssuedAt:                account.BillingLastIssuedAt,
+			NextIssueAt:                 nextIssueAt,
+			EffectiveIssueAmount:        service.ToDisplayPoints(issueAmount),
+			EffectiveIssuePeriodMinutes: issuePeriod,
+		})
+	}
+
+	resputil.Success(c, resp)
 }

--- a/backend/internal/handler/user_test.go
+++ b/backend/internal/handler/user_test.go
@@ -1,0 +1,103 @@
+package handler
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+
+	"github.com/raids-lab/crater/dao/model"
+	"github.com/raids-lab/crater/internal/util"
+)
+
+func TestShouldIssueInitialAccountBalance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		featureEnabled bool
+		active         bool
+		adminCount     int
+		want           bool
+	}{
+		{
+			name:           "issues only when feature is active and admins exist",
+			featureEnabled: true,
+			active:         true,
+			adminCount:     1,
+			want:           true,
+		},
+		{
+			name:           "skips before activation",
+			featureEnabled: true,
+			active:         false,
+			adminCount:     1,
+			want:           false,
+		},
+		{
+			name:           "skips without admins",
+			featureEnabled: true,
+			active:         true,
+			adminCount:     0,
+			want:           false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := shouldIssueInitialAccountBalance(tc.featureEnabled, tc.active, tc.adminCount)
+			if got != tc.want {
+				t.Fatalf("shouldIssueInitialAccountBalance() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanViewUserExtraBalance(t *testing.T) {
+	t.Parallel()
+
+	target := &model.User{Model: gorm.Model{ID: 42}}
+	tests := []struct {
+		name  string
+		token util.JWTMessage
+		user  *model.User
+		want  bool
+	}{
+		{
+			name:  "allows self",
+			token: util.JWTMessage{UserID: 42, RolePlatform: model.RoleUser},
+			user:  target,
+			want:  true,
+		},
+		{
+			name:  "allows platform admin",
+			token: util.JWTMessage{UserID: 7, RolePlatform: model.RoleAdmin},
+			user:  target,
+			want:  true,
+		},
+		{
+			name:  "blocks other regular users",
+			token: util.JWTMessage{UserID: 7, RolePlatform: model.RoleUser},
+			user:  target,
+			want:  false,
+		},
+		{
+			name:  "blocks nil target user",
+			token: util.JWTMessage{UserID: 42, RolePlatform: model.RoleAdmin},
+			user:  nil,
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := canViewUserExtraBalance(tc.token, tc.user)
+			if got != tc.want {
+				t.Fatalf("canViewUserExtraBalance() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/vcjob/custom.go
+++ b/backend/internal/handler/vcjob/custom.go
@@ -62,7 +62,11 @@ func (mgr *VolcanojobMgr) CreateTrainingJob(c *gin.Context) {
 		return
 	}
 
-	exceededResources := aitaskctl.CheckResourcesBeforeCreateJob(c, token.UserID, token.AccountID)
+	exceededResources, err := aitaskctl.CheckResourcesBeforeCreateJob(c, token.UserID, token.AccountID)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.ServiceError)
+		return
+	}
 	if len(exceededResources) > 0 {
 		resputil.Error(c, fmt.Sprintf("%v", exceededResources), resputil.NotSpecified)
 		return

--- a/backend/internal/handler/vcjob/jupyter.go
+++ b/backend/internal/handler/vcjob/jupyter.go
@@ -76,7 +76,11 @@ func (mgr *VolcanojobMgr) CreateJupyterJob(c *gin.Context) {
 		resputil.Error(c, err.Error(), resputil.ServiceError)
 		return
 	}
-	exceededResources := aitaskctl.CheckResourcesBeforeCreateJob(c, token.UserID, token.AccountID)
+	exceededResources, err := aitaskctl.CheckResourcesBeforeCreateJob(c, token.UserID, token.AccountID)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.ServiceError)
+		return
+	}
 	if len(exceededResources) > 0 {
 		resputil.Error(c, fmt.Sprintf("%v", exceededResources), resputil.ServiceError)
 		return

--- a/backend/internal/handler/vcjob/lifecycle.go
+++ b/backend/internal/handler/vcjob/lifecycle.go
@@ -20,6 +20,12 @@ func (mgr *VolcanojobMgr) submitJob(
 	token util.JWTMessage,
 	job *batch.Job,
 ) error {
+	if mgr.billingService != nil {
+		if err := mgr.billingService.OnJobCreateCheck(ctx, token.UserID, token.AccountID); err != nil {
+			return err
+		}
+	}
+
 	scheduleTypeInt, err := strconv.ParseInt(
 		job.Annotations[vcjobservice.AnnotationKeyScheduleType], 10, 64,
 	)

--- a/backend/internal/handler/vcjob/pytorch.go
+++ b/backend/internal/handler/vcjob/pytorch.go
@@ -42,7 +42,11 @@ func (mgr *VolcanojobMgr) CreatePytorchJob(c *gin.Context) {
 	for i := range len(req.Tasks) {
 		jobResources = aitaskctl.AddResourceList(jobResources, req.Tasks[i].Resource)
 	}
-	exceededResources := aitaskctl.CheckResourcesBeforeCreateJob(c, token.UserID, token.AccountID)
+	exceededResources, err := aitaskctl.CheckResourcesBeforeCreateJob(c, token.UserID, token.AccountID)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.ServiceError)
+		return
+	}
 	if len(exceededResources) > 0 {
 		resputil.Error(c, fmt.Sprintf("%v", exceededResources), resputil.NotSpecified)
 		return

--- a/backend/internal/handler/vcjob/tensorflow.go
+++ b/backend/internal/handler/vcjob/tensorflow.go
@@ -54,6 +54,8 @@ type (
 //	@Failure		400					{object}	resputil.Response[any]	"Request parameter error"
 //	@Failure		500					{object}	resputil.Response[any]	"Other errors"
 //	@Router			/v1/vcjobs/tensorflow [post]
+//
+//nolint:gocyclo // TODO
 func (mgr *VolcanojobMgr) CreateTensorflowJob(c *gin.Context) {
 	token := util.GetToken(c)
 
@@ -77,7 +79,11 @@ func (mgr *VolcanojobMgr) CreateTensorflowJob(c *gin.Context) {
 	for i := range len(req.Tasks) {
 		jobResources = aitaskctl.AddResourceList(jobResources, req.Tasks[i].Resource)
 	}
-	exceededResources := aitaskctl.CheckResourcesBeforeCreateJob(c, token.UserID, token.AccountID)
+	exceededResources, err := aitaskctl.CheckResourcesBeforeCreateJob(c, token.UserID, token.AccountID)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.ServiceError)
+		return
+	}
 	if len(exceededResources) > 0 {
 		resputil.Error(c, fmt.Sprintf("%v", exceededResources), resputil.NotSpecified)
 		return

--- a/backend/internal/handler/vcjob/vcjob.go
+++ b/backend/internal/handler/vcjob/vcjob.go
@@ -53,6 +53,7 @@ type VolcanojobMgr struct {
 	serviceManager  crclient.ServiceManagerInterface
 	configService   *service.ConfigService
 	queueQuotaSvc   *service.PrequeueService
+	billingService  *service.BillingService
 	prequeueWatcher *prequeuewatcher.PrequeueWatcher
 }
 
@@ -67,6 +68,7 @@ func NewVolcanojobMgr(conf *handler.RegisterConfig) handler.Manager {
 		serviceManager:  conf.ServiceManager,
 		configService:   conf.ConfigService,
 		queueQuotaSvc:   conf.PrequeueService,
+		billingService:  conf.BillingService,
 		prequeueWatcher: conf.PrequeueWatcher,
 	}
 }
@@ -79,9 +81,13 @@ func (mgr *VolcanojobMgr) RegisterProtected(g *gin.RouterGroup) {
 	g.GET("", mgr.GetSelfJobs)
 	g.GET("all", mgr.GetAllJobsInDays)
 	g.GET("user/:username", mgr.GetUserJobsInDays)
+	g.GET("billing", mgr.GetSelfJobBilling)
+	g.GET("billing/all", mgr.GetAllJobBillingInDays)
+	g.GET("billing/user/:username", mgr.GetUserJobBillingInDays)
 	g.DELETE(":name", mgr.DeleteJob)
 
 	g.GET(":name/detail", mgr.GetJobDetail)
+	g.GET(":name/billing", mgr.GetJobBillingDetail)
 	g.GET(":name/yaml", mgr.GetJobYaml)
 	g.GET(":name/pods", mgr.GetJobPods)
 	g.GET(":name/template", mgr.GetJobTemplate)
@@ -115,6 +121,9 @@ func (mgr *VolcanojobMgr) RegisterProtected(g *gin.RouterGroup) {
 func (mgr *VolcanojobMgr) RegisterAdmin(g *gin.RouterGroup) {
 	g.GET("", mgr.GetAllJobsInDays)
 	g.GET("user/:username", mgr.GetUserJobsInDays)
+	g.GET("billing", mgr.GetAllJobBillingInDays)
+	g.GET("billing/user/:username", mgr.GetUserJobBillingInDays)
+	g.GET(":name/billing", mgr.GetJobBillingDetail)
 	// delete job
 	g.DELETE(":name", mgr.AdminDeleteJob)
 }
@@ -366,15 +375,56 @@ func (mgr *VolcanojobMgr) buildDeleteJobPlan(c *gin.Context, jobRecord *model.Jo
 func (mgr *VolcanojobMgr) applyDeleteJobPlan(c *gin.Context, jobName string, plan *deleteJobPlan) error {
 	j := query.Job
 	if plan.shouldDeleteRecord {
-		_, err := j.WithContext(c).Where(j.JobName.Eq(jobName)).Delete()
+		record, err := j.WithContext(c).Where(j.JobName.Eq(jobName)).First()
+		if err != nil {
+			return err
+		}
+		if err := mgr.settleJobBeforeDelete(c, record, plan.clusterJob); err != nil {
+			return err
+		}
+		_, err = j.WithContext(c).Where(j.JobName.Eq(jobName)).Delete()
 		return err
+	}
+
+	completedAt := time.Now()
+	if mgr.billingService != nil {
+		record, err := j.WithContext(c).Where(j.JobName.Eq(jobName)).First()
+		if err != nil {
+			return err
+		}
+		finalJob := *record
+		finalJob.Status = model.Deleted
+		finalJob.CompletedTimestamp = completedAt
+		if err := mgr.billingService.OnJobFinishedSettlement(c.Request.Context(), &finalJob); err != nil {
+			return err
+		}
 	}
 
 	_, err := j.WithContext(c).Where(j.JobName.Eq(jobName)).Updates(model.Job{
 		Status:             model.Deleted,
-		CompletedTimestamp: time.Now(),
+		CompletedTimestamp: completedAt,
 	})
 	return err
+}
+
+func (mgr *VolcanojobMgr) settleJobBeforeDelete(c *gin.Context, record *model.Job, job *batch.Job) error {
+	if mgr.billingService == nil || record == nil {
+		return nil
+	}
+
+	finalJob := *record
+	finalJob.CompletedTimestamp = resolveDeleteSettlementTime(record, job)
+	return mgr.billingService.OnJobFinishedSettlement(c.Request.Context(), &finalJob)
+}
+
+func resolveDeleteSettlementTime(record *model.Job, job *batch.Job) time.Time {
+	if record != nil && !record.CompletedTimestamp.IsZero() {
+		return record.CompletedTimestamp
+	}
+	if job != nil && !job.Status.State.LastTransitionTime.IsZero() {
+		return job.Status.State.LastTransitionTime.Time
+	}
+	return time.Now()
 }
 
 func (mgr *VolcanojobMgr) deleteClusterJob(c *gin.Context, plan *deleteJobPlan) error {
@@ -498,6 +548,12 @@ type (
 		Locked                  bool               `json:"locked"`
 		PermanentLocked         bool               `json:"permanentLocked"`
 		LockedTimestamp         metav1.Time        `json:"lockedTimestamp"`
+	}
+
+	JobBillingResp struct {
+		JobName           string  `json:"jobName"`
+		Name              string  `json:"name"`
+		BilledPointsTotal float64 `json:"billedPointsTotal"`
 	}
 )
 
@@ -654,6 +710,114 @@ func (mgr *VolcanojobMgr) GetUserJobsInDays(c *gin.Context) {
 
 	jobList := convertJobResp(jobs)
 	resputil.Success(c, jobList)
+}
+
+func convertJobBillingResp(jobs []*model.Job) []JobBillingResp {
+	jobList := make([]JobBillingResp, len(jobs))
+	for i := range jobs {
+		jobList[i] = JobBillingResp{
+			JobName:           jobs[i].JobName,
+			Name:              jobs[i].Name,
+			BilledPointsTotal: service.ToDisplayPoints(jobs[i].BilledPointsTotal),
+		}
+	}
+	return jobList
+}
+
+func (mgr *VolcanojobMgr) GetSelfJobBilling(c *gin.Context) {
+	if mgr.billingService == nil || !mgr.billingService.IsUserFacingEnabled(c.Request.Context()) {
+		resputil.Success(c, []JobBillingResp{})
+		return
+	}
+
+	token := util.GetToken(c)
+	j := query.Job
+	jobs, err := j.WithContext(c).
+		Where(j.UserID.Eq(token.UserID), j.AccountID.Eq(token.AccountID)).
+		Find()
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+
+	resputil.Success(c, convertJobBillingResp(jobs))
+}
+
+func (mgr *VolcanojobMgr) GetAllJobBillingInDays(c *gin.Context) {
+	type QueryParams struct {
+		Days int `form:"days"`
+	}
+
+	var req QueryParams
+	if err := c.ShouldBindQuery(&req); err != nil {
+		resputil.BadRequestError(c, err.Error())
+		return
+	}
+
+	days := 7
+	if req.Days > 0 {
+		days = req.Days
+	}
+
+	j := query.Job
+	q := j.WithContext(c)
+	if req.Days != -1 {
+		now := time.Now()
+		lookbackPeriod := now.AddDate(0, 0, -days)
+		q = q.Where(j.CreatedAt.Gte(lookbackPeriod))
+	}
+	jobs, err := q.Find()
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+
+	resputil.Success(c, convertJobBillingResp(jobs))
+}
+
+func (mgr *VolcanojobMgr) GetUserJobBillingInDays(c *gin.Context) {
+	username := c.Param("username")
+	if username == "" {
+		resputil.BadRequestError(c, "username is required")
+		return
+	}
+
+	type QueryParams struct {
+		Days int `form:"days"`
+	}
+
+	var req QueryParams
+	if err := c.ShouldBindQuery(&req); err != nil {
+		resputil.BadRequestError(c, err.Error())
+		return
+	}
+
+	days := 30
+	if req.Days > 0 {
+		days = req.Days
+	}
+
+	u := query.User
+	targetUser, err := u.WithContext(c).Where(u.Name.Eq(username)).First()
+	if err != nil {
+		resputil.Error(c, "User not found", resputil.NotSpecified)
+		return
+	}
+
+	j := query.Job
+	q := j.WithContext(c).Where(j.UserID.Eq(targetUser.ID))
+	if req.Days != -1 {
+		now := time.Now()
+		lookbackPeriod := now.AddDate(0, 0, -days)
+		q = q.Where(j.CreatedAt.Gte(lookbackPeriod))
+	}
+	jobs, err := q.Find()
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+
+	resputil.Success(c, convertJobBillingResp(jobs))
 }
 
 func convertJobResp(jobs []*model.Job) []JobResp {
@@ -1211,4 +1375,30 @@ func (mgr *VolcanojobMgr) ToggleAlertState(c *gin.Context) {
 	}
 	message := fmt.Sprintf("Set %s AlertEnabled to %t", req.JobName, !preStatus)
 	resputil.Success(c, message)
+}
+
+func (mgr *VolcanojobMgr) GetJobBillingDetail(c *gin.Context) {
+	if mgr.billingService == nil || !mgr.billingService.IsFeatureEnabled(c.Request.Context()) {
+		resputil.Success(c, JobBillingResp{})
+		return
+	}
+
+	var req JobActionReq
+	if err := c.ShouldBindUri(&req); err != nil {
+		resputil.BadRequestError(c, err.Error())
+		return
+	}
+
+	token := util.GetToken(c)
+	job, err := getJob(c, req.JobName, &token)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		return
+	}
+
+	resputil.Success(c, JobBillingResp{
+		JobName:           job.JobName,
+		Name:              job.Name,
+		BilledPointsTotal: service.ToDisplayPoints(job.BilledPointsTotal),
+	})
 }

--- a/backend/internal/handler/vcjob/vcjob_test.go
+++ b/backend/internal/handler/vcjob/vcjob_test.go
@@ -1,0 +1,63 @@
+package vcjob
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+
+	"github.com/raids-lab/crater/dao/model"
+)
+
+func TestResolveDeleteSettlementTime(t *testing.T) {
+	t.Parallel()
+
+	recordCompletedAt := time.Date(2026, 4, 15, 9, 30, 0, 0, time.UTC)
+	jobTransitionAt := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		record *model.Job
+		job    *batch.Job
+		check  func(time.Time) bool
+	}{
+		{
+			name:   "prefers record completed timestamp",
+			record: &model.Job{CompletedTimestamp: recordCompletedAt},
+			job: &batch.Job{Status: batch.JobStatus{
+				State: batch.JobState{LastTransitionTime: metav1.NewTime(jobTransitionAt)},
+			}},
+			check: func(got time.Time) bool {
+				return got.Equal(recordCompletedAt)
+			},
+		},
+		{
+			name:   "falls back to job transition timestamp",
+			record: &model.Job{},
+			job: &batch.Job{Status: batch.JobStatus{
+				State: batch.JobState{LastTransitionTime: metav1.NewTime(jobTransitionAt)},
+			}},
+			check: func(got time.Time) bool {
+				return got.Equal(jobTransitionAt)
+			},
+		},
+		{
+			name: "falls back to current time when timestamps missing",
+			check: func(got time.Time) bool {
+				return !got.IsZero()
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveDeleteSettlementTime(tc.record, tc.job)
+			if !tc.check(got) {
+				t.Fatalf("resolveDeleteSettlementTime() = %v", got)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/vcjob/webide.go
+++ b/backend/internal/handler/vcjob/webide.go
@@ -62,7 +62,11 @@ func (mgr *VolcanojobMgr) CreateWebIDEJob(c *gin.Context) {
 		return
 	}
 
-	exceededResources := aitaskctl.CheckResourcesBeforeCreateJob(c, token.UserID, token.AccountID)
+	exceededResources, err := aitaskctl.CheckResourcesBeforeCreateJob(c, token.UserID, token.AccountID)
+	if err != nil {
+		resputil.Error(c, err.Error(), resputil.ServiceError)
+		return
+	}
 	if len(exceededResources) > 0 {
 		resputil.Error(c, fmt.Sprintf("%v", exceededResources), resputil.ServiceError)
 		return

--- a/backend/internal/service/billing_amount.go
+++ b/backend/internal/service/billing_amount.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	// BillingPointScale stores 1 point as 1,000,000 internal units.
+	BillingPointScale int64 = 1_000_000
+	// LegacyBillingMilliPointScale stores the previous milli-point precision.
+	LegacyBillingMilliPointScale int64 = 1_000
+	billingAmountDecimals              = 2
+	displayPointsDivisor               = 100
+	billingCentScale                   = BillingPointScale / displayPointsDivisor
+)
+
+type BillingAmountInput int64
+
+func (a *BillingAmountInput) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+
+	var raw string
+	if trimmed[0] == '"' {
+		if err := json.Unmarshal(trimmed, &raw); err != nil {
+			return err
+		}
+	} else {
+		raw = string(trimmed)
+	}
+
+	parsed, err := ParseBillingAmountString(raw)
+	if err != nil {
+		return err
+	}
+	*a = BillingAmountInput(parsed)
+	return nil
+}
+
+func (a BillingAmountInput) MicroPoints() int64 {
+	return int64(a)
+}
+
+func BillingWholePoints(points int64) int64 {
+	return points * BillingPointScale
+}
+
+func ParseBillingAmountString(raw string) (int64, error) {
+	trimmed, sign, err := trimSignedBillingAmount(raw)
+	if err != nil {
+		return 0, err
+	}
+
+	wholePart, fractionPart, err := splitBillingAmountParts(raw, trimmed)
+	if err != nil {
+		return 0, err
+	}
+
+	whole, err := parseBillingWholePart(raw, wholePart)
+	if err != nil {
+		return 0, err
+	}
+	fraction, err := parseBillingFraction(raw, fractionPart)
+	if err != nil {
+		return 0, err
+	}
+
+	return combineBillingAmount(raw, sign, whole, fraction)
+}
+
+func trimSignedBillingAmount(raw string) (trimmed string, sign int64, err error) {
+	trimmed = strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", 0, errors.New("billing amount is empty")
+	}
+
+	sign = 1
+	if trimmed[0] == '+' || trimmed[0] == '-' {
+		if trimmed[0] == '-' {
+			sign = -1
+		}
+		trimmed = trimmed[1:]
+	}
+	if trimmed == "" {
+		return "", 0, errors.New("billing amount is empty")
+	}
+
+	return trimmed, sign, nil
+}
+
+func splitBillingAmountParts(raw, trimmed string) (wholePart, fractionPart string, err error) {
+	wholePart, fractionPart, hasDot := strings.Cut(trimmed, ".")
+	if hasDot && strings.Contains(fractionPart, ".") {
+		return "", "", fmt.Errorf("invalid billing amount %q", raw)
+	}
+	if wholePart == "" {
+		wholePart = "0"
+	}
+	return wholePart, fractionPart, nil
+}
+
+func parseBillingWholePart(raw, wholePart string) (int64, error) {
+	whole, err := strconv.ParseInt(wholePart, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid billing amount %q", raw)
+	}
+	return whole, nil
+}
+
+func parseBillingFraction(raw, fractionPart string) (int64, error) {
+	if len(fractionPart) > billingAmountDecimals {
+		return 0, fmt.Errorf("billing amount %q supports at most %d decimal places", raw, billingAmountDecimals)
+	}
+	for _, ch := range fractionPart {
+		if ch < '0' || ch > '9' {
+			return 0, fmt.Errorf("invalid billing amount %q", raw)
+		}
+	}
+	for len(fractionPart) < billingAmountDecimals {
+		fractionPart += "0"
+	}
+	if fractionPart == "" {
+		return 0, nil
+	}
+
+	fraction, err := strconv.ParseInt(fractionPart, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid billing amount %q", raw)
+	}
+	return fraction, nil
+}
+
+func combineBillingAmount(raw string, sign, whole, fraction int64) (int64, error) {
+	total := new(big.Int).Mul(big.NewInt(whole), big.NewInt(BillingPointScale))
+	total.Add(total, big.NewInt(fraction*billingCentScale))
+	if sign < 0 {
+		total.Neg(total)
+	}
+	if !total.IsInt64() {
+		return 0, fmt.Errorf("billing amount %q overflows int64", raw)
+	}
+	return total.Int64(), nil
+}
+
+func FormatBillingAmountConfigValue(amount int64) string {
+	return strconv.FormatInt(amount, 10)
+}
+
+func ParseBillingAmountConfigValue(raw string, def int64) int64 {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return def
+	}
+	parsed, err := strconv.ParseInt(trimmed, 10, 64)
+	if err != nil {
+		return def
+	}
+	return parsed
+}
+
+func roundBillingMicroToCents(v int64) int64 {
+	if v >= 0 {
+		return (v + billingCentScale/2) / billingCentScale
+	}
+	return (v - billingCentScale/2) / billingCentScale
+}
+
+func ToDisplayPoints(totalMicro int64) float64 {
+	if totalMicro == 0 {
+		return 0
+	}
+	return float64(roundBillingMicroToCents(totalMicro)) / displayPointsDivisor
+}
+
+func quantityToRat(q resource.Quantity) (*big.Rat, error) {
+	r, ok := new(big.Rat).SetString(q.AsDec().String())
+	if !ok {
+		return nil, fmt.Errorf("failed to parse quantity %q", q.String())
+	}
+	return r, nil
+}
+
+func ratFloorToInt64(r *big.Rat) int64 {
+	if r == nil || r.Sign() <= 0 {
+		return 0
+	}
+	n := new(big.Int).Quo(r.Num(), r.Denom())
+	if !n.IsInt64() {
+		return math.MaxInt64
+	}
+	return n.Int64()
+}

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -1,0 +1,1411 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"strconv"
+	"sync"
+	"time"
+
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+
+	"github.com/raids-lab/crater/dao/model"
+	"github.com/raids-lab/crater/dao/query"
+	"github.com/raids-lab/crater/pkg/cronjob"
+	"github.com/raids-lab/crater/pkg/patrol"
+)
+
+const (
+	defaultRunningSettlementIntervalMinutes = 5
+	defaultBillingJobFreeMinutes            = 0
+	defaultBillingIssueAmount               = 1000 * BillingPointScale
+	defaultBillingIssuePeriodMinutes        = 43200
+	minRunningSettlementIntervalMinutes     = 1
+	billingCreateBlockedMsgPrefix           = "billing precheck blocked: account free balance (%d) and extra balance (%d) "
+	billingCreateBlockedMsgSuffix           = "are both non-positive, please recharge or grant rewards first"
+)
+
+type BillingStatus struct {
+	FeatureEnabled                    bool    `json:"featureEnabled"`
+	Active                            bool    `json:"active"`
+	RunningSettlementEnabled          bool    `json:"runningSettlementEnabled"`
+	RunningSettlementIntervalMinutes  int     `json:"runningSettlementIntervalMinutes"`
+	JobFreeMinutes                    int     `json:"jobFreeMinutes"`
+	DefaultIssueAmount                float64 `json:"defaultIssueAmount"`
+	DefaultIssuePeriodMinutes         int     `json:"defaultIssuePeriodMinutes"`
+	AccountIssueAmountOverrideEnabled bool    `json:"accountIssueAmountOverrideEnabled"`
+	AccountIssuePeriodOverrideEnabled bool    `json:"accountIssuePeriodOverrideEnabled"`
+	BaseLoopCronStatus                string  `json:"baseLoopCronStatus"`
+	BaseLoopCronEnabled               bool    `json:"baseLoopCronEnabled"`
+}
+
+type BillingUpdate struct {
+	FeatureEnabled                    *bool  `json:"featureEnabled"`
+	Active                            *bool  `json:"active"`
+	RunningSettlementEnabled          *bool  `json:"runningSettlementEnabled"`
+	RunningSettlementIntervalMinutes  *int   `json:"runningSettlementIntervalMinutes"`
+	JobFreeMinutes                    *int   `json:"jobFreeMinutes"`
+	DefaultIssueAmount                *int64 `json:"defaultIssueAmount"`
+	DefaultIssuePeriodMinutes         *int   `json:"defaultIssuePeriodMinutes"`
+	AccountIssueAmountOverrideEnabled *bool  `json:"accountIssueAmountOverrideEnabled"`
+	AccountIssuePeriodOverrideEnabled *bool  `json:"accountIssuePeriodOverrideEnabled"`
+}
+
+type BillingResetAllResult struct {
+	AccountsAffected     int       `json:"accountsAffected"`
+	UserAccountsAffected int       `json:"userAccountsAffected"`
+	IssuedAt             time.Time `json:"issuedAt"`
+}
+
+type billingStatusTargets struct {
+	currentActive                   bool
+	targetActive                    bool
+	currentRunningSettlementEnabled bool
+	targetRunningSettlementEnabled  bool
+	currentFeatureEnabled           bool
+	targetFeatureEnabled            bool
+	currentBaseLoopCronEnabled      bool
+}
+
+type billingIssueConfig struct {
+	defaultAmount         int64
+	defaultPeriod         int
+	amountOverrideEnabled bool
+	periodOverrideEnabled bool
+}
+
+type BillingService struct {
+	q                   *query.Query
+	cronJobManager      *cronjob.CronJobManager
+	lastTickMu          sync.Mutex
+	lastRunningSettleAt time.Time
+}
+
+func NewBillingService(q *query.Query) *BillingService {
+	return &BillingService{q: q}
+}
+
+func (s *BillingService) SetCronJobManager(cjm *cronjob.CronJobManager) {
+	s.cronJobManager = cjm
+}
+
+func (s *BillingService) GetStatus(ctx context.Context) BillingStatus {
+	cronStatus, cronEnabled := s.GetBaseLoopCronStatus(ctx)
+	return BillingStatus{
+		FeatureEnabled:                    s.IsFeatureEnabled(ctx),
+		Active:                            s.IsActive(ctx),
+		RunningSettlementEnabled:          s.IsRunningSettlementEnabled(ctx),
+		RunningSettlementIntervalMinutes:  s.GetRunningSettlementIntervalMinutes(ctx),
+		JobFreeMinutes:                    s.GetJobFreeMinutes(ctx),
+		DefaultIssueAmount:                ToDisplayPoints(s.GetDefaultIssueAmount(ctx)),
+		DefaultIssuePeriodMinutes:         s.GetDefaultIssuePeriodMinutes(ctx),
+		AccountIssueAmountOverrideEnabled: s.IsAccountIssueAmountOverrideEnabled(ctx),
+		AccountIssuePeriodOverrideEnabled: s.IsAccountIssuePeriodOverrideEnabled(ctx),
+		BaseLoopCronStatus:                string(cronStatus),
+		BaseLoopCronEnabled:               cronEnabled,
+	}
+}
+
+func (s *BillingService) UpdateStatus(ctx context.Context, req BillingUpdate) error {
+	if err := validateBillingUpdate(req); err != nil {
+		return err
+	}
+
+	targets, err := s.resolveStatusTargets(ctx, req)
+	if err != nil {
+		return err
+	}
+	shouldIssueOnActivation := !targets.currentActive && targets.targetActive
+	shouldPreSettleBeforeConfigUpdate := s.shouldPreSettleBeforeStatusUpdate(
+		ctx,
+		req,
+		targets.currentFeatureEnabled,
+		targets.currentActive,
+		targets.targetFeatureEnabled,
+		targets.targetActive,
+	)
+	settleAt := time.Now()
+	updates := buildBillingStatusConfigUpdates(req, targets)
+	err = query.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return s.applyStatusUpdateTx(
+			ctx,
+			tx,
+			req,
+			targets.currentFeatureEnabled,
+			targets.targetFeatureEnabled,
+			shouldPreSettleBeforeConfigUpdate,
+			shouldIssueOnActivation,
+			settleAt,
+			updates,
+		)
+	})
+	if err != nil {
+		return err
+	}
+	return s.syncBillingCronState(ctx, shouldSuspendBillingBaseLoopCron(targets))
+}
+
+func (s *BillingService) resolveStatusTargets(ctx context.Context, req BillingUpdate) (billingStatusTargets, error) {
+	targets := billingStatusTargets{
+		currentActive:                   s.IsActive(ctx),
+		currentRunningSettlementEnabled: s.IsRunningSettlementEnabled(ctx),
+	}
+	if s.cronJobManager != nil {
+		_, targets.currentBaseLoopCronEnabled = s.GetBaseLoopCronStatus(ctx)
+	}
+	targets.targetActive = targets.currentActive
+	if req.Active != nil {
+		targets.targetActive = *req.Active
+	}
+	targets.targetRunningSettlementEnabled = targets.currentRunningSettlementEnabled
+	if req.RunningSettlementEnabled != nil {
+		targets.targetRunningSettlementEnabled = *req.RunningSettlementEnabled
+	}
+
+	targets.currentFeatureEnabled, targets.targetFeatureEnabled = s.resolveBillingFeatureState(ctx, req)
+	targets = normalizeBillingStatusTargets(targets)
+	if targets.targetActive {
+		if err := s.ValidateActivationReady(ctx); err != nil {
+			return billingStatusTargets{}, err
+		}
+	}
+
+	return targets, nil
+}
+
+func (s *BillingService) applyStatusUpdateTx(
+	ctx context.Context,
+	tx *gorm.DB,
+	req BillingUpdate,
+	currentFeatureEnabled bool,
+	targetFeatureEnabled bool,
+	shouldPreSettleBeforeConfigUpdate bool,
+	shouldIssueOnActivation bool,
+	settleAt time.Time,
+	updates map[string]string,
+) error {
+	if shouldPreSettleBeforeConfigUpdate {
+		if _, err := s.settleAllRunningJobsAtTx(ctx, tx, settleAt); err != nil {
+			return err
+		}
+	}
+	if err := applySystemConfigUpdates(ctx, tx, updates); err != nil {
+		return err
+	}
+	if err := s.bootstrapOnFirstFeatureEnable(ctx, tx, req, currentFeatureEnabled); err != nil {
+		return err
+	}
+	if shouldIssueOnActivation {
+		if _, _, err := s.issueNeverIssuedAccountsNowTx(ctx, tx, settleAt); err != nil {
+			return err
+		}
+	}
+	return ensureBillingBaseLoopCronConfig(ctx, tx, targetFeatureEnabled)
+}
+
+func (s *BillingService) HandleBaseLoopCronSuspended(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.lastTickMu.Lock()
+	s.lastRunningSettleAt = time.Time{}
+	s.lastTickMu.Unlock()
+
+	return query.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return applySystemConfigUpdates(ctx, tx, map[string]string{
+			model.ConfigKeyEnableRunningSettlement: strconv.FormatBool(false),
+		})
+	})
+}
+
+func (s *BillingService) IsFeatureEnabled(ctx context.Context) bool {
+	return s.readBoolConfig(ctx, model.ConfigKeyEnableBillingFeature)
+}
+
+func (s *BillingService) IsActive(ctx context.Context) bool {
+	return s.readBoolConfig(ctx, model.ConfigKeyEnableBillingActive)
+}
+
+func (s *BillingService) IsRunningSettlementEnabled(ctx context.Context) bool {
+	return s.readBoolConfig(ctx, model.ConfigKeyEnableRunningSettlement)
+}
+
+func (s *BillingService) GetRunningSettlementIntervalMinutes(ctx context.Context) int {
+	v := s.readIntConfig(ctx, model.ConfigKeyRunningSettlementIntervalMinute, defaultRunningSettlementIntervalMinutes)
+	if v < minRunningSettlementIntervalMinutes {
+		return defaultRunningSettlementIntervalMinutes
+	}
+	return v
+}
+
+func (s *BillingService) GetJobFreeMinutes(ctx context.Context) int {
+	v := s.readIntConfig(ctx, model.ConfigKeyBillingJobFreeMinutes, defaultBillingJobFreeMinutes)
+	if v < 0 {
+		return defaultBillingJobFreeMinutes
+	}
+	return v
+}
+
+func (s *BillingService) GetDefaultIssueAmount(ctx context.Context) int64 {
+	v := s.readAmountConfig(ctx, model.ConfigKeyBillingDefaultIssueAmount, defaultBillingIssueAmount)
+	if v < 0 {
+		return defaultBillingIssueAmount
+	}
+	return v
+}
+
+func (s *BillingService) GetDefaultIssuePeriodMinutes(ctx context.Context) int {
+	v := s.readIntConfig(ctx, model.ConfigKeyBillingDefaultIssuePeriodMinute, defaultBillingIssuePeriodMinutes)
+	if v <= 0 {
+		return defaultBillingIssuePeriodMinutes
+	}
+	return v
+}
+
+func (s *BillingService) IsAccountIssueAmountOverrideEnabled(ctx context.Context) bool {
+	return s.readBoolConfig(ctx, model.ConfigKeyBillingAccountIssueAmountOverrideEnabled)
+}
+
+func (s *BillingService) IsAccountIssuePeriodOverrideEnabled(ctx context.Context) bool {
+	return s.readBoolConfig(ctx, model.ConfigKeyBillingAccountIssuePeriodOverrideEnabled)
+}
+
+func (s *BillingService) ResolveEffectiveIssueConfigForAccount(
+	ctx context.Context,
+	account *model.Account,
+) (issueAmount int64, periodMinutes int) {
+	return resolveEffectiveIssueConfig(
+		account,
+		s.IsAccountIssueAmountOverrideEnabled(ctx),
+		s.IsAccountIssuePeriodOverrideEnabled(ctx),
+		s.GetDefaultIssueAmount(ctx),
+		s.GetDefaultIssuePeriodMinutes(ctx),
+	)
+}
+
+func (s *BillingService) ResolveEffectiveIssueConfigForUserAccount(
+	ctx context.Context,
+	userAccount *model.UserAccount,
+	account *model.Account,
+) (issueAmount int64, periodMinutes int) {
+	issueAmount, periodMinutes = s.ResolveEffectiveIssueConfigForAccount(ctx, account)
+	issueAmount = resolveUserIssueAmount(issueAmount, userAccount, s.IsAccountIssueAmountOverrideEnabled(ctx))
+	if periodMinutes <= 0 {
+		periodMinutes = 0
+	}
+	return issueAmount, periodMinutes
+}
+
+func (s *BillingService) ComputeNextIssueAt(lastIssuedAt *time.Time, periodMinutes int, now time.Time) *time.Time {
+	if periodMinutes <= 0 {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if lastIssuedAt == nil || lastIssuedAt.IsZero() {
+		next := now
+		return &next
+	}
+	next := lastIssuedAt.Add(time.Duration(periodMinutes) * time.Minute)
+	if !next.After(now) {
+		v := now
+		return &v
+	}
+	return &next
+}
+
+func (s *BillingService) GetBaseLoopCronStatus(ctx context.Context) (model.CronJobConfigStatus, bool) {
+	if s.cronJobManager == nil {
+		return model.CronJobConfigStatusUnknown, false
+	}
+	configs, err := s.cronJobManager.GetCronjobConfigs(ctx, []string{patrol.TRIGGER_BILLING_BASE_LOOP_JOB}, nil, nil, nil)
+	if err != nil || len(configs) == 0 || configs[0] == nil {
+		return model.CronJobConfigStatusUnknown, false
+	}
+	status := configs[0].Status
+	return status, status != model.CronJobConfigStatusSuspended
+}
+
+func (s *BillingService) ValidateActivationReady(ctx context.Context) error {
+	r := query.Resource
+	resources, err := r.WithContext(ctx).Where(r.DeletedAt.IsNull()).Find()
+	if err != nil {
+		return fmt.Errorf("billing activation blocked: failed to validate resource pricing: %w", err)
+	}
+	if len(resources) == 0 {
+		return errors.New("billing activation blocked: no resources found")
+	}
+	for _, r := range resources {
+		if r.UnitPrice < 0 {
+			return fmt.Errorf("billing activation blocked: resource %q has invalid unitPrice=%d", r.ResourceName, r.UnitPrice)
+		}
+	}
+	return nil
+}
+
+func (s *BillingService) OnJobCreateCheck(ctx context.Context, userID, accountID uint) error {
+	if !s.IsFeatureEnabled(ctx) || !s.IsActive(ctx) {
+		return nil
+	}
+	var (
+		user model.User
+		ua   model.UserAccount
+	)
+	u := query.User
+	uaQuery := query.UserAccount
+	foundUser, err := u.WithContext(ctx).Where(u.ID.Eq(userID), u.DeletedAt.IsNull()).First()
+	if err != nil {
+		return fmt.Errorf("billing precheck failed: user not found: %w", err)
+	}
+	foundUA, err := uaQuery.WithContext(ctx).
+		Where(
+			uaQuery.UserID.Eq(userID),
+			uaQuery.AccountID.Eq(accountID),
+			uaQuery.DeletedAt.IsNull(),
+		).
+		First()
+	if err != nil {
+		return fmt.Errorf("billing precheck failed: user-account relation not found: %w", err)
+	}
+	user = *foundUser
+	ua = *foundUA
+	if shouldBlockJobCreateForBalance(ua.PeriodFreeBalance, user.ExtraBalance) {
+		return fmt.Errorf(
+			billingCreateBlockedMsgPrefix+billingCreateBlockedMsgSuffix,
+			ua.PeriodFreeBalance,
+			user.ExtraBalance,
+		)
+	}
+	return nil
+}
+
+func shouldBlockJobCreateForBalance(periodFreeBalance, extraBalance int64) bool {
+	return periodFreeBalance <= 0 && extraBalance <= 0
+}
+
+func (s *BillingService) OnJobFinishedSettlement(ctx context.Context, job *model.Job) error {
+	if job == nil || !s.IsFeatureEnabled(ctx) || !s.IsActive(ctx) {
+		return nil
+	}
+	settleAt := job.CompletedTimestamp
+	if settleAt.IsZero() {
+		settleAt = time.Now()
+	}
+	_, err := s.settleOneJobByIdentity(ctx, job.ID, job.JobName, settleAt)
+	return err
+}
+
+func (s *BillingService) RunRunningSettlementTick(ctx context.Context) error {
+	_, err := s.runRunningSettlementTickWithInterval(ctx, time.Now())
+	return err
+}
+
+func (s *BillingService) runRunningSettlementTickWithInterval(
+	ctx context.Context,
+	now time.Time,
+) (settled int, err error) {
+	if !s.IsFeatureEnabled(ctx) || !s.IsActive(ctx) || !s.IsRunningSettlementEnabled(ctx) {
+		return 0, nil
+	}
+
+	interval := time.Duration(s.GetRunningSettlementIntervalMinutes(ctx)) * time.Minute
+	s.lastTickMu.Lock()
+	defer s.lastTickMu.Unlock()
+	if !s.lastRunningSettleAt.IsZero() && now.Sub(s.lastRunningSettleAt) < interval {
+		return 0, nil
+	}
+
+	settled, err = s.runRunningSettlementTickOnce(ctx, now)
+	if err != nil {
+		return 0, err
+	}
+	s.lastRunningSettleAt = now
+	return settled, nil
+}
+
+func (s *BillingService) RunBaseLoopOnce(ctx context.Context) (any, error) {
+	featureEnabled := s.IsFeatureEnabled(ctx)
+	if !featureEnabled {
+		return map[string]any{
+			"featureEnabled": false,
+			"issuedAccounts": 0,
+			"settledJobs":    0,
+		}, nil
+	}
+
+	active := s.IsActive(ctx)
+	issued := 0
+	var err error
+	if shouldIssueDueAccounts(featureEnabled, active) {
+		issued, err = s.IssueDueAccounts(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	settled := 0
+	if active && s.IsRunningSettlementEnabled(ctx) {
+		settled, err = s.runRunningSettlementTickWithInterval(ctx, time.Now())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return map[string]any{
+		"featureEnabled": true,
+		"issuedAccounts": issued,
+		"settledJobs":    settled,
+	}, nil
+}
+
+// ReconcileOnce keeps backward compatibility with old naming.
+func (s *BillingService) ReconcileOnce(ctx context.Context) (any, error) {
+	return s.RunBaseLoopOnce(ctx)
+}
+
+func (s *BillingService) IssueDueAccounts(ctx context.Context) (int, error) {
+	if !shouldIssueDueAccounts(s.IsFeatureEnabled(ctx), s.IsActive(ctx)) {
+		return 0, nil
+	}
+
+	now := time.Now()
+	issued := 0
+	err := query.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		issueConfig := loadBillingIssueConfigTx(ctx, tx)
+		accountQuery := query.Use(tx).Account
+		accounts, err := accountQuery.WithContext(ctx).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where(accountQuery.DeletedAt.IsNull()).
+			Find()
+		if err != nil {
+			return err
+		}
+		for i := range accounts {
+			acc := accounts[i]
+			issueAmount, periodMinutes := issueConfig.resolveForAccount(acc)
+			if !isIssueConfigValid(issueAmount, periodMinutes) {
+				continue
+			}
+			period := time.Duration(periodMinutes) * time.Minute
+			if acc.BillingLastIssuedAt != nil && now.Sub(*acc.BillingLastIssuedAt) < period {
+				continue
+			}
+			if _, err := s.issueAccountNowTx(ctx, tx, acc.ID, issueAmount, now); err != nil {
+				return err
+			}
+			issued++
+		}
+		return nil
+	})
+	return issued, err
+}
+
+func (s *BillingService) IssueAccountNow(ctx context.Context, accountID uint) error {
+	now := time.Now()
+	return query.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		issueConfig := loadBillingIssueConfigTx(ctx, tx)
+		accountQuery := query.Use(tx).Account
+		account, err := accountQuery.WithContext(ctx).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where(accountQuery.ID.Eq(accountID), accountQuery.DeletedAt.IsNull()).
+			First()
+		if err != nil {
+			return err
+		}
+		issueAmount, periodMinutes := issueConfig.resolveForAccount(account)
+		if !isIssueConfigValid(issueAmount, periodMinutes) {
+			return nil
+		}
+		_, err = s.issueAccountNowTx(ctx, tx, accountID, issueAmount, now)
+		return err
+	})
+}
+
+func (s *BillingService) IssueUserAccountNow(ctx context.Context, userID, accountID uint) error {
+	return query.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return s.issueUserAccountNowTx(ctx, tx, userID, accountID)
+	})
+}
+
+func (s *BillingService) bootstrapIssueConfigOnFeatureEnableTx(ctx context.Context, tx *gorm.DB) error {
+	issueConfig := loadBillingIssueConfigTx(ctx, tx)
+	var accounts []model.Account
+	accountQuery := query.Use(tx).Account
+	foundAccounts, err := accountQuery.WithContext(ctx).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where(accountQuery.DeletedAt.IsNull()).
+		Find()
+	if err != nil {
+		return err
+	}
+	accounts = make([]model.Account, 0, len(foundAccounts))
+	for i := range foundAccounts {
+		accounts = append(accounts, *foundAccounts[i])
+	}
+	for i := range accounts {
+		acc := &accounts[i]
+		updates := map[string]any{}
+		if acc.BillingIssueAmount == nil {
+			v := issueConfig.defaultAmount
+			updates["billing_issue_amount"] = v
+			acc.BillingIssueAmount = &v
+		}
+		if acc.BillingIssuePeriodMinutes == nil {
+			v := issueConfig.defaultPeriod
+			updates["billing_issue_period_minutes"] = v
+			acc.BillingIssuePeriodMinutes = &v
+		}
+		if len(updates) > 0 {
+			if _, err := accountQuery.WithContext(ctx).
+				Where(accountQuery.ID.Eq(acc.ID), accountQuery.DeletedAt.IsNull()).
+				Updates(updates); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *BillingService) issueAccountNowTx(
+	ctx context.Context,
+	tx *gorm.DB,
+	accountID uint,
+	issueAmount int64,
+	now time.Time,
+) (int, error) {
+	if getSystemBoolWithTx(ctx, tx, model.ConfigKeyEnableBillingActive) {
+		if _, err := settleRunningJobsForAccountAtTx(ctx, tx, accountID, now); err != nil {
+			return 0, err
+		}
+	}
+
+	txQuery := query.Use(tx)
+	uaQuery := txQuery.UserAccount
+	amountOverrideEnabled := getSystemBoolWithTx(ctx, tx, model.ConfigKeyBillingAccountIssueAmountOverrideEnabled)
+	foundUserAccounts, err := uaQuery.WithContext(tx.Statement.Context).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where(uaQuery.AccountID.Eq(accountID), uaQuery.DeletedAt.IsNull()).
+		Find()
+	if err != nil {
+		return 0, err
+	}
+	userAccounts := make([]model.UserAccount, 0, len(foundUserAccounts))
+	for i := range foundUserAccounts {
+		userAccounts = append(userAccounts, *foundUserAccounts[i])
+	}
+
+	for i := range userAccounts {
+		ua := &userAccounts[i]
+		issueAmountForUser := resolveUserIssueAmount(issueAmount, ua, amountOverrideEnabled)
+		if _, err := uaQuery.WithContext(tx.Statement.Context).
+			Where(uaQuery.UserID.Eq(ua.UserID), uaQuery.AccountID.Eq(ua.AccountID), uaQuery.DeletedAt.IsNull()).
+			Update(uaQuery.PeriodFreeBalance, issueAmountForUser); err != nil {
+			return 0, err
+		}
+	}
+
+	accountQuery := txQuery.Account
+	if _, err := accountQuery.WithContext(tx.Statement.Context).
+		Where(accountQuery.ID.Eq(accountID), accountQuery.DeletedAt.IsNull()).
+		Update(accountQuery.BillingLastIssuedAt, now); err != nil {
+		return 0, err
+	}
+	return len(userAccounts), nil
+}
+
+func (s *BillingService) issueUserAccountNowTx(ctx context.Context, tx *gorm.DB, userID, accountID uint) error {
+	txQuery := query.Use(tx)
+	accountQuery := txQuery.Account
+	account, err := accountQuery.WithContext(ctx).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where(accountQuery.ID.Eq(accountID), accountQuery.DeletedAt.IsNull()).
+		First()
+	if err != nil {
+		return err
+	}
+	issueConfig := loadBillingIssueConfigTx(ctx, tx)
+	issueAmount, periodMinutes := issueConfig.resolveForAccount(account)
+	if !isIssueConfigValid(issueAmount, periodMinutes) {
+		return nil
+	}
+
+	uaQuery := txQuery.UserAccount
+	ua, err := uaQuery.WithContext(ctx).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where(uaQuery.UserID.Eq(userID), uaQuery.AccountID.Eq(accountID), uaQuery.DeletedAt.IsNull()).
+		First()
+	if err != nil {
+		return err
+	}
+
+	issueAmount = resolveUserIssueAmount(issueAmount, ua, issueConfig.amountOverrideEnabled)
+	_, err = uaQuery.WithContext(ctx).
+		Where(uaQuery.UserID.Eq(userID), uaQuery.AccountID.Eq(accountID), uaQuery.DeletedAt.IsNull()).
+		Update(uaQuery.PeriodFreeBalance, issueAmount)
+	return err
+}
+
+func (s *BillingService) runRunningSettlementTickOnce(ctx context.Context, settleAt time.Time) (int, error) {
+	settledJobs := 0
+	err := query.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var err error
+		settledJobs, err = s.settleAllRunningJobsAtTx(ctx, tx, settleAt)
+		return err
+	})
+	if err == nil {
+		klog.Infof("[Billing] running settlement done, settledJobs=%d", settledJobs)
+	}
+	return settledJobs, err
+}
+
+func (s *BillingService) settleAllRunningJobsAtTx(ctx context.Context, tx *gorm.DB, settleAt time.Time) (int, error) {
+	txQuery := query.Use(tx)
+	priceMap, err := loadUnitPriceMapTx(ctx, tx)
+	if err != nil {
+		return 0, err
+	}
+	jobQuery := txQuery.Job
+	foundJobs, err := jobQuery.WithContext(ctx).
+		Where(jobQuery.DeletedAt.IsNull(), jobQuery.Status.Eq(string(batch.Running))).
+		Find()
+	if err != nil {
+		return 0, err
+	}
+	runningJobs := make([]model.Job, 0, len(foundJobs))
+	for i := range foundJobs {
+		runningJobs = append(runningJobs, *foundJobs[i])
+	}
+	settledJobs := 0
+	for i := range runningJobs {
+		charged, err := settleOneJobTx(ctx, tx, runningJobs[i].ID, settleAt, priceMap)
+		if err != nil {
+			return 0, err
+		}
+		if charged > 0 {
+			settledJobs++
+		}
+	}
+	return settledJobs, nil
+}
+
+func (s *BillingService) UpdateResourceUnitPrice(ctx context.Context, resourceID uint, unitPrice int64) error {
+	settleAt := time.Now()
+	return query.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		txQuery := query.Use(tx)
+		resourceQuery := txQuery.Resource
+		resource, err := resourceQuery.WithContext(ctx).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where(resourceQuery.ID.Eq(resourceID), resourceQuery.DeletedAt.IsNull()).
+			First()
+		if err != nil {
+			return err
+		}
+		if resource.UnitPrice == unitPrice {
+			return nil
+		}
+		if s.IsFeatureEnabled(ctx) && s.IsActive(ctx) {
+			if _, err := s.settleAllRunningJobsAtTx(ctx, tx, settleAt); err != nil {
+				return err
+			}
+		}
+		_, err = resourceQuery.WithContext(ctx).
+			Where(resourceQuery.ID.Eq(resourceID), resourceQuery.DeletedAt.IsNull()).
+			Update(resourceQuery.UnitPrice, unitPrice)
+		return err
+	})
+}
+
+func (s *BillingService) settleOneJobByIdentity(ctx context.Context, jobID uint, jobName string, settleAt time.Time) (int64, error) {
+	var charged int64
+	err := query.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		txQuery := query.Use(tx)
+		priceMap, err := loadUnitPriceMapTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		var targetID uint
+		if jobID > 0 {
+			targetID = jobID
+		} else {
+			jobQuery := txQuery.Job
+			job, err := jobQuery.WithContext(ctx).
+				Where(jobQuery.JobName.Eq(jobName), jobQuery.DeletedAt.IsNull()).
+				First()
+			if err != nil {
+				return err
+			}
+			targetID = job.ID
+		}
+		charged, err = settleOneJobTx(ctx, tx, targetID, settleAt, priceMap)
+		return err
+	})
+	return charged, err
+}
+
+func settleOneJobTx(ctx context.Context, tx *gorm.DB, jobID uint, settleAt time.Time, priceMap map[string]int64) (int64, error) {
+	job, err := loadJobForSettlementTx(tx, jobID)
+	if err != nil {
+		return 0, err
+	}
+	if job == nil || job.RunningTimestamp.IsZero() {
+		return 0, nil
+	}
+	jobFreeMinutes := getSystemIntWithTx(ctx, tx, model.ConfigKeyBillingJobFreeMinutes, defaultBillingJobFreeMinutes)
+	if jobFreeMinutes < 0 {
+		jobFreeMinutes = defaultBillingJobFreeMinutes
+	}
+	billableDuration, billedUntil, ok := computeSettlementWindow(job, settleAt, jobFreeMinutes)
+	if !ok {
+		return 0, nil
+	}
+	newTotalMicro, jobCost := calcSettlementCharge(job, priceMap, billableDuration)
+	freeDeduct, extraDeduct, freeDebt, err := deductSettlementCost(tx, job, jobCost)
+	if err != nil {
+		return 0, err
+	}
+	if err := persistJobSettlementState(tx, job.ID, billedUntil, newTotalMicro); err != nil {
+		return 0, err
+	}
+
+	klog.Infof("[Billing] settled job=%s window=%s charged=%d free=%d extra=%d debt=%d",
+		job.JobName, billableDuration, jobCost, freeDeduct, extraDeduct, freeDebt)
+	return jobCost, nil
+}
+
+func validateBillingUpdate(req BillingUpdate) error {
+	if req.RunningSettlementIntervalMinutes != nil && *req.RunningSettlementIntervalMinutes < minRunningSettlementIntervalMinutes {
+		return fmt.Errorf("runningSettlementIntervalMinutes must be >= %d", minRunningSettlementIntervalMinutes)
+	}
+	if req.JobFreeMinutes != nil && *req.JobFreeMinutes < 0 {
+		return errors.New("jobFreeMinutes must be >= 0")
+	}
+	if req.DefaultIssueAmount != nil && *req.DefaultIssueAmount < 0 {
+		return errors.New("defaultIssueAmount must be >= 0")
+	}
+	if req.DefaultIssuePeriodMinutes != nil && *req.DefaultIssuePeriodMinutes <= 0 {
+		return errors.New("defaultIssuePeriodMinutes must be > 0")
+	}
+	return nil
+}
+
+func (s *BillingService) resolveBillingFeatureState(
+	ctx context.Context,
+	req BillingUpdate,
+) (currentFeatureEnabled, targetFeatureEnabled bool) {
+	currentFeatureEnabled = s.IsFeatureEnabled(ctx)
+	targetFeatureEnabled = currentFeatureEnabled
+	if req.FeatureEnabled != nil {
+		targetFeatureEnabled = *req.FeatureEnabled
+	}
+	return currentFeatureEnabled, targetFeatureEnabled
+}
+
+func buildBillingStatusConfigUpdates(req BillingUpdate, targets billingStatusTargets) map[string]string {
+	updates := make(map[string]string)
+	if req.FeatureEnabled != nil {
+		updates[model.ConfigKeyEnableBillingFeature] = strconv.FormatBool(targets.targetFeatureEnabled)
+	}
+	if req.Active != nil || targets.currentActive != targets.targetActive {
+		updates[model.ConfigKeyEnableBillingActive] = strconv.FormatBool(targets.targetActive)
+	}
+	if req.RunningSettlementEnabled != nil ||
+		targets.currentRunningSettlementEnabled != targets.targetRunningSettlementEnabled {
+		updates[model.ConfigKeyEnableRunningSettlement] = strconv.FormatBool(targets.targetRunningSettlementEnabled)
+	}
+	if req.RunningSettlementIntervalMinutes != nil {
+		updates[model.ConfigKeyRunningSettlementIntervalMinute] = strconv.Itoa(*req.RunningSettlementIntervalMinutes)
+	}
+	if req.JobFreeMinutes != nil {
+		updates[model.ConfigKeyBillingJobFreeMinutes] = strconv.Itoa(*req.JobFreeMinutes)
+	}
+	if req.DefaultIssueAmount != nil {
+		updates[model.ConfigKeyBillingDefaultIssueAmount] = FormatBillingAmountConfigValue(*req.DefaultIssueAmount)
+	}
+	if req.DefaultIssuePeriodMinutes != nil {
+		updates[model.ConfigKeyBillingDefaultIssuePeriodMinute] = strconv.Itoa(*req.DefaultIssuePeriodMinutes)
+	}
+	if req.AccountIssueAmountOverrideEnabled != nil {
+		updates[model.ConfigKeyBillingAccountIssueAmountOverrideEnabled] = strconv.FormatBool(*req.AccountIssueAmountOverrideEnabled)
+	}
+	if req.AccountIssuePeriodOverrideEnabled != nil {
+		updates[model.ConfigKeyBillingAccountIssuePeriodOverrideEnabled] = strconv.FormatBool(*req.AccountIssuePeriodOverrideEnabled)
+	}
+	return updates
+}
+
+func normalizeBillingStatusTargets(targets billingStatusTargets) billingStatusTargets {
+	if !targets.targetFeatureEnabled {
+		targets.targetActive = false
+	}
+	if !targets.currentBaseLoopCronEnabled {
+		targets.targetRunningSettlementEnabled = false
+	}
+	if !targets.targetActive {
+		targets.targetRunningSettlementEnabled = false
+	}
+	return targets
+}
+
+func shouldSuspendBillingBaseLoopCron(targets billingStatusTargets) bool {
+	return !targets.targetFeatureEnabled || !targets.targetActive
+}
+
+func applySystemConfigUpdates(ctx context.Context, tx *gorm.DB, updates map[string]string) error {
+	for k, v := range updates {
+		if err := upsertSystemConfigTx(ctx, tx, k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *BillingService) bootstrapOnFirstFeatureEnable(
+	ctx context.Context,
+	tx *gorm.DB,
+	req BillingUpdate,
+	currentFeatureEnabled bool,
+) error {
+	if req.FeatureEnabled != nil && *req.FeatureEnabled && !currentFeatureEnabled {
+		return s.bootstrapIssueConfigOnFeatureEnableTx(ctx, tx)
+	}
+	return nil
+}
+
+func (s *BillingService) shouldPreSettleBeforeStatusUpdate(
+	ctx context.Context,
+	req BillingUpdate,
+	currentFeatureEnabled bool,
+	currentActive bool,
+	targetFeatureEnabled bool,
+	targetActive bool,
+) bool {
+	if !currentFeatureEnabled || !currentActive {
+		return false
+	}
+	if !targetFeatureEnabled || !targetActive {
+		return true
+	}
+	if req.JobFreeMinutes != nil && *req.JobFreeMinutes != s.GetJobFreeMinutes(ctx) {
+		return true
+	}
+	return false
+}
+
+func (s *BillingService) issueAllConfiguredAccountsNowTx(
+	ctx context.Context,
+	tx *gorm.DB,
+	now time.Time,
+) (accountsAffected, userAccountsAffected int, err error) {
+	return s.issueConfiguredAccountsNowTx(ctx, tx, now, false)
+}
+
+func (s *BillingService) issueNeverIssuedAccountsNowTx(
+	ctx context.Context,
+	tx *gorm.DB,
+	now time.Time,
+) (accountsAffected, userAccountsAffected int, err error) {
+	return s.issueConfiguredAccountsNowTx(ctx, tx, now, true)
+}
+
+func (s *BillingService) issueConfiguredAccountsNowTx(
+	ctx context.Context,
+	tx *gorm.DB,
+	now time.Time,
+	onlyNeverIssued bool,
+) (accountsAffected, userAccountsAffected int, err error) {
+	issueConfig := loadBillingIssueConfigTx(ctx, tx)
+	accountQuery := query.Use(tx).Account
+	foundAccounts, err := accountQuery.WithContext(ctx).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where(accountQuery.DeletedAt.IsNull()).
+		Find()
+	if err != nil {
+		return 0, 0, err
+	}
+	accounts := make([]model.Account, 0, len(foundAccounts))
+	for i := range foundAccounts {
+		accounts = append(accounts, *foundAccounts[i])
+	}
+
+	for i := range accounts {
+		account := &accounts[i]
+		if onlyNeverIssued && account.BillingLastIssuedAt != nil && !account.BillingLastIssuedAt.IsZero() {
+			continue
+		}
+		issueAmount, periodMinutes := issueConfig.resolveForAccount(account)
+		if !isIssueConfigValid(issueAmount, periodMinutes) {
+			continue
+		}
+		issuedUserAccounts, err := s.issueAccountNowTx(ctx, tx, account.ID, issueAmount, now)
+		if err != nil {
+			return 0, 0, err
+		}
+		accountsAffected++
+		userAccountsAffected += issuedUserAccounts
+	}
+	return accountsAffected, userAccountsAffected, nil
+}
+
+func (s *BillingService) ResetAllPeriodFreeBalances(ctx context.Context) (*BillingResetAllResult, error) {
+	now := time.Now()
+	result := &BillingResetAllResult{IssuedAt: now}
+	err := query.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		accountsAffected, userAccountsAffected, err := s.issueAllConfiguredAccountsNowTx(ctx, tx, now)
+		if err != nil {
+			return err
+		}
+		result.AccountsAffected = accountsAffected
+		result.UserAccountsAffected = userAccountsAffected
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func ensureBillingBaseLoopCronConfig(ctx context.Context, tx *gorm.DB, targetFeatureEnabled bool) error {
+	jobName := patrol.TRIGGER_BILLING_BASE_LOOP_JOB
+	cronQuery := query.Use(tx).CronJobConfig
+	_, cronErr := cronQuery.WithContext(ctx).Where(cronQuery.Name.Eq(jobName)).First()
+	if errors.Is(cronErr, gorm.ErrRecordNotFound) {
+		if targetFeatureEnabled {
+			newJob := &model.CronJobConfig{
+				Name:    jobName,
+				Type:    model.CronJobTypePatrolFunc,
+				Spec:    "*/1 * * * *",
+				Status:  model.CronJobConfigStatusSuspended,
+				Config:  datatypes.JSON("{}"),
+				EntryID: -1,
+			}
+			return tx.WithContext(ctx).Create(newJob).Error
+		}
+		return nil
+	}
+	return cronErr
+}
+
+func loadJobForSettlementTx(tx *gorm.DB, jobID uint) (*model.Job, error) {
+	jobQuery := query.Use(tx).Job
+	return jobQuery.WithContext(tx.Statement.Context).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where(jobQuery.ID.Eq(jobID), jobQuery.DeletedAt.IsNull()).
+		First()
+}
+
+func computeSettlementWindow(
+	job *model.Job,
+	settleAt time.Time,
+	freeMinutes int,
+) (billableDuration time.Duration, billedUntil time.Time, ok bool) {
+	startAt := job.RunningTimestamp
+	if startAt.IsZero() || !settleAt.After(startAt) {
+		return 0, time.Time{}, false
+	}
+
+	lastSettledAt := startAt
+	if job.LastSettledAt != nil && job.LastSettledAt.After(startAt) {
+		lastSettledAt = *job.LastSettledAt
+	}
+	if !settleAt.After(lastSettledAt) {
+		return 0, time.Time{}, false
+	}
+
+	elapsed := settleAt.Sub(lastSettledAt)
+	freeBudget := time.Duration(freeMinutes) * time.Minute
+	if freeBudget < 0 {
+		freeBudget = 0
+	}
+
+	consumedFree := time.Duration(0)
+	if job.LastSettledAt != nil && job.LastSettledAt.After(job.RunningTimestamp) {
+		consumedFree = job.LastSettledAt.Sub(job.RunningTimestamp)
+		if consumedFree > freeBudget {
+			consumedFree = freeBudget
+		}
+	}
+	remainingFree := freeBudget - consumedFree
+	if remainingFree < 0 {
+		remainingFree = 0
+	}
+
+	if elapsed <= remainingFree {
+		return 0, settleAt, true
+	}
+	return elapsed - remainingFree, settleAt, true
+}
+
+func calcSettlementCharge(job *model.Job, priceMap map[string]int64, billableDuration time.Duration) (newTotalMicro, jobCost int64) {
+	windowCostMicro := calcJobCostMicroPoints(job.Resources.Data(), priceMap, billableDuration)
+	if windowCostMicro < 0 {
+		windowCostMicro = 0
+	}
+	newTotalMicro = job.BilledPointsTotal + windowCostMicro
+	if newTotalMicro < job.BilledPointsTotal {
+		newTotalMicro = job.BilledPointsTotal
+	}
+	jobCost = newTotalMicro - job.BilledPointsTotal
+	return newTotalMicro, jobCost
+}
+
+func deductSettlementCost(tx *gorm.DB, job *model.Job, jobCost int64) (freeDeduct, extraDeduct, freeDebt int64, err error) {
+	txQuery := query.Use(tx)
+	uaQuery := txQuery.UserAccount
+	ua, err := uaQuery.WithContext(tx.Statement.Context).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where(uaQuery.UserID.Eq(job.UserID), uaQuery.AccountID.Eq(job.AccountID), uaQuery.DeletedAt.IsNull()).
+		First()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	userQuery := txQuery.User
+	user, err := userQuery.WithContext(tx.Statement.Context).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where(userQuery.ID.Eq(job.UserID), userQuery.DeletedAt.IsNull()).
+		First()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	freeDeduct, extraDeduct, freeDebt = computeSettlementDeductions(ua.PeriodFreeBalance, user.ExtraBalance, jobCost)
+	newPeriodFreeBalance := ua.PeriodFreeBalance - freeDeduct - freeDebt
+	newExtraBalance := user.ExtraBalance - extraDeduct
+
+	if _, err := uaQuery.WithContext(tx.Statement.Context).
+		Where(uaQuery.UserID.Eq(ua.UserID), uaQuery.AccountID.Eq(ua.AccountID), uaQuery.DeletedAt.IsNull()).
+		Update(uaQuery.PeriodFreeBalance, newPeriodFreeBalance); err != nil {
+		return 0, 0, 0, err
+	}
+	if extraDeduct > 0 {
+		if _, err := userQuery.WithContext(tx.Statement.Context).
+			Where(userQuery.ID.Eq(user.ID), userQuery.DeletedAt.IsNull()).
+			Update(userQuery.ExtraBalance, newExtraBalance); err != nil {
+			return 0, 0, 0, err
+		}
+	}
+	return freeDeduct, extraDeduct, freeDebt, nil
+}
+
+func computeSettlementDeductions(periodFreeBalance, extraBalance, jobCost int64) (freeDeduct, extraDeduct, freeDebt int64) {
+	if jobCost <= 0 {
+		return 0, 0, 0
+	}
+
+	freeAvailable := periodFreeBalance
+	if freeAvailable < 0 {
+		freeAvailable = 0
+	}
+	extraAvailable := extraBalance
+	if extraAvailable < 0 {
+		extraAvailable = 0
+	}
+
+	remaining := jobCost
+	freeDeduct = minInt64(remaining, freeAvailable)
+	remaining -= freeDeduct
+	extraDeduct = minInt64(remaining, extraAvailable)
+	remaining -= extraDeduct
+	freeDebt = remaining
+
+	return freeDeduct, extraDeduct, freeDebt
+}
+
+func settleRunningJobsForAccountAtTx(ctx context.Context, tx *gorm.DB, accountID uint, settleAt time.Time) (int, error) {
+	txQuery := query.Use(tx)
+	priceMap, err := loadUnitPriceMapTx(ctx, tx)
+	if err != nil {
+		return 0, err
+	}
+
+	jobQuery := txQuery.Job
+	foundJobs, err := jobQuery.WithContext(ctx).
+		Where(
+			jobQuery.DeletedAt.IsNull(),
+			jobQuery.AccountID.Eq(accountID),
+			jobQuery.Status.Eq(string(batch.Running)),
+		).
+		Find()
+	if err != nil {
+		return 0, err
+	}
+
+	settledJobs := 0
+	for i := range foundJobs {
+		charged, settleErr := settleOneJobTx(ctx, tx, foundJobs[i].ID, settleAt, priceMap)
+		if settleErr != nil {
+			return 0, settleErr
+		}
+		if charged > 0 {
+			settledJobs++
+		}
+	}
+
+	return settledJobs, nil
+}
+
+func persistJobSettlementState(tx *gorm.DB, jobID uint, billedUntil time.Time, newTotalMicro int64) error {
+	jobQuery := query.Use(tx).Job
+	_, err := jobQuery.WithContext(tx.Statement.Context).
+		Where(jobQuery.ID.Eq(jobID), jobQuery.DeletedAt.IsNull()).
+		Updates(map[string]any{
+			"last_settled_at":     billedUntil,
+			"billed_points_total": newTotalMicro,
+			"updated_at":          time.Now(),
+		})
+	return err
+}
+
+func loadUnitPriceMapTx(_ context.Context, tx *gorm.DB) (map[string]int64, error) {
+	resourceQuery := query.Use(tx).Resource
+	foundResources, err := resourceQuery.WithContext(tx.Statement.Context).
+		Where(resourceQuery.DeletedAt.IsNull()).
+		Find()
+	if err != nil {
+		return nil, err
+	}
+	resources := make([]model.Resource, 0, len(foundResources))
+	for i := range foundResources {
+		resources = append(resources, *foundResources[i])
+	}
+	priceMap := make(map[string]int64, len(resources))
+	for i := range resources {
+		priceMap[resources[i].ResourceName] = resources[i].UnitPrice
+	}
+	return priceMap, nil
+}
+
+func calcJobCostMicroPoints(resources v1.ResourceList, priceMap map[string]int64, billableDuration time.Duration) int64 {
+	if billableDuration <= 0 || len(resources) == 0 || len(priceMap) == 0 {
+		return 0
+	}
+	total := new(big.Rat)
+	durationRat := big.NewRat(billableDuration.Nanoseconds(), int64(time.Hour))
+	for name, qty := range resources {
+		price := priceMap[string(name)]
+		if price <= 0 {
+			continue
+		}
+		amountRat, err := quantityToRat(qty)
+		if err != nil || amountRat.Sign() <= 0 {
+			continue
+		}
+		line := new(big.Rat).Mul(amountRat, big.NewRat(price, 1))
+		line.Mul(line, durationRat)
+		total.Add(total, line)
+	}
+	if total.Sign() <= 0 {
+		return 0
+	}
+	return ratFloorToInt64(total)
+}
+
+func resolveEffectiveIssueConfig(
+	account *model.Account,
+	amountOverrideEnabled bool,
+	periodOverrideEnabled bool,
+	defaultAmount int64,
+	defaultPeriod int,
+) (issueAmount int64, periodMinutes int) {
+	issueAmount = defaultAmount
+	periodMinutes = defaultPeriod
+	if amountOverrideEnabled && account != nil && account.BillingIssueAmount != nil {
+		issueAmount = *account.BillingIssueAmount
+	}
+	if periodOverrideEnabled && account != nil && account.BillingIssuePeriodMinutes != nil {
+		periodMinutes = *account.BillingIssuePeriodMinutes
+	}
+	if issueAmount < 0 {
+		issueAmount = 0
+	}
+	if periodMinutes <= 0 {
+		periodMinutes = 0
+	}
+	return issueAmount, periodMinutes
+}
+
+func resolveUserIssueAmount(issueAmount int64, userAccount *model.UserAccount, amountOverrideEnabled bool) int64 {
+	if amountOverrideEnabled && userAccount != nil && userAccount.BillingIssueAmountOverride != nil {
+		issueAmount = *userAccount.BillingIssueAmountOverride
+	}
+	if issueAmount < 0 {
+		return 0
+	}
+	return issueAmount
+}
+
+func (cfg billingIssueConfig) resolveForAccount(account *model.Account) (issueAmount int64, periodMinutes int) {
+	return resolveEffectiveIssueConfig(
+		account,
+		cfg.amountOverrideEnabled,
+		cfg.periodOverrideEnabled,
+		cfg.defaultAmount,
+		cfg.defaultPeriod,
+	)
+}
+
+func shouldIssueDueAccounts(featureEnabled, active bool) bool {
+	return featureEnabled && active
+}
+
+func isIssueConfigValid(issueAmount int64, periodMinutes int) bool {
+	if periodMinutes <= 0 {
+		return false
+	}
+	return issueAmount > 0
+}
+
+func upsertSystemConfigTx(ctx context.Context, tx *gorm.DB, key, value string) error {
+	cfgQuery := query.Use(tx).SystemConfig
+	if _, err := cfgQuery.WithContext(ctx).
+		Where(cfgQuery.Key.Eq(key)).
+		Update(cfgQuery.Value, value); err != nil {
+		return err
+	}
+	cnt, err := cfgQuery.WithContext(ctx).Where(cfgQuery.Key.Eq(key)).Count()
+	if err != nil {
+		return err
+	}
+	if cnt > 0 {
+		return nil
+	}
+	return tx.WithContext(ctx).Create(&model.SystemConfig{Key: key, Value: value}).Error
+}
+
+func getSystemIntWithTx(ctx context.Context, tx *gorm.DB, key string, def int) int {
+	cfgQuery := query.Use(tx).SystemConfig
+	cfg, err := cfgQuery.WithContext(ctx).Where(cfgQuery.Key.Eq(key)).First()
+	if err != nil {
+		return def
+	}
+	v, err := strconv.Atoi(cfg.Value)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+func getDefaultIssueAmountWithTx(ctx context.Context, tx *gorm.DB) int64 {
+	cfgQuery := query.Use(tx).SystemConfig
+	cfg, err := cfgQuery.WithContext(ctx).Where(cfgQuery.Key.Eq(model.ConfigKeyBillingDefaultIssueAmount)).First()
+	if err != nil {
+		return defaultBillingIssueAmount
+	}
+	return ParseBillingAmountConfigValue(cfg.Value, defaultBillingIssueAmount)
+}
+
+func getSystemBoolWithTx(ctx context.Context, tx *gorm.DB, key string) bool {
+	cfgQuery := query.Use(tx).SystemConfig
+	cfg, err := cfgQuery.WithContext(ctx).Where(cfgQuery.Key.Eq(key)).First()
+	if err != nil {
+		return false
+	}
+	v, err := strconv.ParseBool(cfg.Value)
+	if err != nil {
+		return false
+	}
+	return v
+}
+
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func loadBillingIssueConfigTx(ctx context.Context, tx *gorm.DB) billingIssueConfig {
+	defaultAmount := getDefaultIssueAmountWithTx(ctx, tx)
+	if defaultAmount < 0 {
+		defaultAmount = defaultBillingIssueAmount
+	}
+	defaultPeriod := getSystemIntWithTx(ctx, tx, model.ConfigKeyBillingDefaultIssuePeriodMinute, defaultBillingIssuePeriodMinutes)
+	if defaultPeriod <= 0 {
+		defaultPeriod = defaultBillingIssuePeriodMinutes
+	}
+	return billingIssueConfig{
+		defaultAmount:         defaultAmount,
+		defaultPeriod:         defaultPeriod,
+		amountOverrideEnabled: getSystemBoolWithTx(ctx, tx, model.ConfigKeyBillingAccountIssueAmountOverrideEnabled),
+		periodOverrideEnabled: getSystemBoolWithTx(ctx, tx, model.ConfigKeyBillingAccountIssuePeriodOverrideEnabled),
+	}
+}
+
+func (s *BillingService) syncBillingCronState(ctx context.Context, shouldSuspend bool) error {
+	if s.cronJobManager == nil {
+		return nil
+	}
+	if !shouldSuspend {
+		return nil
+	}
+	configs, err := s.cronJobManager.GetCronjobConfigs(ctx, []string{patrol.TRIGGER_BILLING_BASE_LOOP_JOB}, nil, nil, nil)
+	if err != nil {
+		return fmt.Errorf("sync billing cron state failed: %w", err)
+	}
+	if len(configs) == 0 {
+		return nil
+	}
+	if configs[0] == nil || configs[0].Status == model.CronJobConfigStatusSuspended {
+		return nil
+	}
+	desiredStatus := model.CronJobConfigStatusSuspended
+	if err := s.cronJobManager.UpdateJobConfig(nil, patrol.TRIGGER_BILLING_BASE_LOOP_JOB, nil, nil, &desiredStatus, nil); err != nil {
+		return fmt.Errorf("update billing cron state failed: %w", err)
+	}
+	return nil
+}
+
+func (s *BillingService) IsUserFacingEnabled(ctx context.Context) bool {
+	return s.IsFeatureEnabled(ctx) && s.IsActive(ctx)
+}
+
+func (s *BillingService) readBoolConfig(ctx context.Context, key string) bool {
+	val := s.readConfigValue(ctx, key)
+	if val == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(val)
+	if err != nil {
+		return false
+	}
+	return b
+}
+
+func (s *BillingService) readIntConfig(ctx context.Context, key string, def int) int {
+	val := s.readConfigValue(ctx, key)
+	if val == "" {
+		return def
+	}
+	i, err := strconv.Atoi(val)
+	if err != nil {
+		return def
+	}
+	return i
+}
+
+func (s *BillingService) readAmountConfig(ctx context.Context, key string, def int64) int64 {
+	val := s.readConfigValue(ctx, key)
+	if val == "" {
+		return def
+	}
+	return ParseBillingAmountConfigValue(val, def)
+}
+
+func (s *BillingService) readConfigValue(ctx context.Context, key string) string {
+	sc := s.q.SystemConfig
+	cfg, err := sc.WithContext(ctx).Where(sc.Key.Eq(key)).First()
+	if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			klog.Errorf("[Billing] read config %s failed: %v", key, err)
+		}
+		return ""
+	}
+	return cfg.Value
+}

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -1,0 +1,359 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/raids-lab/crater/dao/model"
+)
+
+const boolFalseString = "false"
+
+func TestComputeSettlementDeductions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		periodFreeBalance int64
+		extraBalance      int64
+		jobCost           int64
+		wantFreeDeduct    int64
+		wantExtraDeduct   int64
+		wantFreeDebt      int64
+	}{
+		{
+			name:              "uses free balance first when sufficient",
+			periodFreeBalance: 12,
+			extraBalance:      8,
+			jobCost:           7,
+			wantFreeDeduct:    7,
+			wantExtraDeduct:   0,
+			wantFreeDebt:      0,
+		},
+		{
+			name:              "consumes extra balance before creating debt",
+			periodFreeBalance: 10,
+			extraBalance:      5,
+			jobCost:           20,
+			wantFreeDeduct:    10,
+			wantExtraDeduct:   5,
+			wantFreeDebt:      5,
+		},
+		{
+			name:              "skips negative free balance and spends extra",
+			periodFreeBalance: -3,
+			extraBalance:      6,
+			jobCost:           4,
+			wantFreeDeduct:    0,
+			wantExtraDeduct:   4,
+			wantFreeDebt:      0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			freeDeduct, extraDeduct, freeDebt := computeSettlementDeductions(
+				tc.periodFreeBalance,
+				tc.extraBalance,
+				tc.jobCost,
+			)
+
+			if freeDeduct != tc.wantFreeDeduct {
+				t.Fatalf("freeDeduct = %d, want %d", freeDeduct, tc.wantFreeDeduct)
+			}
+			if extraDeduct != tc.wantExtraDeduct {
+				t.Fatalf("extraDeduct = %d, want %d", extraDeduct, tc.wantExtraDeduct)
+			}
+			if freeDebt != tc.wantFreeDebt {
+				t.Fatalf("freeDebt = %d, want %d", freeDebt, tc.wantFreeDebt)
+			}
+		})
+	}
+}
+
+func TestResolveUserIssueAmount(t *testing.T) {
+	t.Parallel()
+
+	override := int64(25)
+	tests := []struct {
+		name                  string
+		baseAmount            int64
+		userAccount           *model.UserAccount
+		amountOverrideEnabled bool
+		want                  int64
+	}{
+		{
+			name:                  "uses override when switch is enabled",
+			baseAmount:            10,
+			userAccount:           &model.UserAccount{BillingIssueAmountOverride: &override},
+			amountOverrideEnabled: true,
+			want:                  25,
+		},
+		{
+			name:                  "ignores override when switch is disabled",
+			baseAmount:            10,
+			userAccount:           &model.UserAccount{BillingIssueAmountOverride: &override},
+			amountOverrideEnabled: false,
+			want:                  10,
+		},
+		{
+			name:                  "clamps negative result to zero",
+			baseAmount:            -3,
+			userAccount:           nil,
+			amountOverrideEnabled: false,
+			want:                  0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveUserIssueAmount(tc.baseAmount, tc.userAccount, tc.amountOverrideEnabled)
+			if got != tc.want {
+				t.Fatalf("resolveUserIssueAmount() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShouldIssueDueAccounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		featureEnabled bool
+		active         bool
+		want           bool
+	}{
+		{
+			name:           "requires feature enabled and active",
+			featureEnabled: true,
+			active:         true,
+			want:           true,
+		},
+		{
+			name:           "skips when feature disabled",
+			featureEnabled: false,
+			active:         true,
+			want:           false,
+		},
+		{
+			name:           "skips when inactive",
+			featureEnabled: true,
+			active:         false,
+			want:           false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := shouldIssueDueAccounts(tc.featureEnabled, tc.active)
+			if got != tc.want {
+				t.Fatalf("shouldIssueDueAccounts() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShouldBlockJobCreateForBalance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		periodFreeBalance int64
+		extraBalance      int64
+		want              bool
+	}{
+		{
+			name:              "blocks when both balances are zero",
+			periodFreeBalance: 0,
+			extraBalance:      0,
+			want:              true,
+		},
+		{
+			name:              "blocks when free balance is negative and extra balance is zero",
+			periodFreeBalance: -1,
+			extraBalance:      0,
+			want:              true,
+		},
+		{
+			name:              "allows when free balance is positive",
+			periodFreeBalance: 1,
+			extraBalance:      0,
+			want:              false,
+		},
+		{
+			name:              "allows when extra balance is positive",
+			periodFreeBalance: 0,
+			extraBalance:      1,
+			want:              false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := shouldBlockJobCreateForBalance(tc.periodFreeBalance, tc.extraBalance)
+			if got != tc.want {
+				t.Fatalf("shouldBlockJobCreateForBalance() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeBillingStatusTargets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   billingStatusTargets
+		want    billingStatusTargets
+		suspend bool
+	}{
+		{
+			name: "disabling feature forces active and running settlement off",
+			input: billingStatusTargets{
+				targetFeatureEnabled:           false,
+				targetActive:                   true,
+				targetRunningSettlementEnabled: true,
+			},
+			want: billingStatusTargets{
+				targetFeatureEnabled:           false,
+				targetActive:                   false,
+				targetRunningSettlementEnabled: false,
+			},
+			suspend: true,
+		},
+		{
+			name: "disabling active forces running settlement off",
+			input: billingStatusTargets{
+				targetFeatureEnabled:           true,
+				targetActive:                   false,
+				targetRunningSettlementEnabled: true,
+			},
+			want: billingStatusTargets{
+				targetFeatureEnabled:           true,
+				targetActive:                   false,
+				targetRunningSettlementEnabled: false,
+			},
+			suspend: true,
+		},
+		{
+			name: "disabled base loop cron forces running settlement off only",
+			input: billingStatusTargets{
+				targetFeatureEnabled:           true,
+				targetActive:                   true,
+				targetRunningSettlementEnabled: true,
+				currentBaseLoopCronEnabled:     false,
+			},
+			want: billingStatusTargets{
+				targetFeatureEnabled:           true,
+				targetActive:                   true,
+				targetRunningSettlementEnabled: false,
+				currentBaseLoopCronEnabled:     false,
+			},
+			suspend: false,
+		},
+		{
+			name: "feature and active on keep base loop eligible",
+			input: billingStatusTargets{
+				targetFeatureEnabled:           true,
+				targetActive:                   true,
+				targetRunningSettlementEnabled: true,
+				currentBaseLoopCronEnabled:     true,
+			},
+			want: billingStatusTargets{
+				targetFeatureEnabled:           true,
+				targetActive:                   true,
+				targetRunningSettlementEnabled: true,
+				currentBaseLoopCronEnabled:     true,
+			},
+			suspend: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := normalizeBillingStatusTargets(tc.input)
+			if got != tc.want {
+				t.Fatalf("normalizeBillingStatusTargets() = %#v, want %#v", got, tc.want)
+			}
+			if shouldSuspendBillingBaseLoopCron(got) != tc.suspend {
+				t.Fatalf(
+					"shouldSuspendBillingBaseLoopCron() = %v, want %v",
+					shouldSuspendBillingBaseLoopCron(got),
+					tc.suspend,
+				)
+			}
+		})
+	}
+}
+
+func TestBuildBillingStatusConfigUpdates(t *testing.T) {
+	t.Parallel()
+
+	req := BillingUpdate{FeatureEnabled: boolPtr(false)}
+	targets := billingStatusTargets{
+		currentActive:                   true,
+		targetActive:                    false,
+		currentRunningSettlementEnabled: true,
+		targetRunningSettlementEnabled:  false,
+		currentFeatureEnabled:           true,
+		targetFeatureEnabled:            false,
+	}
+
+	updates := buildBillingStatusConfigUpdates(req, targets)
+
+	if updates[model.ConfigKeyEnableBillingFeature] != boolFalseString {
+		t.Fatalf("featureEnabled update = %q, want false", updates[model.ConfigKeyEnableBillingFeature])
+	}
+	if updates[model.ConfigKeyEnableBillingActive] != boolFalseString {
+		t.Fatalf("active update = %q, want false", updates[model.ConfigKeyEnableBillingActive])
+	}
+	if updates[model.ConfigKeyEnableRunningSettlement] != boolFalseString {
+		t.Fatalf(
+			"runningSettlement update = %q, want false",
+			updates[model.ConfigKeyEnableRunningSettlement],
+		)
+	}
+}
+
+func TestBuildBillingStatusConfigUpdatesWritesNormalizedFalseWhenRequestAskedTrue(t *testing.T) {
+	t.Parallel()
+
+	req := BillingUpdate{
+		Active:                   boolPtr(true),
+		RunningSettlementEnabled: boolPtr(true),
+	}
+	targets := billingStatusTargets{
+		currentActive:                   false,
+		targetActive:                    true,
+		currentRunningSettlementEnabled: false,
+		targetRunningSettlementEnabled:  true,
+		currentFeatureEnabled:           true,
+		targetFeatureEnabled:            true,
+	}
+
+	updates := buildBillingStatusConfigUpdates(req, targets)
+
+	if updates[model.ConfigKeyEnableBillingActive] != "true" {
+		t.Fatalf("active update = %q, want true", updates[model.ConfigKeyEnableBillingActive])
+	}
+	if updates[model.ConfigKeyEnableRunningSettlement] != "true" {
+		t.Fatalf(
+			"runningSettlement update = %q, want true",
+			updates[model.ConfigKeyEnableRunningSettlement],
+		)
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/backend/internal/service/config_service.go
+++ b/backend/internal/service/config_service.go
@@ -92,8 +92,20 @@ func (s *ConfigService) initDefaultConfigs(ctx context.Context) error {
 			if err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {
 					defaultValue := ""
-					if key == model.ConfigKeyEnableGpuAnalysis {
+					switch key {
+					case model.ConfigKeyEnableGpuAnalysis,
+						model.ConfigKeyEnableBillingFeature,
+						model.ConfigKeyEnableBillingActive,
+						model.ConfigKeyEnableRunningSettlement,
+						model.ConfigKeyBillingAccountIssueAmountOverrideEnabled,
+						model.ConfigKeyBillingAccountIssuePeriodOverrideEnabled:
 						defaultValue = "false"
+					case model.ConfigKeyRunningSettlementIntervalMinute:
+						defaultValue = "5"
+					case model.ConfigKeyBillingDefaultIssueAmount:
+						defaultValue = FormatBillingAmountConfigValue(defaultBillingIssueAmount)
+					case model.ConfigKeyBillingDefaultIssuePeriodMinute:
+						defaultValue = "43200"
 					}
 					klog.Infof("[ConfigService] Seeding missing config key: %s", key)
 					if createErr := tx.SystemConfig.WithContext(ctx).Create(&model.SystemConfig{

--- a/backend/pkg/aitaskctl/utils.go
+++ b/backend/pkg/aitaskctl/utils.go
@@ -124,16 +124,16 @@ func CheckInteractiveLimitBeforeCreate(
 func CheckResourcesBeforeCreateJob(
 	c context.Context,
 	userID, accountID uint,
-) (exceededResources []v1.ResourceName) {
+) (exceededResources []v1.ResourceName, err error) {
 	uq := query.UserAccount
 	var userQueueQuota datatypes.JSONType[model.QueueQuota]
-	err := uq.WithContext(c).
+	err = uq.WithContext(c).
 		Where(uq.UserID.Eq(userID)).
 		Where(uq.AccountID.Eq(accountID)).
 		Select(uq.Quota).
 		Scan(&userQueueQuota)
 	if err != nil {
-		return exceededResources
+		return nil, err
 	}
 
 	j := query.Job
@@ -144,14 +144,14 @@ func CheckResourcesBeforeCreateJob(
 		Select(j.Resources).
 		Find()
 	if err != nil {
-		return exceededResources
+		return nil, err
 	}
 
 	const maxJobResources = 100
 	if len(jobResources) >= maxJobResources {
 		exceededResources = append(exceededResources, "作业数量超过限制")
-		return exceededResources
+		return exceededResources, nil
 	}
 
-	return exceededResources
+	return exceededResources, nil
 }

--- a/backend/pkg/cronjob/manger.go
+++ b/backend/pkg/cronjob/manger.go
@@ -28,6 +28,7 @@ func NewCronJobManager(
 	kubeClient kubernetes.Interface,
 	promClient monitor.PrometheusInterface,
 	gpuAnalysisService patrol.GpuAnalysisServiceInterface,
+	billingService patrol.BillingServiceInterface,
 ) *CronJobManager {
 	return &CronJobManager{
 		Client:     cli,
@@ -43,6 +44,7 @@ func NewCronJobManager(
 			KubeClient:         kubeClient,
 			PromClient:         promClient,
 			GpuAnalysisService: gpuAnalysisService,
+			BillingService:     billingService,
 		},
 		cron: cron.New(cron.WithLocation(time.Local)),
 	}

--- a/backend/pkg/cronjob/manger_test.go
+++ b/backend/pkg/cronjob/manger_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestCronJob(t *testing.T) {
 	t.Run("newCronJobFunc", func(t *testing.T) {
-		manager := NewCronJobManager(nil, nil, nil, nil)
+		manager := NewCronJobManager(nil, nil, nil, nil, nil)
 		PatchConvey("newCronJobFunc", t, func() {
 			jobName := cleaner.CLEAN_LONG_TIME_RUNNING_JOB
 			jobConfig := datatypes.JSON(`{"batchDays": 4, "interactiveDays": 4}`)
@@ -50,7 +50,7 @@ func TestCronJob(t *testing.T) {
 
 	t.Run("prepareUpdateConfig", func(t *testing.T) {
 		PatchConvey("prepareUpdateConfig", t, func() {
-			manager := NewCronJobManager(nil, nil, nil, nil)
+			manager := NewCronJobManager(nil, nil, nil, nil, nil)
 			cur := &model.CronJobConfig{
 				Name:   "test",
 				Type:   model.CronJobTypeCleanerFunc,

--- a/backend/pkg/cronjob/record.go
+++ b/backend/pkg/cronjob/record.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"gorm.io/gen/field"
 	"k8s.io/klog/v2"
 
 	"github.com/raids-lab/crater/dao/model"
@@ -17,17 +18,17 @@ const (
 
 // GetCronjobRecordTimeRange retrieves the time range of all cronjob records
 func (cm *CronJobManager) GetCronjobRecordTimeRange(ctx context.Context) (startTime, endTime time.Time, err error) {
+	recordQuery := query.CronJobRecord
 	var result struct {
 		StartTime time.Time
 		EndTime   time.Time
 	}
-	err = query.
-		GetDB().
-		WithContext(ctx).
-		Model(&model.CronJobRecord{}).
-		Select("min(execute_time) as start_time", "max(execute_time) as end_time").
-		Scan(&result).
-		Error
+	err = recordQuery.WithContext(ctx).
+		Select(
+			recordQuery.ExecuteTime.Min().As("start_time"),
+			recordQuery.ExecuteTime.Max().As("end_time"),
+		).
+		Scan(&result)
 	if err != nil {
 		err = fmt.Errorf("CronJobManager.GetCronjobRecordTimeRange: %w", err)
 		klog.Error(err)
@@ -48,21 +49,22 @@ func (cm *CronJobManager) GetCronjobRecords(
 	endTime *time.Time,
 	status *string,
 ) (records []*model.CronJobRecord, err error) {
+	recordQuery := query.CronJobRecord
 	tx := query.GetDB().WithContext(ctx)
 	if len(names) > 0 {
-		tx = tx.Where(query.CronJobRecord.Name.In(names...))
+		tx = tx.Where(recordQuery.Name.In(names...))
 	}
 	if startTime != nil {
-		tx = tx.Where(query.CronJobRecord.ExecuteTime.Gte(*startTime))
+		tx = tx.Where(recordQuery.ExecuteTime.Gte(*startTime))
 	}
 	if endTime != nil {
-		tx = tx.Where(query.CronJobRecord.ExecuteTime.Lte(*endTime))
+		tx = tx.Where(recordQuery.ExecuteTime.Lte(*endTime))
 	}
 	if status != nil {
-		tx = tx.Where(query.CronJobRecord.Status.Eq(*status))
+		tx = tx.Where(recordQuery.Status.Eq(*status))
 	}
 	err = tx.
-		Order(fmt.Sprintf("%s desc", query.CronJobRecord.ExecuteTime.ColumnName().String())).
+		Order(recordQuery.ExecuteTime.Desc()).
 		Find(&records).
 		Error
 	if err != nil {
@@ -105,42 +107,40 @@ func (cm *CronJobManager) DeleteCronjobRecords(
 func (cm *CronJobManager) GetLastCronjobRecord(
 	ctx context.Context, names []string, status *string, startTime, endTime *time.Time,
 ) ([]*model.CronJobRecord, error) {
-	lastExecuteTimeField := fmt.Sprintf("MAX(%s) as last_execute_time", query.CronJobRecord.ExecuteTime.ColumnName().String())
-	subTx := query.
-		GetDB().
-		WithContext(ctx).
-		Model(&model.CronJobRecord{}).
-		Select([]string{query.CronJobRecord.Name.ColumnName().String(), lastExecuteTimeField})
+	recordQuery := query.CronJobRecord
+	lastRecordQuery := query.CronJobRecord.As("last_record")
+	lastExecuteTime := field.NewTime(lastRecordQuery.TableName(), "last_execute_time")
+	subTx := recordQuery.WithContext(ctx).Select(
+		recordQuery.Name,
+		recordQuery.ExecuteTime.Max().As(lastExecuteTime.ColumnName().String()),
+	)
 
 	if len(names) > 0 {
-		subTx = subTx.Where(query.CronJobRecord.Name.In(names...))
+		subTx = subTx.Where(recordQuery.Name.In(names...))
 	}
 	if status != nil {
-		subTx = subTx.Where(query.CronJobRecord.Status.Eq(*status))
+		subTx = subTx.Where(recordQuery.Status.Eq(*status))
 	}
 	if startTime != nil {
-		subTx = subTx.Where(query.CronJobRecord.ExecuteTime.Gte(*startTime))
+		subTx = subTx.Where(recordQuery.ExecuteTime.Gte(*startTime))
 	}
 	if endTime != nil {
-		subTx = subTx.Where(query.CronJobRecord.ExecuteTime.Lte(*endTime))
+		subTx = subTx.Where(recordQuery.ExecuteTime.Lte(*endTime))
 	}
-	subTx = subTx.Group(query.CronJobRecord.Name.ColumnName().String())
+	subTx = subTx.Group(recordQuery.Name)
 
-	tx := query.
-		GetDB().
-		WithContext(ctx).
-		Model(&model.CronJobRecord{})
+	tx := recordQuery.WithContext(ctx)
 	if len(names) > 0 {
-		tx = tx.Where(query.CronJobRecord.Name.In(names...))
+		tx = tx.Where(recordQuery.Name.In(names...))
 	}
-	subCondtion := fmt.Sprintf("(%s, %s) in (?)",
-		query.CronJobRecord.Name.ColumnName().String(),
-		query.CronJobRecord.ExecuteTime.ColumnName().String(),
+	tx = tx.Join(
+		subTx.As(lastRecordQuery.TableName()),
+		recordQuery.Name.EqCol(lastRecordQuery.Name),
+		recordQuery.ExecuteTime.EqCol(lastExecuteTime),
 	)
-	tx = tx.Where(subCondtion, subTx)
 
 	res := make([]*model.CronJobRecord, 0)
-	err := tx.Find(&res).Error
+	err := tx.Scan(&res)
 	if err != nil {
 		err := fmt.Errorf("CronJobManager.GetLastCronjobRecord: %w", err)
 		klog.Error(err)

--- a/backend/pkg/patrol/billing.go
+++ b/backend/pkg/patrol/billing.go
@@ -1,0 +1,14 @@
+package patrol
+
+import (
+	"context"
+	"fmt"
+)
+
+// RunTriggerBillingBaseLoop is the patrol entry for one-shot billing base loop.
+func RunTriggerBillingBaseLoop(ctx context.Context, clients *Clients) (any, error) {
+	if clients.BillingService == nil {
+		return nil, fmt.Errorf("billing service is not initialized in patrol clients")
+	}
+	return clients.BillingService.RunBaseLoopOnce(ctx)
+}

--- a/backend/pkg/patrol/patrol.go
+++ b/backend/pkg/patrol/patrol.go
@@ -16,6 +16,8 @@ import (
 const (
 	// 占卡检测任务
 	TRIGGER_GPU_ANALYSIS_JOB = "trigger-gpu-analysis-job"
+	// Billing 基础循环
+	TRIGGER_BILLING_BASE_LOOP_JOB = "biling-base-loop"
 	// 未来可以扩展其他巡检任务，例如：
 	// CHECK_NODE_HEALTH = "check-node-health"
 )
@@ -24,12 +26,17 @@ type GpuAnalysisServiceInterface interface {
 	TriggerAllJobsAnalysis(ctx context.Context) (int, error)
 }
 
+type BillingServiceInterface interface {
+	RunBaseLoopOnce(ctx context.Context) (any, error)
+}
+
 // Clients 包含巡检任务所需的客户端
 type Clients struct {
 	Client             client.Client
 	KubeClient         kubernetes.Interface
 	PromClient         monitor.PrometheusInterface
 	GpuAnalysisService GpuAnalysisServiceInterface
+	BillingService     BillingServiceInterface
 }
 
 func NewPatrolClients(
@@ -37,12 +44,14 @@ func NewPatrolClients(
 	kubeClient kubernetes.Interface,
 	promClient monitor.PrometheusInterface,
 	gpuAnalysisService GpuAnalysisServiceInterface,
+	billingService BillingServiceInterface,
 ) *Clients {
 	return &Clients{
 		Client:             cli,
 		KubeClient:         kubeClient,
 		PromClient:         promClient,
 		GpuAnalysisService: gpuAnalysisService,
+		BillingService:     billingService,
 	}
 }
 
@@ -60,6 +69,10 @@ func GetPatrolFunc(jobName string, clients *Clients, jobConfig datatypes.JSON) (
 		}
 		f = func(ctx context.Context) (any, error) {
 			return RunTriggerGpuAnalysis(ctx, clients)
+		}
+	case TRIGGER_BILLING_BASE_LOOP_JOB:
+		f = func(ctx context.Context) (any, error) {
+			return RunTriggerBillingBaseLoop(ctx, clients)
 		}
 
 	default:

--- a/backend/pkg/reconciler/vcjob-reconciler.go
+++ b/backend/pkg/reconciler/vcjob-reconciler.go
@@ -42,6 +42,7 @@ import (
 	"github.com/raids-lab/crater/dao/model"
 	"github.com/raids-lab/crater/dao/query"
 	"github.com/raids-lab/crater/internal/handler/vcjob"
+	"github.com/raids-lab/crater/internal/service"
 	vcjobservice "github.com/raids-lab/crater/internal/service/vcjob"
 	"github.com/raids-lab/crater/pkg/alert"
 	"github.com/raids-lab/crater/pkg/config"
@@ -59,6 +60,7 @@ type VcJobReconciler struct {
 	log              logr.Logger
 	prometheusClient monitor.PrometheusInterface // get monitor data
 	kubeClient       kubernetes.Interface
+	billingService   *service.BillingService
 	prequeueWatcher  *prequeuewatcher.PrequeueWatcher
 }
 
@@ -68,6 +70,7 @@ func NewVcJobReconciler(
 	scheme *runtime.Scheme,
 	prometheusClient monitor.PrometheusInterface,
 	kubeClient kubernetes.Interface,
+	billingService *service.BillingService,
 	prequeueWatcher *prequeuewatcher.PrequeueWatcher,
 ) *VcJobReconciler {
 	return &VcJobReconciler{
@@ -76,6 +79,7 @@ func NewVcJobReconciler(
 		log:              ctrl.Log.WithName("vcjob-reconciler"),
 		prometheusClient: prometheusClient,
 		kubeClient:       kubeClient,
+		billingService:   billingService,
 		prequeueWatcher:  prequeueWatcher,
 	}
 }
@@ -139,6 +143,11 @@ func (r *VcJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				logger.Error(err, "unable to update job profile data")
 				return ctrl.Result{Requeue: true}, err
 			}
+			if r.billingService != nil {
+				if settleErr := r.billingService.OnJobFinishedSettlement(ctx, record); settleErr != nil {
+					logger.Error(settleErr, "billing final settlement hook failed for deleted job")
+				}
+			}
 			r.notifyPrequeue()
 			return ctrl.Result{}, nil
 		}
@@ -173,6 +182,13 @@ func (r *VcJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 		if info.RowsAffected == 0 {
 			logger.Info("job not found in database")
+		}
+		if r.billingService != nil {
+			record.Status = model.Freed
+			record.CompletedTimestamp = time.Now()
+			if settleErr := r.billingService.OnJobFinishedSettlement(ctx, record); settleErr != nil {
+				logger.Error(settleErr, "billing final settlement hook failed")
+			}
 		}
 		r.notifyPrequeue()
 		return ctrl.Result{}, nil
@@ -240,6 +256,26 @@ func (r *VcJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		job.Status.State.Phase == batch.Pending
 
 	if !isJobActive {
+		if r.billingService != nil && (oldRecord.Status == batch.Running || oldRecord.Status == batch.Pending) {
+			finalJob := *oldRecord
+			finalJob.Status = job.Status.State.Phase
+			if updateRecord.RunningTimestamp.IsZero() {
+				finalJob.RunningTimestamp = oldRecord.RunningTimestamp
+			} else {
+				finalJob.RunningTimestamp = updateRecord.RunningTimestamp
+			}
+			finalJob.CompletedTimestamp = updateRecord.CompletedTimestamp
+			if finalJob.CompletedTimestamp.IsZero() {
+				if !job.Status.State.LastTransitionTime.IsZero() {
+					finalJob.CompletedTimestamp = job.Status.State.LastTransitionTime.Time
+				} else if !oldRecord.CompletedTimestamp.IsZero() {
+					finalJob.CompletedTimestamp = oldRecord.CompletedTimestamp
+				}
+			}
+			if settleErr := r.billingService.OnJobFinishedSettlement(ctx, &finalJob); settleErr != nil {
+				logger.Error(settleErr, "billing final settlement hook failed")
+			}
+		}
 		r.cancelPendingApprovalOrders(ctx, job.Name, fmt.Sprintf("job is not running (status: %s), order is canceled", job.Status.State.Phase))
 	}
 

--- a/frontend/src/components/account/account-billing-actions.tsx
+++ b/frontend/src/components/account/account-billing-actions.tsx
@@ -1,0 +1,353 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Loader2Icon, RotateCcwIcon, Settings2Icon } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+import {
+  BillingPeriodFields,
+  billingPeriodFromMinutes,
+} from '@/components/form/billing-period-fields'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui-custom/alert-dialog'
+
+import {
+  apiAdminGetAccountBillingConfig,
+  apiAdminResetAccountBillingBalance,
+  apiAdminUpdateAccountBillingConfig,
+  apiGetAccountBillingConfig,
+  apiResetAccountBillingBalance,
+  apiUpdateAccountBillingConfig,
+} from '@/services/api/billing'
+import { apiGetBillingStatus } from '@/services/api/system-config'
+
+import { isBillingVisible } from '@/utils/billing-visibility'
+
+interface AccountBillingActionsProps {
+  accountId: number
+  isAdminView: boolean
+  editable?: boolean
+}
+
+const hasAtMostTwoDecimalPlaces = (value: number) =>
+  Math.abs(value * 100 - Math.round(value * 100)) < 1e-8
+
+const isBillingAmountValueValid = (value: number | null | undefined) =>
+  value != null && Number.isFinite(value) && value >= 0 && hasAtMostTwoDecimalPlaces(value)
+
+const formatPeriodSummary = (totalMinutes?: number) => {
+  if ((totalMinutes ?? 0) <= 0) {
+    return '已关闭'
+  }
+  const { days, hours, minutes } = billingPeriodFromMinutes(totalMinutes)
+  const parts = [
+    days > 0 ? `${days} 天` : null,
+    hours > 0 ? `${hours} 小时` : null,
+    minutes > 0 ? `${minutes} 分钟` : null,
+  ].filter(Boolean)
+  return parts.join(' ') || `${totalMinutes} 分钟`
+}
+
+export function AccountBillingActions({
+  accountId,
+  isAdminView,
+  editable = true,
+}: AccountBillingActionsProps) {
+  const queryClient = useQueryClient()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const { data: billingStatus } = useQuery({
+    queryKey: ['system-config', 'billing-status'],
+    queryFn: () => apiGetBillingStatus().then((res) => res.data),
+    enabled: editable,
+  })
+  const billingEnabled = editable && isBillingVisible(billingStatus, isAdminView ? 'admin' : 'user')
+  const amountOverrideEnabled =
+    billingEnabled && (billingStatus?.accountIssueAmountOverrideEnabled ?? false)
+  const periodOverrideEnabled =
+    billingEnabled && (billingStatus?.accountIssuePeriodOverrideEnabled ?? false)
+
+  const getAccountBillingConfig = isAdminView
+    ? apiAdminGetAccountBillingConfig
+    : apiGetAccountBillingConfig
+  const updateAccountBillingConfig = isAdminView
+    ? apiAdminUpdateAccountBillingConfig
+    : apiUpdateAccountBillingConfig
+  const resetAccountBilling = isAdminView
+    ? apiAdminResetAccountBillingBalance
+    : apiResetAccountBillingBalance
+
+  const accountBillingConfigQuery = useQuery({
+    queryKey: ['account', accountId, 'billing-config', isAdminView ? 'admin' : 'user'],
+    queryFn: () => getAccountBillingConfig(accountId).then((res) => res.data),
+    enabled: billingEnabled,
+  })
+
+  const accountBillingConfig = accountBillingConfigQuery.data
+
+  const [issueAmountInput, setIssueAmountInput] = useState('')
+  const [issueAmountDirty, setIssueAmountDirty] = useState(false)
+  const [issuePeriodMinutes, setIssuePeriodMinutes] = useState<number | undefined>(undefined)
+  const [issuePeriodDirty, setIssuePeriodDirty] = useState(false)
+
+  useEffect(() => {
+    if (!dialogOpen) {
+      return
+    }
+    setIssueAmountInput(
+      accountBillingConfig?.issueAmount != null
+        ? String(accountBillingConfig.issueAmount)
+        : accountBillingConfig?.effectiveIssueAmount != null
+          ? String(accountBillingConfig.effectiveIssueAmount)
+          : ''
+    )
+    setIssueAmountDirty(false)
+    setIssuePeriodMinutes(
+      accountBillingConfig?.issuePeriodMinutes ??
+        accountBillingConfig?.effectiveIssuePeriodMinutes ??
+        0
+    )
+    setIssuePeriodDirty(false)
+  }, [
+    accountBillingConfig?.effectiveIssueAmount,
+    accountBillingConfig?.effectiveIssuePeriodMinutes,
+    accountBillingConfig?.issueAmount,
+    accountBillingConfig?.issuePeriodMinutes,
+    dialogOpen,
+  ])
+
+  const parsedIssueAmount = issueAmountInput.trim()
+  const hasIssueAmount = parsedIssueAmount !== ''
+  const nextIssueAmount = hasIssueAmount ? Number(parsedIssueAmount) : undefined
+  const isIssueAmountValid = !hasIssueAmount || isBillingAmountValueValid(nextIssueAmount)
+
+  const payload = useMemo(() => {
+    const nextPayload: { issueAmount?: number; issuePeriodMinutes?: number } = {}
+    if (
+      amountOverrideEnabled &&
+      issueAmountDirty &&
+      hasIssueAmount &&
+      isIssueAmountValid &&
+      nextIssueAmount !== undefined
+    ) {
+      nextPayload.issueAmount = nextIssueAmount
+    }
+    if (periodOverrideEnabled && issuePeriodDirty && issuePeriodMinutes !== undefined) {
+      nextPayload.issuePeriodMinutes = issuePeriodMinutes
+    }
+    return nextPayload
+  }, [
+    amountOverrideEnabled,
+    hasIssueAmount,
+    isIssueAmountValid,
+    issueAmountDirty,
+    issuePeriodDirty,
+    issuePeriodMinutes,
+    nextIssueAmount,
+    periodOverrideEnabled,
+  ])
+
+  const canSave = isIssueAmountValid && Object.keys(payload).length > 0
+  const isUsingDefaultBillingIssueAmount = accountBillingConfig?.issueAmount == null
+  const isUsingDefaultBillingIssuePeriod = accountBillingConfig?.issuePeriodMinutes == null
+
+  const effectiveBillingSummary = useMemo(() => {
+    if (!accountBillingConfig) {
+      return '当前生效额度以系统默认配置为准。'
+    }
+    if (accountBillingConfig.effectiveIssuePeriodMinutes <= 0) {
+      return `当前生效额度为 ${accountBillingConfig.effectiveIssueAmount} 点，周期发放已关闭。`
+    }
+    return `当前生效配置：每 ${formatPeriodSummary(accountBillingConfig.effectiveIssuePeriodMinutes)} 发放 ${accountBillingConfig.effectiveIssueAmount} 点。`
+  }, [accountBillingConfig])
+
+  const { mutate: saveBillingConfig, isPending: isSavingBillingConfig } = useMutation({
+    mutationFn: () => updateAccountBillingConfig(accountId, payload),
+    onSuccess: async () => {
+      toast.success('点数发放配置已更新')
+      setDialogOpen(false)
+      await queryClient.invalidateQueries({
+        queryKey: ['account', accountId, 'billing-config'],
+      })
+      await queryClient.invalidateQueries({
+        queryKey: ['account', accountId, 'billing-members'],
+      })
+    },
+    onError: () => {
+      toast.error('点数发放配置更新失败')
+    },
+  })
+
+  const { mutate: resetAccountBillingNow, isPending: isResettingBilling } = useMutation({
+    mutationFn: () => resetAccountBilling(accountId),
+    onSuccess: async () => {
+      toast.success('已重置当前账户全部成员免费额度')
+      await queryClient.invalidateQueries({
+        queryKey: ['account', accountId, 'billing-config'],
+      })
+      await queryClient.invalidateQueries({
+        queryKey: ['account', accountId, 'billing-members'],
+      })
+    },
+    onError: () => {
+      toast.error('重置免费额度失败')
+    },
+  })
+
+  if (!billingEnabled) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-wrap justify-end gap-3">
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogTrigger asChild>
+          <Button>
+            <Settings2Icon className="mr-2 size-4" />
+            点数发放配置
+          </Button>
+        </DialogTrigger>
+        <DialogContent className="max-h-[85vh] overflow-y-auto p-0 sm:max-w-2xl">
+          <DialogHeader className="px-6 pt-6">
+            <DialogTitle>配置账户点数发放</DialogTitle>
+            <DialogDescription>配置当前账户的默认点数发放规则。</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-5 px-6 pb-6">
+            <div className="bg-muted/30 rounded-xl border p-4">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="bg-background rounded-lg border p-4">
+                  <p className="text-muted-foreground text-xs">当前生效发放额度</p>
+                  <p className="mt-2 text-2xl font-semibold">
+                    {accountBillingConfig?.effectiveIssueAmount ?? 0}
+                    <span className="text-muted-foreground ml-1 text-sm font-medium">点</span>
+                  </p>
+                </div>
+                <div className="bg-background rounded-lg border p-4">
+                  <p className="text-muted-foreground text-xs">当前生效发放周期</p>
+                  <p className="mt-2 text-lg font-semibold">
+                    {formatPeriodSummary(accountBillingConfig?.effectiveIssuePeriodMinutes)}
+                  </p>
+                </div>
+              </div>
+              <p className="text-muted-foreground mt-3 text-xs">{effectiveBillingSummary}</p>
+            </div>
+
+            <div className="space-y-4">
+              <section className="space-y-3 rounded-xl border p-4">
+                <div className="space-y-1">
+                  <Label>周期发放额度</Label>
+                  <p className="text-muted-foreground text-xs">
+                    {amountOverrideEnabled
+                      ? isUsingDefaultBillingIssueAmount
+                        ? `当前展示的是生效值 ${accountBillingConfig?.effectiveIssueAmount ?? 0} 点。`
+                        : '当前展示的是账户已配置额度。'
+                      : '当前由系统默认发放额度控制。'}
+                  </p>
+                </div>
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.01}
+                  disabled={!amountOverrideEnabled || accountBillingConfigQuery.isLoading}
+                  value={issueAmountInput}
+                  onChange={(e) => {
+                    setIssueAmountInput(e.target.value)
+                    setIssueAmountDirty(true)
+                  }}
+                  placeholder="留空表示沿用当前配置"
+                />
+                {!isIssueAmountValid ? (
+                  <p className="text-destructive text-xs">请输入非负点数，最多保留两位小数。</p>
+                ) : null}
+              </section>
+
+              <section className="space-y-3 rounded-xl border p-4">
+                <div className="space-y-1">
+                  <Label>发放周期</Label>
+                  <p className="text-muted-foreground text-xs">
+                    {periodOverrideEnabled
+                      ? isUsingDefaultBillingIssuePeriod
+                        ? `当前展示的是生效周期 ${formatPeriodSummary(accountBillingConfig?.effectiveIssuePeriodMinutes)}。`
+                        : '填 0 表示关闭当前账户的周期发放。'
+                      : '当前由系统默认发放周期控制。'}
+                  </p>
+                </div>
+                <BillingPeriodFields
+                  totalMinutes={issuePeriodMinutes}
+                  disabled={!periodOverrideEnabled || accountBillingConfigQuery.isLoading}
+                  onChange={(value) => {
+                    setIssuePeriodMinutes(value.totalMinutes)
+                    setIssuePeriodDirty(true)
+                  }}
+                />
+              </section>
+            </div>
+          </div>
+          <DialogFooter className="border-t px-6 py-4">
+            <DialogClose asChild>
+              <Button variant="outline">取消</Button>
+            </DialogClose>
+            <Button
+              onClick={() => saveBillingConfig()}
+              disabled={isSavingBillingConfig || !canSave}
+            >
+              {isSavingBillingConfig ? <Loader2Icon className="mr-2 size-4 animate-spin" /> : null}
+              保存
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button variant="outline" disabled={isResettingBilling}>
+            {isResettingBilling ? (
+              <Loader2Icon className="mr-2 size-4 animate-spin" />
+            ) : (
+              <RotateCcwIcon className="mr-2 size-4" />
+            )}
+            一键重置免费额度
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认重置当前账户免费额度？</AlertDialogTitle>
+            <AlertDialogDescription>
+              将重置当前账户所有成员的本周期免费额度。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => resetAccountBillingNow()}
+              disabled={isResettingBilling}
+            >
+              确认重置
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/frontend/src/components/account/account-member-table.tsx
+++ b/frontend/src/components/account/account-member-table.tsx
@@ -69,6 +69,7 @@ import {
 import CapacityBadges from '@/components/badge/capacity-badges'
 import UserAccessBadge from '@/components/badge/user-access-badge'
 import UserRoleBadge, { userRoles } from '@/components/badge/user-role-badge'
+import { BillingInlineMeter } from '@/components/custom/billing-balance-meter'
 import SelectBox from '@/components/custom/select-box'
 import FormLabelMust from '@/components/form/form-label-must'
 import UserLabel from '@/components/label/user-label'
@@ -102,12 +103,22 @@ import {
   apiUserOutOfProjectList,
   apiUserRemoveAccountMember,
   apiUserUpdateAccountMember,
+  apiUserUpdateAccountMemberPartial,
 } from '@/services/api/account'
 import { Role, apiQueueSwitch } from '@/services/api/auth'
+import {
+  AccountBillingMember,
+  apiAdminGetAccountBillingMembers,
+  apiAdminUpdateAccountBillingMemberIssueAmount,
+  apiGetAccountBillingMembers,
+  apiUpdateAccountBillingMemberIssueAmount,
+} from '@/services/api/billing'
+import { apiGetBillingStatus } from '@/services/api/system-config'
 import { queryAccountByID } from '@/services/query/account'
 
 import useIsAdmin from '@/hooks/use-admin'
 
+import { isBillingVisible } from '@/utils/billing-visibility'
 import { atomUserContext, atomUserInfo } from '@/utils/store'
 
 // Moved Zod schema to component
@@ -123,11 +134,19 @@ const formSchema = z.object({
   }),
 })
 
+const hasAtMostTwoDecimalPlaces = (value: number) =>
+  Math.abs(value * 100 - Math.round(value * 100)) < 1e-8
+
+const isBillingAmountValueValid = (value: number | null | undefined) =>
+  value != null && Number.isFinite(value) && value >= 0 && hasAtMostTwoDecimalPlaces(value)
+
 interface AccountMemberTableProps {
   accountId: number
   editable?: boolean
   storageKey?: string
 }
+
+type AccountMemberRow = IUserInAccount & Partial<AccountBillingMember>
 
 export function AccountMemberTable({
   accountId,
@@ -145,11 +164,17 @@ export function AccountMemberTable({
   // Get account info to check if it's default account
   const { data: accountInfo } = useQuery({
     ...queryAccountByID(accountId),
-    enabled: !!accountId,
+    enabled: isAdminView && !!accountId,
   })
+  const { data: billingStatus } = useQuery({
+    queryKey: ['system-config', 'billing-status'],
+    queryFn: () => apiGetBillingStatus().then((res) => res.data),
+    enabled: editable,
+  })
+  const billingEnabled = editable && isBillingVisible(billingStatus, isAdminView ? 'admin' : 'user')
 
   // Check if current account is default account
-  const isDefaultAccount = accountInfo?.name === 'default'
+  const isDefaultAccount = isAdminView && accountInfo?.name === 'default'
 
   const getHeader = useCallback(
     (key: string): string => {
@@ -189,6 +214,9 @@ export function AccountMemberTable({
   const addAccountMember = isAdminView ? apiAddUser : apiUserAddAccountMember
   const updateAccountMember = isAdminView ? apiUpdateUser : apiUserUpdateAccountMember
   const removeAccountMember = isAdminView ? apiRemoveUser : apiUserRemoveAccountMember
+  const listBillingMembers = isAdminView
+    ? apiAdminGetAccountBillingMembers
+    : apiGetAccountBillingMembers
 
   const accountUsersQuery = useQuery({
     queryKey: ['account', accountId, 'users', isAdminView ? 'admin' : 'user'],
@@ -303,6 +331,41 @@ export function AccountMemberTable({
     },
   })
 
+  const billingMembersQuery = useQuery({
+    queryKey: ['account', accountId, 'billing-members', isAdminView ? 'admin' : 'user'],
+    queryFn: () => listBillingMembers(accountId).then((res) => res.data),
+    enabled: billingEnabled,
+  })
+
+  const mergedAccountUsers = useMemo<AccountMemberRow[]>(() => {
+    const billingByUserId = new Map(
+      (billingMembersQuery.data ?? []).map((item) => [item.userId, item] as const)
+    )
+    return (accountUsersQuery.data ?? []).map((user) => ({
+      ...user,
+      ...billingByUserId.get(user.id),
+    }))
+  }, [accountUsersQuery.data, billingMembersQuery.data])
+
+  const mergedAccountUsersQuery = useMemo(
+    () =>
+      ({
+        data: mergedAccountUsers,
+        isLoading: accountUsersQuery.isLoading || (billingEnabled && billingMembersQuery.isLoading),
+        dataUpdatedAt: Math.max(accountUsersQuery.dataUpdatedAt, billingMembersQuery.dataUpdatedAt),
+        refetch: accountUsersQuery.refetch,
+      }) as UseQueryResult<AccountMemberRow[], Error>,
+    [
+      accountUsersQuery.dataUpdatedAt,
+      accountUsersQuery.isLoading,
+      accountUsersQuery.refetch,
+      billingEnabled,
+      billingMembersQuery.dataUpdatedAt,
+      billingMembersQuery.isLoading,
+      mergedAccountUsers,
+    ]
+  )
+
   const { data: usersOutOfProjectData, isLoading: isLoadingUsersOutOfProject } = useQuery({
     queryKey: ['usersOutOfProject', accountId, isAdminView ? 'admin' : 'user'],
     queryFn: () => listUsersOutOfAccount(accountId),
@@ -315,7 +378,7 @@ export function AccountMemberTable({
     setUsersOutOfProject(usersOutOfProjectData)
   }, [usersOutOfProjectData, isLoadingUsersOutOfProject])
 
-  const columns = useMemo<ColumnDef<IUserInAccount>[]>(
+  const columns = useMemo<ColumnDef<AccountMemberRow>[]>(
     () => [
       {
         accessorKey: 'name',
@@ -378,6 +441,22 @@ export function AccountMemberTable({
         },
         enableSorting: false,
       },
+      ...(billingEnabled
+        ? [
+            {
+              accessorKey: 'billing',
+              header: ({ column }) => <DataTableColumnHeader column={column} title="免费额度" />,
+              cell: ({ row }) => (
+                <BillingIssueAmountCell
+                  user={row.original}
+                  accountId={accountId}
+                  isAdminView={isAdminView}
+                  editable={editable}
+                />
+              ),
+            } as ColumnDef<AccountMemberRow>,
+          ]
+        : []),
       {
         id: 'actions',
         enableHiding: false,
@@ -415,6 +494,7 @@ export function AccountMemberTable({
       setPendingDeleteUser,
       accessModes,
       isDefaultAccount,
+      billingEnabled,
       isAdminView,
       currentUser,
       currentAccountContext,
@@ -474,7 +554,7 @@ export function AccountMemberTable({
       <DataTable
         key={`${accountId}-${accountUsersQuery.data?.length}`}
         columns={columns as ColumnDef<unknown>[]}
-        query={accountUsersQuery as UseQueryResult<unknown[], Error>}
+        query={mergedAccountUsersQuery as UseQueryResult<unknown[], Error>}
         storageKey={storageKey}
         toolbarConfig={toolbarConfig}
       >
@@ -501,8 +581,134 @@ export function AccountMemberTable({
   )
 }
 
+interface BillingIssueAmountCellProps {
+  user: AccountMemberRow
+  accountId: number
+  isAdminView: boolean
+  editable: boolean
+}
+
+const BillingIssueAmountCell: FC<BillingIssueAmountCellProps> = ({
+  user,
+  accountId,
+  isAdminView,
+  editable,
+}) => {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [billingDialogOpen, setBillingDialogOpen] = useState(false)
+  const [billingIssueAmountInput, setBillingIssueAmountInput] = useState('')
+
+  useEffect(() => {
+    if (!billingDialogOpen) {
+      return
+    }
+    setBillingIssueAmountInput(
+      user.issueAmountOverride == null ? '' : String(user.issueAmountOverride)
+    )
+  }, [billingDialogOpen, user.issueAmountOverride])
+
+  const parsedBillingIssueAmount = billingIssueAmountInput.trim()
+  const hasBillingOverride = parsedBillingIssueAmount !== ''
+  const nextBillingIssueAmount = hasBillingOverride ? Number(parsedBillingIssueAmount) : null
+  const isBillingIssueAmountValid =
+    !hasBillingOverride || isBillingAmountValueValid(nextBillingIssueAmount)
+
+  const { mutate: updateBillingIssueAmount, isPending: isBillingIssueAmountPending } = useMutation({
+    mutationFn: (issueAmountOverride: number | null) =>
+      isAdminView
+        ? apiAdminUpdateAccountBillingMemberIssueAmount(accountId, user.id, {
+            issueAmountOverride,
+          })
+        : apiUpdateAccountBillingMemberIssueAmount(accountId, user.id, {
+            issueAmountOverride,
+          }),
+    onSuccess: async () => {
+      toast.success('点数额度已更新')
+      setBillingDialogOpen(false)
+      await queryClient.invalidateQueries({
+        queryKey: ['account', accountId, 'billing-members'],
+      })
+    },
+    onError: () => {
+      toast.error('点数额度更新失败')
+    },
+  })
+
+  const balance = user.periodFreeBalance ?? 0
+  const total = user.effectiveIssueAmount ?? 0
+
+  const meter = <BillingInlineMeter balance={balance} total={total} className="w-[112px]" />
+
+  const onSaveBillingIssueAmount = () => {
+    if (!isBillingIssueAmountValid) {
+      return
+    }
+    updateBillingIssueAmount(nextBillingIssueAmount)
+  }
+
+  return (
+    <>
+      {editable ? (
+        <button
+          type="button"
+          onClick={() => setBillingDialogOpen(true)}
+          className="hover:bg-muted/60 focus-visible:ring-ring rounded-md p-1 text-left transition focus-visible:ring-2 focus-visible:outline-none"
+        >
+          {meter}
+        </button>
+      ) : (
+        meter
+      )}
+      {billingDialogOpen && (
+        <Dialog open={billingDialogOpen} onOpenChange={setBillingDialogOpen}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>配置用户点数额度</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-3">
+              <div className="space-y-1">
+                <div className="text-sm font-medium">{user.name}</div>
+                <p className="text-muted-foreground text-xs">
+                  当前生效额度为 {user.effectiveIssueAmount ?? 0} 点。
+                </p>
+              </div>
+              <Input
+                type="number"
+                min={0}
+                step={0.01}
+                value={billingIssueAmountInput}
+                onChange={(e) => setBillingIssueAmountInput(e.target.value)}
+                placeholder="留空表示沿用账户配置"
+              />
+              {!isBillingIssueAmountValid ? (
+                <p className="text-destructive text-xs">请输入非负点数，最多保留两位小数。</p>
+              ) : (
+                <p className="text-muted-foreground text-xs">
+                  保存后会更新该用户在当前账户下的周期发放额度。
+                </p>
+              )}
+            </div>
+            <DialogFooter>
+              <Button
+                onClick={onSaveBillingIssueAmount}
+                disabled={isBillingIssueAmountPending || !isBillingIssueAmountValid}
+              >
+                {t('accountDetail.form.save')}
+              </Button>
+              <DialogClose asChild>
+                <Button variant="outline">{t('accountDetail.form.cancel')}</Button>
+              </DialogClose>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
+  )
+}
+
 interface ActionsCellProps {
-  user: IUserInAccount
+  user: AccountMemberRow
   accountId: number
   t: (key: string) => string
   updateUser: (user: IUserInAccountCreate) => void
@@ -553,14 +759,23 @@ const ActionsCell: FC<ActionsCellProps> = ({
 
   const queryClient = useQueryClient()
   const { mutate: updateQuota, isPending: isQuotaPending } = useMutation({
-    mutationFn: (quota: Record<string, string>) =>
-      apiUpdateUserOutOfProjectList({
-        aid: accountId,
-        uid: user.id,
-        role: user.role,
-        accessmode: user.accessmode,
-        quota,
-      }),
+    mutationFn: (capability: Record<string, string>) => {
+      const quota = { capability }
+      return isAdminView
+        ? apiUpdateUserOutOfProjectList({
+            aid: accountId,
+            uid: user.id,
+            role: user.role,
+            accessmode: user.accessmode,
+            quota,
+          })
+        : apiUserUpdateAccountMemberPartial(accountId, user.id, {
+            uid: user.id,
+            role: user.role,
+            accessmode: user.accessmode,
+            quota,
+          })
+    },
     onSuccess: async () => {
       toast.success(t('accountDetail.toast.updated'))
       setQuotaDialogOpen(false)

--- a/frontend/src/components/custom/billing-balance-meter.tsx
+++ b/frontend/src/components/custom/billing-balance-meter.tsx
@@ -1,0 +1,174 @@
+import { CSSProperties, ReactNode } from 'react'
+
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+
+import { ProgressBar, progressTextColor } from '@/components/ui-custom/colorful-progress'
+import { MetricMeter } from '@/components/ui-custom/metric-meter'
+
+import { formatBillingPoints } from '@/utils/billing'
+
+import { cn } from '@/lib/utils'
+
+interface BillingBalanceMeterProps {
+  balance: number
+  total: number
+  label?: ReactNode
+  hoverContent?: ReactNode
+  className?: string
+  meterClassName?: string
+  compact?: boolean
+  hideValueText?: boolean
+}
+
+interface BillingInlineMeterProps {
+  balance: number
+  total: number
+  className?: string
+}
+
+export function getBillingDisplayTotal(balance: number, total: number) {
+  if (total > 0) {
+    return total
+  }
+  return Math.max(balance, 0)
+}
+
+export function formatBillingPair(balance: number, total: number) {
+  const displayTotal = getBillingDisplayTotal(balance, total)
+  if (displayTotal <= 0) {
+    return formatBillingPoints(balance)
+  }
+  return `${formatBillingPoints(balance)}/${formatBillingPoints(displayTotal)}`
+}
+
+export function getBillingBalancePercent(balance: number, total: number) {
+  const displayTotal = getBillingDisplayTotal(balance, total)
+  if (displayTotal <= 0) {
+    return balance > 0 ? 100 : 0
+  }
+  return Math.min(100, Math.max(0, (balance / displayTotal) * 100))
+}
+
+export function BillingInlineMeter({ balance, total, className }: BillingInlineMeterProps) {
+  const percent = getBillingBalancePercent(balance, total)
+
+  return (
+    <MetricMeter
+      percent={percent}
+      mode="balance"
+      primary={
+        <>
+          {percent.toFixed(1)}
+          <span className="ml-0.5">%</span>
+        </>
+      }
+      secondary={formatBillingPair(balance, total)}
+      className={className}
+    />
+  )
+}
+
+function getCompactBalanceColor(percent: number) {
+  if (percent > 90) {
+    return 'var(--highlight-emerald)'
+  }
+  if (percent > 70) {
+    return 'var(--highlight-sky)'
+  }
+  if (percent > 50) {
+    return 'var(--highlight-yellow)'
+  }
+  if (percent > 20) {
+    return 'var(--highlight-orange)'
+  }
+  return 'var(--highlight-red)'
+}
+
+function getCompactBorderProgressStyle(percent: number): CSSProperties {
+  const normalizedPercent = Math.min(100, Math.max(0, percent))
+  const progressAngle = normalizedPercent * 3.6
+  const progressColor = getCompactBalanceColor(normalizedPercent)
+  const surfaceColor = `color-mix(in srgb, ${progressColor} 14%, var(--card))`
+
+  return {
+    background: `linear-gradient(${surfaceColor}, ${surfaceColor}) padding-box, conic-gradient(from -90deg, ${progressColor} 0deg ${progressAngle}deg, var(--border) ${progressAngle}deg 360deg) border-box`,
+  }
+}
+
+export function BillingBalanceMeter({
+  balance,
+  total,
+  label,
+  hoverContent,
+  className,
+  meterClassName,
+  compact = false,
+  hideValueText = false,
+}: BillingBalanceMeterProps) {
+  const percent = getBillingBalancePercent(balance, total)
+  const compactBorderProgressStyle = getCompactBorderProgressStyle(percent)
+
+  const content = (
+    <div className={cn('inline-flex min-w-0', className)}>
+      <div
+        className={cn(
+          'w-[118px]',
+          compact &&
+            'flex h-9 w-[156px] items-center justify-between rounded-md border border-transparent px-3 shadow-xs transition-[background,transform]',
+          meterClassName
+        )}
+        style={compact ? compactBorderProgressStyle : undefined}
+      >
+        {compact ? (
+          <>
+            <div className="text-muted-foreground min-w-0 truncate text-[12px] leading-none">
+              {label}
+            </div>
+            <p
+              className={cn(
+                progressTextColor(percent, 'balance'),
+                'mb-0 text-[14px] leading-none font-bold'
+              )}
+            >
+              {percent.toFixed(1)}
+              <span className="ml-0.5">%</span>
+            </p>
+          </>
+        ) : (
+          <>
+            <div className="mb-0.5 flex items-center justify-between gap-2">
+              <div className="text-muted-foreground min-w-0 truncate text-[10px] leading-none">
+                {label}
+              </div>
+              <p className={progressTextColor(percent, 'balance')}>
+                {percent.toFixed(1)}
+                <span className="ml-0.5">%</span>
+              </p>
+            </div>
+            <ProgressBar percent={percent} mode="balance" className="h-1 w-full" />
+            {!hideValueText && (
+              <p className="text-muted-foreground pt-1 font-mono text-xs">
+                {formatBillingPair(balance, total)}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+
+  if (!hoverContent) {
+    return content
+  }
+
+  return (
+    <HoverCard openDelay={150} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <div className="cursor-help">{content}</div>
+      </HoverCardTrigger>
+      <HoverCardContent side="bottom" align="start" className="w-[240px] space-y-2 p-3">
+        {hoverContent}
+      </HoverCardContent>
+    </HoverCard>
+  )
+}

--- a/frontend/src/components/custom/billing-points-badge.tsx
+++ b/frontend/src/components/custom/billing-points-badge.tsx
@@ -1,0 +1,23 @@
+import { Badge } from '@/components/ui/badge'
+
+import { formatBillingPoints } from '@/utils/billing'
+
+import { cn } from '@/lib/utils'
+
+interface BillingPointsBadgeProps {
+  value?: number
+  className?: string
+  showLabel?: boolean
+}
+
+export function BillingPointsBadge({
+  value = 0,
+  className,
+  showLabel = false,
+}: BillingPointsBadgeProps) {
+  return (
+    <Badge variant="secondary" className={cn('font-mono font-normal', className)}>
+      {showLabel ? `累计 ${formatBillingPoints(value)}` : formatBillingPoints(value)}
+    </Badge>
+  )
+}

--- a/frontend/src/components/custom/billing-price-preview.tsx
+++ b/frontend/src/components/custom/billing-price-preview.tsx
@@ -1,0 +1,124 @@
+import { useQuery } from '@tanstack/react-query'
+import { CoinsIcon } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+
+import { apiBillingPriceList } from '@/services/api/billing'
+import { apiGetBillingStatus } from '@/services/api/system-config'
+
+import {
+  BillingPriceEntryInput,
+  formatBillingPoints,
+  summarizeBillingPriceEntries,
+} from '@/utils/billing'
+import { isBillingVisibleForUser } from '@/utils/billing-visibility'
+
+import { cn } from '@/lib/utils'
+
+interface BillingPricePreviewProps {
+  entries: BillingPriceEntryInput[]
+  className?: string
+}
+
+export function BillingPricePreview({ entries, className }: BillingPricePreviewProps) {
+  const { data: billingStatus } = useQuery({
+    queryKey: ['system-config', 'billing-status', 'price-preview'],
+    queryFn: () => apiGetBillingStatus().then((res) => res.data),
+    staleTime: 60 * 1000,
+  })
+  const billingVisible = isBillingVisibleForUser(billingStatus)
+  const { data: priceSources } = useQuery({
+    queryKey: ['resources', 'billing-price-preview'],
+    queryFn: () => apiBillingPriceList(),
+    select: (res) =>
+      res.data.reduce<Record<string, { label: string; unitPrice: number }>>((acc, resource) => {
+        acc[resource.name] = {
+          label: resource.label || resource.name,
+          unitPrice: resource.unitPrice ?? 0,
+        }
+        return acc
+      }, {}),
+    staleTime: 60 * 1000,
+    enabled: billingVisible,
+  })
+
+  const summaries = summarizeBillingPriceEntries(entries, priceSources ?? {})
+  const visibleSummaries = summaries.filter((entry) => entry.items.length > 0)
+  const totalPerHour = visibleSummaries.reduce((sum, entry) => sum + entry.subtotalPerHour, 0)
+  const uniqueItems = new Map<string, { label: string; unitPrice: number }>()
+
+  visibleSummaries.forEach((summary) => {
+    summary.items.forEach((item) => {
+      if (!uniqueItems.has(item.name)) {
+        uniqueItems.set(item.name, {
+          label: item.label,
+          unitPrice: item.unitPrice,
+        })
+      }
+    })
+  })
+
+  if (!billingVisible || entries.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={cn('bg-muted/20 rounded-xl border p-4', className)}>
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <CoinsIcon className="text-primary size-4" />
+        资源价格预览（点/单位/小时）
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {uniqueItems.size > 0 ? (
+          Array.from(uniqueItems.entries()).map(([name, item]) => (
+            <Badge key={name} variant="outline" className="bg-background font-normal">
+              <span className="text-muted-foreground mr-1">{item.label}</span>
+              <span className="font-mono">{formatBillingPoints(item.unitPrice)}</span>
+            </Badge>
+          ))
+        ) : (
+          <div className="text-muted-foreground bg-background rounded-lg border border-dashed px-3 py-2 text-xs">
+            当前配置中的资源单价均为 0.00，表示免费或暂未配置计费。
+          </div>
+        )}
+      </div>
+
+      {visibleSummaries.length > 1 && (
+        <div className="mt-3 grid gap-2">
+          {visibleSummaries.map((summary, index) => (
+            <div
+              key={`${summary.label ?? 'default'}-${index}`}
+              className="bg-background/80 flex items-center justify-between rounded-lg border px-3 py-2 text-sm"
+            >
+              <span className="text-muted-foreground">
+                {summary.label}
+                {summary.multiplier > 1 ? ` x${summary.multiplier}` : ''}
+              </span>
+              <span className="font-mono">{formatBillingPoints(summary.subtotalPerHour)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="bg-background mt-3 flex items-center justify-between rounded-lg border px-3 py-2">
+        <div>
+          <div className="text-sm font-medium">当前配置理论总价（点/小时）</div>
+          <div className="text-muted-foreground text-xs">
+            按小时展示并保留两位小数；0.00 表示免费或暂未配置，不参与提交前额度校验
+          </div>
+        </div>
+        <div className="font-mono text-sm font-semibold">{formatBillingPoints(totalPerHour)}</div>
+      </div>
+
+      <div className="bg-background mt-3 flex items-center justify-between rounded-lg border px-3 py-2">
+        <div>
+          <div className="text-sm font-medium">当前每个作业免费时长</div>
+          <div className="text-muted-foreground text-xs">超出后按资源单价进入计费。</div>
+        </div>
+        <div className="font-mono text-sm font-semibold">
+          {billingStatus?.jobFreeMinutes ?? 0} 分钟
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/custom/billing-summary-cards.tsx
+++ b/frontend/src/components/custom/billing-summary-cards.tsx
@@ -1,0 +1,131 @@
+import { ReactNode } from 'react'
+
+import { BillingBalanceMeter, formatBillingPair } from '@/components/custom/billing-balance-meter'
+import { TimeDistance } from '@/components/custom/time-distance'
+
+import { BillingSummaryResp } from '@/services/api/context'
+
+import { formatBillingPoints } from '@/utils/billing'
+
+import { cn } from '@/lib/utils'
+
+interface BillingAccountLike {
+  accountId: number
+  accountName: string
+  accountNickname?: string
+  periodFreeBalance: number
+  nextIssueAt?: string
+  effectiveIssueAmount: number
+}
+
+interface BillingSummaryCardsProps {
+  summary?: Partial<BillingSummaryResp>
+  accounts?: BillingAccountLike[]
+  className?: string
+  emphasis?: 'inline' | 'user'
+  compact?: boolean
+}
+
+function getActiveBucket(periodFreeBalance: number, extraBalance: number) {
+  return periodFreeBalance <= 0 && extraBalance > 0 ? '额外额度' : '免费额度'
+}
+
+function DetailRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3 text-xs">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono">{value}</span>
+    </div>
+  )
+}
+
+export function BillingSummaryCards({
+  summary,
+  accounts,
+  className,
+  emphasis = 'inline',
+  compact = false,
+}: BillingSummaryCardsProps) {
+  const periodFreeBalance = summary?.periodFreeBalance ?? 0
+  const extraBalance = summary?.extraBalance ?? 0
+  const effectiveIssueAmount = summary?.effectiveIssueAmount ?? 0
+  const nextIssueAt = summary?.nextIssueAt
+  const currentBucket = getActiveBucket(periodFreeBalance, extraBalance)
+
+  if (emphasis === 'user') {
+    const accountRows = accounts?.length
+      ? accounts
+      : [
+          {
+            accountId: 0,
+            accountName: '当前账户',
+            accountNickname: '当前账户',
+            periodFreeBalance,
+            nextIssueAt,
+            effectiveIssueAmount,
+          },
+        ]
+    const totalBalance =
+      accountRows.reduce((sum, item) => sum + item.periodFreeBalance, 0) + extraBalance
+    const issuedTotal =
+      accountRows.reduce((sum, item) => sum + Math.max(item.effectiveIssueAmount, 0), 0) +
+      Math.max(extraBalance, 0)
+    const totalAmount = issuedTotal > 0 ? issuedTotal : Math.max(totalBalance, 0)
+
+    return (
+      <div className={cn('inline-flex', className)}>
+        <BillingBalanceMeter
+          balance={totalBalance}
+          total={totalAmount}
+          meterClassName="w-[126px]"
+          hoverContent={
+            <div className="space-y-2">
+              {accountRows.map((item) => (
+                <div key={item.accountId} className="space-y-1">
+                  <DetailRow
+                    label={item.accountNickname || item.accountName}
+                    value={formatBillingPair(item.periodFreeBalance, item.effectiveIssueAmount)}
+                  />
+                  <DetailRow
+                    label="重置时间"
+                    value={item.nextIssueAt ? <TimeDistance date={item.nextIssueAt} /> : '-'}
+                  />
+                </div>
+              ))}
+              <DetailRow label="额外额度" value={formatBillingPoints(extraBalance)} />
+            </div>
+          }
+        />
+      </div>
+    )
+  }
+
+  const layerBalance = currentBucket === '额外额度' ? extraBalance : periodFreeBalance
+  const layerTotal = currentBucket === '额外额度' ? extraBalance : effectiveIssueAmount
+  return (
+    <div className={cn('inline-flex', className)}>
+      <BillingBalanceMeter
+        balance={layerBalance}
+        total={layerTotal}
+        label={currentBucket === '额外额度' ? '额外' : '免费'}
+        meterClassName="w-[122px]"
+        compact={compact}
+        hideValueText={compact}
+        hoverContent={
+          <div className="space-y-2">
+            <DetailRow label="当前使用层级" value={currentBucket} />
+            <DetailRow
+              label="剩余/账户总额"
+              value={formatBillingPair(layerBalance, effectiveIssueAmount)}
+            />
+            <DetailRow label="额外额度" value={formatBillingPoints(extraBalance)} />
+            <DetailRow
+              label="下次重置时间"
+              value={nextIssueAt ? <TimeDistance date={nextIssueAt} /> : '-'}
+            />
+          </div>
+        }
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/custom/user-points-tooltip.tsx
+++ b/frontend/src/components/custom/user-points-tooltip.tsx
@@ -1,0 +1,171 @@
+import { useQuery } from '@tanstack/react-query'
+import { ReactNode, useState } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+
+import { BillingInlineMeter, formatBillingPair } from '@/components/custom/billing-balance-meter'
+import { TimeDistance } from '@/components/custom/time-distance'
+
+import { apiAdminGetUserBillingAccounts } from '@/services/api/billing'
+
+import { formatBillingPoints } from '@/utils/billing'
+
+import { cn } from '@/lib/utils'
+
+interface UserPointsTooltipProps {
+  userName?: string
+  totalPoints: number
+  extraPoints?: number
+  periodFreePoints?: number
+  effectiveIssueAmount?: number
+  nextIssueLabel?: ReactNode
+  fetchDetail?: boolean
+  showInlineBreakdown?: boolean
+  inlineVariant?: 'minimal' | 'summary'
+  mode?: 'default' | 'account'
+}
+
+export function UserPointsTooltip({
+  userName,
+  totalPoints,
+  extraPoints = 0,
+  periodFreePoints = 0,
+  effectiveIssueAmount = 0,
+  nextIssueLabel,
+  fetchDetail = false,
+  showInlineBreakdown = false,
+  inlineVariant = 'minimal',
+  mode = 'default',
+}: UserPointsTooltipProps) {
+  const [open, setOpen] = useState(false)
+  const { data } = useQuery({
+    queryKey: ['admin', 'users', userName, 'billing-accounts', 'tooltip'],
+    queryFn: () => apiAdminGetUserBillingAccounts(userName ?? '').then((res) => res.data),
+    enabled: Boolean(fetchDetail && userName && open),
+    staleTime: 60 * 1000,
+  })
+
+  const aggregatedPeriodFreePoints = data?.reduce((sum, item) => sum + item.periodFreeBalance, 0)
+  const aggregatedIssueAmount = data?.reduce(
+    (sum, item) => sum + Math.max(item.effectiveIssueAmount, 0),
+    0
+  )
+  const useAggregatedTotals = mode !== 'account' && Boolean(data?.length)
+  const resolvedPeriodFreePoints = useAggregatedTotals
+    ? (aggregatedPeriodFreePoints ?? periodFreePoints)
+    : periodFreePoints
+  const resolvedEffectiveIssueAmount = useAggregatedTotals
+    ? (aggregatedIssueAmount ?? effectiveIssueAmount)
+    : effectiveIssueAmount
+
+  const inlineContent = !showInlineBreakdown ? (
+    <Badge variant="outline" className="font-mono text-xs font-normal">
+      {formatBillingPoints(totalPoints)}
+    </Badge>
+  ) : mode === 'account' ? (
+    <BillingInlineMeter
+      balance={resolvedPeriodFreePoints}
+      total={resolvedEffectiveIssueAmount}
+      className={inlineVariant === 'minimal' ? 'w-[96px]' : 'w-[116px]'}
+    />
+  ) : (
+    <BillingInlineMeter
+      balance={resolvedPeriodFreePoints}
+      total={resolvedEffectiveIssueAmount}
+      className="w-[96px]"
+    />
+  )
+
+  return (
+    <HoverCard open={open} onOpenChange={setOpen} openDelay={150} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <div
+          className={cn(
+            'inline-flex cursor-help flex-wrap items-center gap-1.5',
+            showInlineBreakdown && 'w-full'
+          )}
+        >
+          {inlineContent}
+        </div>
+      </HoverCardTrigger>
+      <HoverCardContent side="top" align="start" className="w-[260px] space-y-2 p-3">
+        <div className="space-y-2 text-xs">
+          {mode === 'account' ? (
+            <>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">当前账户免费额度</span>
+                <span className="font-mono">
+                  {formatBillingPair(resolvedPeriodFreePoints, resolvedEffectiveIssueAmount)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">额外点数</span>
+                <span className="font-mono">{formatBillingPoints(extraPoints)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">总可用</span>
+                <span className="font-mono">{formatBillingPoints(totalPoints)}</span>
+              </div>
+              {nextIssueLabel ? (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">重置时间</span>
+                  <span className="font-medium">{nextIssueLabel}</span>
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">总可用</span>
+                <span className="font-mono">{formatBillingPoints(totalPoints)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">免费额度合计</span>
+                <span className="font-mono">
+                  {formatBillingPair(resolvedPeriodFreePoints, resolvedEffectiveIssueAmount)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">额外点数</span>
+                <span className="font-mono">{formatBillingPoints(extraPoints)}</span>
+              </div>
+              {nextIssueLabel ? (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">重置时间</span>
+                  <span className="font-medium">{nextIssueLabel}</span>
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+        {fetchDetail && (data?.length ?? 0) > 0 ? (
+          <div className="space-y-2 border-t pt-2">
+            {(data ?? []).map((item) => {
+              return (
+                <div key={item.accountId} className="space-y-1">
+                  <div className="flex items-center justify-between gap-3 text-[11px]">
+                    <span className="text-muted-foreground max-w-[148px] truncate">
+                      {item.accountNickname || item.accountName}
+                    </span>
+                    <span className="font-mono">
+                      {formatBillingPair(item.periodFreeBalance, item.effectiveIssueAmount)}
+                    </span>
+                  </div>
+                  {item.nextIssueAt ? (
+                    <div className="flex items-center justify-between text-[11px]">
+                      <span className="text-muted-foreground">重置时间</span>
+                      <span className="font-medium">
+                        <TimeDistance date={item.nextIssueAt} />
+                      </span>
+                    </div>
+                  ) : null}
+                </div>
+              )
+            })}
+          </div>
+        ) : null}
+      </HoverCardContent>
+    </HoverCard>
+  )
+}

--- a/frontend/src/components/form/billing-period-fields.tsx
+++ b/frontend/src/components/form/billing-period-fields.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+export type BillingPeriodValue = {
+  days: number
+  hours: number
+  minutes: number
+  totalMinutes: number
+}
+
+export const billingPeriodFromMinutes = (totalMinutes?: number): BillingPeriodValue => {
+  const minutes = Math.max(0, Math.floor(totalMinutes ?? 0))
+  const days = Math.floor(minutes / (24 * 60))
+  const remainAfterDays = minutes % (24 * 60)
+  const hours = Math.floor(remainAfterDays / 60)
+  const mins = remainAfterDays % 60
+  return { days, hours, minutes: mins, totalMinutes: minutes }
+}
+
+export interface BillingPeriodFieldsProps {
+  totalMinutes?: number
+  onChange?: (value: BillingPeriodValue) => void
+  disabled?: boolean
+  className?: string
+}
+
+export function BillingPeriodFields({
+  totalMinutes,
+  onChange,
+  disabled,
+  className,
+}: BillingPeriodFieldsProps) {
+  const initial = billingPeriodFromMinutes(totalMinutes)
+  const [days, setDays] = useState<number>(initial.days)
+  const [hours, setHours] = useState<number>(initial.hours)
+  const [minutes, setMinutes] = useState<number>(initial.minutes)
+
+  useEffect(() => {
+    const next = billingPeriodFromMinutes(totalMinutes)
+    setDays(next.days)
+    setHours(next.hours)
+    setMinutes(next.minutes)
+  }, [totalMinutes])
+
+  const normalized = useMemo(() => {
+    const d = Math.max(0, Number.isFinite(days) ? Math.floor(days) : 0)
+    const h = Math.min(23, Math.max(0, Number.isFinite(hours) ? Math.floor(hours) : 0))
+    const m = Math.min(59, Math.max(0, Number.isFinite(minutes) ? Math.floor(minutes) : 0))
+    return {
+      days: d,
+      hours: h,
+      minutes: m,
+      totalMinutes: d * 24 * 60 + h * 60 + m,
+    }
+  }, [days, hours, minutes])
+
+  const didMountRef = useRef(false)
+  const onChangeRef = useRef<typeof onChange>(undefined)
+  useEffect(() => {
+    onChangeRef.current = onChange
+  }, [onChange])
+
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return
+    }
+    onChangeRef.current?.(normalized)
+  }, [normalized])
+
+  return (
+    <div className={className}>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        <div className="space-y-1">
+          <Label>天</Label>
+          <Input
+            type="number"
+            min={0}
+            disabled={disabled}
+            value={days}
+            onChange={(e) => setDays(Number(e.target.value))}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label>小时</Label>
+          <Input
+            type="number"
+            min={0}
+            max={23}
+            disabled={disabled}
+            value={hours}
+            onChange={(e) => setHours(Number(e.target.value))}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label>分钟</Label>
+          <Input
+            type="number"
+            min={0}
+            max={59}
+            disabled={disabled}
+            value={minutes}
+            onChange={(e) => setMinutes(Number(e.target.value))}
+          />
+        </div>
+      </div>
+      <p className="text-muted-foreground mt-2 text-xs">共 {normalized.totalMinutes} 分钟</p>
+    </div>
+  )
+}

--- a/frontend/src/components/form/resource-form-field.tsx
+++ b/frontend/src/components/form/resource-form-field.tsx
@@ -37,6 +37,7 @@ import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 import TipBadge from '@/components/badge/tip-badge'
+import { BillingPricePreview } from '@/components/custom/billing-price-preview'
 import Combobox, { ComboboxItem } from '@/components/form/combobox'
 import FormLabelMust from '@/components/form/form-label-must'
 import GrafanaIframe from '@/components/layout/embed/grafana-iframe'
@@ -80,6 +81,15 @@ export function ResourceFormFields<T extends FieldValues>({
 }: ResourceFormFieldsProps<T>) {
   const { t } = useTranslation()
   const gpuCount = form.watch(gpuCountPath)
+  const cpu = form.watch(cpuPath)
+  const memory = form.watch(memoryPath)
+  const gpuModel = form.watch(gpuModelPath)
+  const rdmaEnabled = rdmaPath ? form.watch(rdmaPath.rdmaEnabled) : false
+  const rdmaLabel = rdmaPath ? form.watch(rdmaPath.rdmaLabel) : undefined
+  const vgpuEnabled = vgpuPath ? form.watch(vgpuPath.vgpuEnabled) : false
+  const vgpuModels = (vgpuPath ? form.watch(vgpuPath.vgpuModels) : undefined) as
+    | Array<{ label?: string; value?: number }>
+    | undefined
   const grafanaOverview = useAtomValue(configGrafanaOverviewAtom)
 
   // 获取可用资源列表
@@ -102,6 +112,32 @@ export function ResourceFormFields<T extends FieldValues>({
         )
     },
   })
+
+  const billingEntry = useMemo(() => {
+    const resourceList: Record<string, string> = {}
+    if (typeof cpu === 'number' && cpu > 0) {
+      resourceList.cpu = `${cpu}`
+    }
+    if (typeof memory === 'number' && memory > 0) {
+      resourceList.memory = `${memory}Gi`
+    }
+    if (typeof gpuCount === 'number' && gpuCount > 0 && typeof gpuModel === 'string' && gpuModel) {
+      resourceList[gpuModel] = `${gpuCount}`
+    }
+    if (rdmaEnabled && typeof rdmaLabel === 'string' && rdmaLabel) {
+      resourceList[rdmaLabel] = '1'
+    }
+    if (vgpuEnabled && Array.isArray(vgpuModels)) {
+      vgpuModels.forEach((model: { label?: string; value?: number }) => {
+        const label = model?.label
+        const value = model?.value
+        if (typeof label === 'string' && label && typeof value === 'number' && value > 0) {
+          resourceList[label] = `${value}`
+        }
+      })
+    }
+    return [{ resourceList }]
+  }, [cpu, memory, gpuCount, gpuModel, rdmaEnabled, rdmaLabel, vgpuEnabled, vgpuModels])
 
   return (
     <>
@@ -231,6 +267,7 @@ export function ResourceFormFields<T extends FieldValues>({
           </SheetContent>
         </Sheet>
       </div>
+      <BillingPricePreview entries={billingEntry} />
     </>
   )
 }

--- a/frontend/src/components/job/create-billing-block-dialog.tsx
+++ b/frontend/src/components/job/create-billing-block-dialog.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface CreateBillingBlockDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function CreateBillingBlockDialog({ open, onOpenChange }: CreateBillingBlockDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>当前额度不足，无法提交作业</DialogTitle>
+        </DialogHeader>
+        <div className="text-muted-foreground space-y-2 text-sm">
+          <p>当前账户免费额度和额外额度都小于等于 0，提交作业已被拦截。</p>
+          <p>请联系管理员发放免费额度或额外点数后再试。</p>
+        </div>
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)}>知道了</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/job/detail/index.tsx
+++ b/frontend/src/components/job/detail/index.tsx
@@ -23,6 +23,7 @@ import {
   CheckCircleIcon,
   ClipboardListIcon,
   ClockIcon,
+  CoinsIcon,
   CreditCardIcon,
   FileSlidersIcon,
   GaugeIcon,
@@ -72,6 +73,7 @@ import {
 } from '@/components/ui-custom/alert-dialog'
 
 import { listApprovalOrdersbyName } from '@/services/api/approvalorder'
+import { apiJobBillingDetail } from '@/services/api/billing'
 import { apiGetPodIngresses } from '@/services/api/tool'
 import {
   JobPhase,
@@ -92,6 +94,7 @@ import useIsAdmin from '@/hooks/use-admin'
 import useFixedLayout from '@/hooks/use-fixed-layout'
 import { useSnapshotDisabled } from '@/hooks/use-snapshot-disabled'
 
+import { formatBillingPoints } from '@/utils/billing'
 import { hasNvidiaGPU } from '@/utils/resource'
 import { configGrafanaJobAtom } from '@/utils/store/config'
 import { getDaysDifference } from '@/utils/time'
@@ -118,6 +121,11 @@ export default function BaseCore({ jobName, ...props }: DetailPageCoreProps & { 
     queryKey: ['job', 'detail', jobName],
     queryFn: () => apiJobGetDetail(jobName),
     select: (res) => res.data,
+    refetchInterval: REFETCH_INTERVAL,
+  })
+  const { data: billingDetail } = useQuery({
+    queryKey: ['job', 'detail', jobName, 'billing'],
+    queryFn: () => apiJobBillingDetail(jobName).then((res) => res.data),
     refetchInterval: REFETCH_INTERVAL,
   })
 
@@ -370,6 +378,15 @@ export default function BaseCore({ jobName, ...props }: DetailPageCoreProps & { 
           title: '状态',
           icon: ActivityIcon,
           value: <JobPhaseLabel jobPhase={data.status} />,
+        },
+        {
+          title: '累计消耗',
+          icon: CoinsIcon,
+          value: (
+            <span className="font-mono text-sm">
+              {formatBillingPoints(billingDetail?.billedPointsTotal ?? 0)}
+            </span>
+          ),
         },
         {
           title: '创建于',

--- a/frontend/src/components/job/overview/admin-jobs.tsx
+++ b/frontend/src/components/job/overview/admin-jobs.tsx
@@ -15,7 +15,7 @@
  */
 // i18n-processed-v1.1.0
 // Modified code
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { UseQueryResult, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ColumnDef } from '@tanstack/react-table'
 import { t } from 'i18next'
 import { CalendarIcon, LockIcon, Trash2Icon } from 'lucide-react'
@@ -36,6 +36,7 @@ import JobTypeLabel, { jobTypes } from '@/components/badge/job-type-badge'
 import NodeBadges from '@/components/badge/node-badges'
 import ResourceBadges from '@/components/badge/resource-badges'
 import ScheduleTypeLabel from '@/components/badge/schedule-type-badge'
+import { BillingPointsBadge } from '@/components/custom/billing-points-badge
 import { TimeDistance } from '@/components/custom/time-distance'
 import { JobActionsMenu } from '@/components/job/overview/job-actions-menu'
 import { scheduleTypes } from '@/components/job/statuses'
@@ -45,6 +46,8 @@ import { DataTable } from '@/components/query-table'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
 import { DataTableToolbarConfig } from '@/components/query-table/toolbar'
 
+import { apiAdminGetJobBillingList } from '@/services/api/billing'
+import { apiAdminGetBillingStatus } from '@/services/api/system-config'
 import {
   IJobInfo,
   JobPhase,
@@ -53,8 +56,9 @@ import {
   apiAdminGetJobList,
   apiJobDeleteForAdmin,
   getUnifiedJobPhase,
-} from '@/services/api/vcjob'
+} from '@/services/api/vcjob
 
+import { isBillingVisibleForAdmin } from '@/utils/billing-visibility'
 import { logger } from '@/utils/loglevel'
 
 import { DurationDialog } from '../../../routes/admin/jobs/-components/duration-dialog'
@@ -69,6 +73,8 @@ export type StatusValue =
   | 'Succeeded'
   | 'Preempted'
   | 'Deleted'
+
+type JobTableRow = IJobInfo & { billedPointsTotal?: number }
 
 export const getHeader = (key: string): string => {
   switch (key) {
@@ -106,6 +112,11 @@ const AdminJobOverview = () => {
   const [selectedJobs, setSelectedJobs] = useState<IJobInfo[]>([])
   const [isLockDialogOpen, setIsLockDialogOpen] = useState(false)
   const [isExtendDialogOpen, setIsExtendDialogOpen] = useState(false)
+  const { data: billingStatus } = useQuery({
+    queryKey: ['admin', 'system-config', 'billing-status'],
+    queryFn: () => apiAdminGetBillingStatus().then((res) => res.data),
+  })
+  const billingVisible = isBillingVisibleForAdmin(billingStatus)
 
   const toolbarConfig: DataTableToolbarConfig = {
     globalSearch: {
@@ -136,6 +147,47 @@ const AdminJobOverview = () => {
     queryFn: () => apiAdminGetJobList(days),
     select: (res) => res.data,
   })
+  const billingQuery = useQuery({
+    queryKey: ['admin', 'tasklist', 'job', 'billing', days],
+    queryFn: () => apiAdminGetJobBillingList(days),
+    select: (res) =>
+      res.data.reduce<Record<string, number>>((acc, item) => {
+        acc[item.jobName] = item.billedPointsTotal
+        return acc
+      }, {}),
+    enabled: billingVisible,
+  })
+  const refetchVcjobQuery = vcjobQuery.refetch
+  const refetchBillingQuery = billingQuery.refetch
+  const refetchMergedQuery = useCallback(async () => {
+    const [vcjobResult] = await Promise.all([refetchVcjobQuery(), refetchBillingQuery()])
+    return vcjobResult
+  }, [refetchBillingQuery, refetchVcjobQuery])
+  const mergedVcjobQuery = useMemo(
+    () =>
+      ({
+        data: (vcjobQuery.data ?? []).map((job) => ({
+          ...job,
+          billedPointsTotal: billingQuery.data?.[job.jobName] ?? 0,
+        })),
+        isLoading: vcjobQuery.isLoading || (billingVisible && billingQuery.isLoading),
+        dataUpdatedAt: Math.max(
+          vcjobQuery.dataUpdatedAt,
+          billingVisible ? billingQuery.dataUpdatedAt : 0
+        ),
+        refetch: refetchMergedQuery,
+      }) as unknown as UseQueryResult<JobTableRow[], Error>,
+    [
+      billingVisible,
+      billingQuery.data,
+      billingQuery.dataUpdatedAt,
+      billingQuery.isLoading,
+      refetchMergedQuery,
+      vcjobQuery.data,
+      vcjobQuery.dataUpdatedAt,
+      vcjobQuery.isLoading,
+    ]
+  )
 
   const refetchTaskList = useCallback(async () => {
     try {
@@ -143,6 +195,11 @@ const AdminJobOverview = () => {
         new Promise((resolve) => setTimeout(resolve, 200)).then(() =>
           queryClient.invalidateQueries({
             queryKey: ['admin', 'tasklist', 'job', days],
+          })
+        ),
+        new Promise((resolve) => setTimeout(resolve, 200)).then(() =>
+          queryClient.invalidateQueries({
+            queryKey: ['admin', 'tasklist', 'job', 'billing', days],
           })
         ),
       ])
@@ -159,7 +216,7 @@ const AdminJobOverview = () => {
     },
   })
 
-  const vcjobColumns = useMemo<ColumnDef<IJobInfo>[]>(() => {
+  const vcjobColumns = useMemo<ColumnDef<JobTableRow>[]>(() => {
     const getHeader = (key: string): string => {
       switch (key) {
         case 'jobName':
@@ -248,6 +305,15 @@ const AdminJobOverview = () => {
           return <ResourceBadges resources={resources} />
         },
       },
+      ...(billingVisible
+        ? [
+            {
+              accessorKey: 'billedPointsTotal',
+              header: ({ column }) => <DataTableColumnHeader column={column} title="累计点数" />,
+              cell: ({ row }) => <BillingPointsBadge value={row.original.billedPointsTotal ?? 0} />,
+            } as ColumnDef<JobTableRow>,
+          ]
+        : []),
       {
         accessorFn: (row) => getUnifiedJobPhase(row.status),
         id: 'status',
@@ -307,7 +373,7 @@ const AdminJobOverview = () => {
         },
       },
     ]
-  }, [deleteTask, refetchTaskList, t])
+  }, [billingVisible, deleteTask, refetchTaskList, t])
 
   return (
     <>
@@ -317,7 +383,7 @@ const AdminJobOverview = () => {
           description: t('adminJobOverview.description'),
         }}
         storageKey="admin_job_overview"
-        query={vcjobQuery}
+        query={mergedVcjobQuery}
         columns={vcjobColumns}
         toolbarConfig={toolbarConfig}
         multipleHandlers={[

--- a/frontend/src/components/job/overview/admin-jobs.tsx
+++ b/frontend/src/components/job/overview/admin-jobs.tsx
@@ -36,7 +36,7 @@ import JobTypeLabel, { jobTypes } from '@/components/badge/job-type-badge'
 import NodeBadges from '@/components/badge/node-badges'
 import ResourceBadges from '@/components/badge/resource-badges'
 import ScheduleTypeLabel from '@/components/badge/schedule-type-badge'
-import { BillingPointsBadge } from '@/components/custom/billing-points-badge
+import { BillingPointsBadge } from '@/components/custom/billing-points-badge'
 import { TimeDistance } from '@/components/custom/time-distance'
 import { JobActionsMenu } from '@/components/job/overview/job-actions-menu'
 import { scheduleTypes } from '@/components/job/statuses'
@@ -56,7 +56,7 @@ import {
   apiAdminGetJobList,
   apiJobDeleteForAdmin,
   getUnifiedJobPhase,
-} from '@/services/api/vcjob
+} from '@/services/api/vcjob'
 
 import { isBillingVisibleForAdmin } from '@/utils/billing-visibility'
 import { logger } from '@/utils/loglevel'

--- a/frontend/src/components/job/overview/custom-jobs.tsx
+++ b/frontend/src/components/job/overview/custom-jobs.tsx
@@ -46,7 +46,7 @@ import {
   apiJobDelete,
   getUnifiedJobPhase,
   isInteracitveJob,
-} from '@/services/api/vcjob
+} from '@/services/api/vcjob'
 
 import { isBillingVisibleForUser } from '@/utils/billing-visibility'
 import { logger } from '@/utils/loglevel'

--- a/frontend/src/components/job/overview/custom-jobs.tsx
+++ b/frontend/src/components/job/overview/custom-jobs.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { UseQueryResult, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ColumnDef } from '@tanstack/react-table'
 import { Trash2Icon } from 'lucide-react'
 import { useMemo } from 'react'
@@ -26,6 +26,7 @@ import NodeBadges from '@/components/badge/node-badges'
 import ResourceBadges from '@/components/badge/resource-badges'
 import ScheduleTypeLabel from '@/components/badge/schedule-type-badge'
 import DocsButton from '@/components/button/docs-button'
+import { BillingPointsBadge } from '@/components/custom/billing-points-badge'
 import { TimeDistance } from '@/components/custom/time-distance'
 import JobResourceSummary from '@/components/job/job-resource-summary'
 import { JobActionsMenu } from '@/components/job/overview/job-actions-menu'
@@ -34,6 +35,8 @@ import { JobNameCell } from '@/components/label/job-name-label'
 import { DataTable } from '@/components/query-table'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
 
+import { apiJobBillingList } from '@/services/api/billing'
+import { apiGetBillingStatus } from '@/services/api/system-config'
 import {
   IJobInfo,
   JobPhase,
@@ -43,17 +46,25 @@ import {
   apiJobDelete,
   getUnifiedJobPhase,
   isInteracitveJob,
-} from '@/services/api/vcjob'
+} from '@/services/api/vcjob
 
+import { isBillingVisibleForUser } from '@/utils/billing-visibility'
 import { logger } from '@/utils/loglevel'
 
 import { REFETCH_INTERVAL } from '@/lib/constants'
 
 import ListedNewJobButton from '../new-job-button'
 
+type JobTableRow = IJobInfo & { billedPointsTotal?: number }
+
 const VolcanoOverview = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const { data: billingStatus } = useQuery({
+    queryKey: ['system-config', 'billing-status'],
+    queryFn: () => apiGetBillingStatus().then((res) => res.data),
+  })
+  const billingVisible = isBillingVisibleForUser(billingStatus)
 
   const batchQuery = useQuery({
     queryKey: ['job', 'batch'],
@@ -61,12 +72,49 @@ const VolcanoOverview = () => {
     select: (res) => res.data.filter((task) => !isInteracitveJob(task.jobType)),
     refetchInterval: REFETCH_INTERVAL,
   })
+  const billingQuery = useQuery({
+    queryKey: ['job', 'billing'],
+    queryFn: apiJobBillingList,
+    select: (res) =>
+      res.data.reduce<Record<string, number>>((acc, item) => {
+        acc[item.jobName] = item.billedPointsTotal
+        return acc
+      }, {}),
+    refetchInterval: REFETCH_INTERVAL,
+    enabled: billingVisible,
+  })
+  const mergedBatchQuery = useMemo(
+    () =>
+      ({
+        data: (batchQuery.data ?? []).map((job) => ({
+          ...job,
+          billedPointsTotal: billingQuery.data?.[job.jobName] ?? 0,
+        })),
+        isLoading: batchQuery.isLoading || (billingVisible && billingQuery.isLoading),
+        dataUpdatedAt: Math.max(
+          batchQuery.dataUpdatedAt,
+          billingVisible ? billingQuery.dataUpdatedAt : 0
+        ),
+        refetch: batchQuery.refetch,
+      }) as unknown as UseQueryResult<JobTableRow[], Error>,
+    [
+      batchQuery.data,
+      batchQuery.dataUpdatedAt,
+      batchQuery.isLoading,
+      batchQuery.refetch,
+      billingVisible,
+      billingQuery.data,
+      billingQuery.dataUpdatedAt,
+      billingQuery.isLoading,
+    ]
+  )
 
   const refetchTaskList = async () => {
     try {
       // 并行发送所有异步请求
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['job'] }),
+        queryClient.invalidateQueries({ queryKey: ['job', 'billing'] }),
         queryClient.invalidateQueries({ queryKey: ['aitask', 'quota'] }),
         queryClient.invalidateQueries({ queryKey: ['aitask', 'stats'] }),
         queryClient.invalidateQueries({ queryKey: ['context', 'job-resource-summary'] }),
@@ -84,7 +132,7 @@ const VolcanoOverview = () => {
     },
   })
 
-  const batchColumns = useMemo<ColumnDef<IJobInfo>[]>(
+  const batchColumns = useMemo<ColumnDef<JobTableRow>[]>(
     () => [
       {
         accessorKey: 'jobType',
@@ -142,6 +190,15 @@ const VolcanoOverview = () => {
           return <ResourceBadges resources={resources} />
         },
       },
+      ...(billingVisible
+        ? [
+            {
+              accessorKey: 'billedPointsTotal',
+              header: ({ column }) => <DataTableColumnHeader column={column} title="累计点数" />,
+              cell: ({ row }) => <BillingPointsBadge value={row.original.billedPointsTotal ?? 0} />,
+            } as ColumnDef<JobTableRow>,
+          ]
+        : []),
       {
         accessorKey: 'createdAt',
         header: ({ column }) => (
@@ -181,7 +238,7 @@ const VolcanoOverview = () => {
         },
       },
     ],
-    [deleteTask]
+    [billingVisible, deleteTask]
   )
 
   return (
@@ -191,7 +248,7 @@ const VolcanoOverview = () => {
         description: '使用自定义作业进行训练、推理等任务',
       }}
       storageKey="portal_batch_job_overview"
-      query={batchQuery}
+      query={mergedBatchQuery}
       columns={batchColumns}
       toolbarConfig={jobToolbarConfig}
       briefChildren={<JobResourceSummary />}

--- a/frontend/src/components/job/overview/emias-jobs.tsx
+++ b/frontend/src/components/job/overview/emias-jobs.tsx
@@ -35,6 +35,7 @@ import {
 import JobPhaseLabel, { jobPhases } from '@/components/badge/job-phase-badge'
 import JobTypeLabel from '@/components/badge/job-type-badge'
 import ResourceBadges from '@/components/badge/resource-badges'
+import { BillingPointsBadge } from '@/components/custom/billing-points-badge'
 import { TimeDistance } from '@/components/custom/time-distance'
 import JobResourceSummary from '@/components/job/job-resource-summary'
 import { getHeader } from '@/components/job/statuses'
@@ -54,9 +55,12 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui-custom/alert-dialog'
 
+import { apiJobBillingList } from '@/services/api/billing'
+import { apiGetBillingStatus } from '@/services/api/system-config'
 import { apiJobBatchList, apiJobDelete } from '@/services/api/vcjob'
 import { IJobInfo, JobType, getUnifiedJobPhase } from '@/services/api/vcjob'
 
+import { isBillingVisibleForUser } from '@/utils/billing-visibility'
 import { logger } from '@/utils/loglevel'
 
 import { REFETCH_INTERVAL } from '@/lib/constants'
@@ -145,11 +149,17 @@ interface ColocateJobInfo extends IJobInfo {
   id: number
   profileStatus: string
   priority: string
+  billedPointsTotal?: number
 }
 
 const ColocateOverview = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const { data: billingStatus } = useQuery({
+    queryKey: ['system-config', 'billing-status'],
+    queryFn: () => apiGetBillingStatus().then((res) => res.data),
+  })
+  const billingVisible = isBillingVisibleForUser(billingStatus)
 
   const batchQuery = useQuery({
     queryKey: ['job', 'batch'],
@@ -160,12 +170,49 @@ const ColocateOverview = () => {
         .sort((a, b) => b.createdAt.localeCompare(a.createdAt)) as unknown as ColocateJobInfo[],
     refetchInterval: REFETCH_INTERVAL,
   })
+  const billingQuery = useQuery({
+    queryKey: ['job', 'billing'],
+    queryFn: apiJobBillingList,
+    select: (res) =>
+      res.data.reduce<Record<string, number>>((acc, item) => {
+        acc[item.jobName] = item.billedPointsTotal
+        return acc
+      }, {}),
+    refetchInterval: REFETCH_INTERVAL,
+    enabled: billingVisible,
+  })
+  const mergedBatchQuery = useMemo(
+    () =>
+      ({
+        data: (batchQuery.data ?? []).map((job) => ({
+          ...job,
+          billedPointsTotal: billingQuery.data?.[job.jobName] ?? 0,
+        })),
+        isLoading: batchQuery.isLoading || (billingVisible && billingQuery.isLoading),
+        dataUpdatedAt: Math.max(
+          batchQuery.dataUpdatedAt,
+          billingVisible ? billingQuery.dataUpdatedAt : 0
+        ),
+        refetch: batchQuery.refetch,
+      }) as typeof batchQuery,
+    [
+      batchQuery.data,
+      batchQuery.dataUpdatedAt,
+      batchQuery.isLoading,
+      batchQuery.refetch,
+      billingVisible,
+      billingQuery.data,
+      billingQuery.dataUpdatedAt,
+      billingQuery.isLoading,
+    ]
+  )
 
   const refetchTaskList = async () => {
     try {
       // 并行发送所有异步请求
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['job'] }),
+        queryClient.invalidateQueries({ queryKey: ['job', 'billing'] }),
         queryClient.invalidateQueries({ queryKey: ['aitask', 'quota'] }),
         queryClient.invalidateQueries({ queryKey: ['aitask', 'stats'] }),
         queryClient.invalidateQueries({ queryKey: ['context', 'job-resource-summary'] }),
@@ -280,6 +327,15 @@ const ColocateOverview = () => {
           return (value as string[]).includes(row.getValue(id))
         },
       },
+      ...(billingVisible
+        ? [
+            {
+              accessorKey: 'billedPointsTotal',
+              header: ({ column }) => <DataTableColumnHeader column={column} title="累计点数" />,
+              cell: ({ row }) => <BillingPointsBadge value={row.original.billedPointsTotal ?? 0} />,
+            } as ColumnDef<ColocateJobInfo>,
+          ]
+        : []),
       {
         accessorKey: 'createdAt',
         header: ({ column }) => (
@@ -360,7 +416,7 @@ const ColocateOverview = () => {
         },
       },
     ],
-    [deleteTask, t, priorities, profilingStatuses]
+    [billingVisible, deleteTask, t, priorities, profilingStatuses]
   )
 
   return (
@@ -371,7 +427,7 @@ const ColocateOverview = () => {
           description: t('jobs.customJobs.description'),
         }}
         storageKey="portal_aijob_batch"
-        query={batchQuery}
+        query={mergedBatchQuery}
         columns={batchColumns}
         toolbarConfig={getToolbarConfig(t)}
         multipleHandlers={[

--- a/frontend/src/components/layout/detail-page.tsx
+++ b/frontend/src/components/layout/detail-page.tsx
@@ -125,12 +125,12 @@ export default function DetailPage({
     <div className="flex h-full w-full flex-col gap-6 overflow-hidden">
       <div className="shrink-0 space-y-6">
         {header}
-        <div className="text-muted-foreground grid grid-cols-3 gap-3 text-sm">
+        <div className="text-muted-foreground grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
           {info.map((data, index) => (
-            <div key={index} className={cn('flex items-center', data.className)}>
-              <data.icon className="text-muted-foreground mr-1.5 size-4" />
+            <div key={index} className={cn('flex min-w-0 items-center', data.className)}>
+              <data.icon className="text-muted-foreground mr-1.5 size-4 shrink-0" />
               <span className="text-muted-foreground mr-1.5 truncate text-sm">{data.title}:</span>
-              <span className="truncate">{data.value}</span>
+              <span className="min-w-0 truncate">{data.value}</span>
             </div>
           ))}
         </div>

--- a/frontend/src/components/node/node-list.tsx
+++ b/frontend/src/components/node/node-list.tsx
@@ -27,7 +27,7 @@ import TooltipLink from '@/components/label/tooltip-link'
 import TooltipCopy from '@/components/label/tooltop-copy'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
 import { DataTableToolbarConfig } from '@/components/query-table/toolbar'
-import { ProgressBar, progressTextColor } from '@/components/ui-custom/colorful-progress'
+import { MetricMeter } from '@/components/ui-custom/metric-meter'
 
 import { IClusterNodeTaint, INodeBriefInfo, NodeStatus } from '@/services/api/cluster'
 
@@ -203,14 +203,16 @@ export const UsageCell: FC<{
   }
 
   return (
-    <div className="w-20">
-      <p className={progressTextColor(usagePercent)}>
-        {usagePercent.toFixed(1)}
-        <span className="ml-0.5">%</span>
-      </p>
-      <ProgressBar percent={usagePercent} className="h-1 w-full" />
-      <p className="text-muted-foreground pt-1 font-mono text-xs">{displayValue}</p>
-    </div>
+    <MetricMeter
+      percent={usagePercent}
+      primary={
+        <>
+          {usagePercent.toFixed(1)}
+          <span className="ml-0.5">%</span>
+        </>
+      }
+      secondary={displayValue}
+    />
   )
 }
 
@@ -231,14 +233,17 @@ export const MultiGPUUsageCell: FC<{
   return (
     <div className="flex flex-col items-start justify-center gap-2">
       {gpuInfoList.map((gpuInfo, index) => (
-        <div key={index} className="w-20">
-          <p className={progressTextColor(gpuInfo.usagePercent)}>
-            {gpuInfo.usagePercent.toFixed(1)}
-            <span className="ml-0.5">%</span>
-          </p>
-          <ProgressBar percent={gpuInfo.usagePercent} className="h-1 w-full" />
-          <p className="text-muted-foreground pt-1 font-mono text-xs">{gpuInfo.displayValue}</p>
-        </div>
+        <MetricMeter
+          key={index}
+          percent={gpuInfo.usagePercent}
+          primary={
+            <>
+              {gpuInfo.usagePercent.toFixed(1)}
+              <span className="ml-0.5">%</span>
+            </>
+          }
+          secondary={gpuInfo.displayValue}
+        />
       ))}
     </div>
   )

--- a/frontend/src/components/ui-custom/colorful-progress.tsx
+++ b/frontend/src/components/ui-custom/colorful-progress.tsx
@@ -16,32 +16,69 @@
 // i18n-processed-v1.1.0
 import { cn } from '@/lib/utils'
 
-export const progressTextColor = (percent: number) => {
+export type ProgressMode = 'usage' | 'balance'
+
+const getProgressTone = (percent: number, mode: ProgressMode) => {
+  if (mode === 'balance') {
+    if (percent > 90) {
+      return 'emerald'
+    }
+    if (percent > 70) {
+      return 'sky'
+    }
+    if (percent > 50) {
+      return 'yellow'
+    }
+    if (percent > 20) {
+      return 'orange'
+    }
+    return 'red'
+  }
+  if (percent <= 20) {
+    return 'emerald'
+  }
+  if (percent <= 50) {
+    return 'sky'
+  }
+  if (percent <= 70) {
+    return 'yellow'
+  }
+  if (percent <= 90) {
+    return 'orange'
+  }
+  return 'red'
+}
+
+export const progressTextColor = (percent: number, mode: ProgressMode = 'usage') => {
+  const tone = getProgressTone(percent, mode)
   return cn('text-highlight-emerald mb-0.5 font-mono text-sm font-bold', {
-            'text-highlight-emerald': percent <= 20,
-            'text-highlight-sky': percent > 20 && percent <= 50,
-            'text-highlight-yellow': percent > 50 && percent <= 70,
-            'text-highlight-orange': percent > 70 && percent <= 90,
-            'text-highlight-red': percent > 90,
-          })
+    'text-highlight-emerald': tone === 'emerald',
+    'text-highlight-sky': tone === 'sky',
+    'text-highlight-yellow': tone === 'yellow',
+    'text-highlight-orange': tone === 'orange',
+    'text-highlight-red': tone === 'red',
+  })
 }
 
 export const ProgressBar = ({
   percent,
   label,
   className,
+  mode = 'usage',
 }: {
   percent: number
   label?: string
   className?: string
+  mode?: ProgressMode
 }) => {
-  const newWidth = percent > 100 ? 100 : percent
+  const normalizedPercent = Math.min(100, Math.max(0, percent))
+  const tone = getProgressTone(normalizedPercent, mode)
   return (
     <div
       className={cn(
         'bg-accent text-foreground relative h-2 rounded-md',
         {
-          'text-white': percent > 90,
+          'text-white': mode === 'usage' && normalizedPercent > 90,
         },
         className
       )}
@@ -50,15 +87,15 @@ export const ProgressBar = ({
         className={cn(
           'h-2 rounded-md transition-all duration-500',
           {
-            'bg-highlight-emerald': percent <= 20,
-            'bg-highlight-sky': percent > 20 && percent <= 50,
-            'bg-highlight-yellow': percent > 50 && percent <= 70,
-            'bg-highlight-orange': percent > 70 && percent <= 90,
-            'bg-highlight-red': percent > 90,
+            'bg-highlight-emerald': tone === 'emerald',
+            'bg-highlight-sky': tone === 'sky',
+            'bg-highlight-yellow': tone === 'yellow',
+            'bg-highlight-orange': tone === 'orange',
+            'bg-highlight-red': tone === 'red',
           },
           className
         )}
-        style={{ width: `${newWidth}%` }}
+        style={{ width: `${normalizedPercent}%` }}
       ></div>
       {label && (
         <div className="absolute inset-0 font-mono text-xs font-medium">

--- a/frontend/src/components/ui-custom/metric-meter.tsx
+++ b/frontend/src/components/ui-custom/metric-meter.tsx
@@ -1,0 +1,59 @@
+import { ReactNode } from 'react'
+
+import { ProgressBar, ProgressMode, progressTextColor } from '@/components/ui-custom/colorful-progress'
+
+import { cn } from '@/lib/utils'
+
+interface MetricMeterProps {
+  percent: number
+  primary: ReactNode
+  secondary?: ReactNode
+  leading?: ReactNode
+  trailing?: ReactNode
+  layout?: 'stacked' | 'inline'
+  mode?: ProgressMode
+  className?: string
+  barClassName?: string
+}
+
+export function MetricMeter({
+  percent,
+  primary,
+  secondary,
+  leading,
+  trailing,
+  layout = 'stacked',
+  mode = 'usage',
+  className,
+  barClassName,
+}: MetricMeterProps) {
+  const normalizedPercent = Math.min(100, Math.max(0, percent))
+
+  if (layout === 'inline') {
+    return (
+      <div className={cn('inline-flex min-w-0 items-center gap-2', className)}>
+        {leading}
+        <span className="font-mono text-xs font-semibold">{primary}</span>
+        <div className="min-w-0 flex-1">
+          <ProgressBar
+            percent={normalizedPercent}
+            mode={mode}
+            className={cn('h-1 w-full min-w-12', barClassName)}
+          />
+        </div>
+        {trailing}
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('w-20', className)}>
+      <div className="flex items-end justify-between gap-1">
+        <p className={progressTextColor(normalizedPercent, mode)}>{primary}</p>
+        {trailing ? <div className="text-muted-foreground text-[10px]">{trailing}</div> : null}
+      </div>
+      <ProgressBar percent={normalizedPercent} mode={mode} className={cn('h-1 w-full', barClassName)} />
+      {secondary ? <p className="text-muted-foreground pt-1 font-mono text-xs">{secondary}</p> : null}
+    </div>
+  )
+}

--- a/frontend/src/hooks/use-job-create-billing-block.ts
+++ b/frontend/src/hooks/use-job-create-billing-block.ts
@@ -1,0 +1,34 @@
+import { HTTPError } from 'ky'
+import { useState } from 'react'
+
+import { ERROR_BUSINESS_LOGIC_ERROR } from '@/services/error_code'
+import { IErrorResponse } from '@/services/types'
+
+const BILLING_BLOCK_PREFIX = 'billing precheck blocked:'
+
+export function isJobCreateBillingBlocked(error: unknown) {
+  if (!(error instanceof HTTPError)) {
+    return false
+  }
+  const errorWithData = error as HTTPError & { data?: IErrorResponse }
+  return (
+    errorWithData.data?.code === ERROR_BUSINESS_LOGIC_ERROR &&
+    Boolean(errorWithData.data?.msg?.startsWith(BILLING_BLOCK_PREFIX))
+  )
+}
+
+export function useJobCreateBillingBlockDialog() {
+  const [open, setOpen] = useState(false)
+
+  return {
+    billingBlockDialogOpen: open,
+    setBillingBlockDialogOpen: setOpen,
+    handleJobCreateError: (error: unknown) => {
+      if (isJobCreateBillingBlocked(error)) {
+        setOpen(true)
+        return true
+      }
+      return false
+    },
+  }
+}

--- a/frontend/src/routes/admin/accounts/-components/account-form-component.tsx
+++ b/frontend/src/routes/admin/accounts/-components/account-form-component.tsx
@@ -19,7 +19,7 @@ import { format } from 'date-fns'
 import { zhCN } from 'date-fns/locale'
 import { useAtomValue } from 'jotai'
 import { CalendarIcon, CirclePlusIcon, XIcon } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -41,6 +41,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 
 import LoadableButton from '@/components/button/loadable-button'
 import SelectBox from '@/components/custom/select-box'
+import { BillingPeriodFields } from '@/components/form/billing-period-fields'
 import FormExportButton from '@/components/form/form-export-button'
 import FormImportButton from '@/components/form/form-import-button'
 import FormLabelMust from '@/components/form/form-label-must'
@@ -49,9 +50,14 @@ import { SandwichLayout } from '@/components/sheet/sandwich-sheet'
 
 import { IAccount, apiAccountCreate, apiAccountUpdate } from '@/services/api/account'
 import { apiAdminUserList } from '@/services/api/admin/user'
+import {
+  apiAdminGetAccountBillingConfig,
+  apiAdminUpdateAccountBillingConfig,
+} from '@/services/api/billing'
 import { apiResourceList } from '@/services/api/resource'
+import { apiAdminGetBillingStatus } from '@/services/api/system-config'
 
-import { convertFormToQuota } from '@/utils/quota'
+import { convertFormToQuota, convertQuotaToForm } from '@/utils/quota'
 import { globalSettings } from '@/utils/store'
 
 import { cn } from '@/lib/utils'
@@ -80,7 +86,7 @@ export const AccountForm = ({ onOpenChange, account }: AccountFormProps) => {
       })),
   })
 
-  const { data: resourceDimension } = useQuery({
+  const resourceDimensionQuery = useQuery({
     queryKey: ['resources', 'list'],
     queryFn: () => apiResourceList(false),
     select: (res) => {
@@ -113,6 +119,22 @@ export const AccountForm = ({ onOpenChange, account }: AccountFormProps) => {
         )
     },
   })
+  const resourceDimension = resourceDimensionQuery.data
+
+  const { data: billingStatus } = useQuery({
+    queryKey: ['admin', 'system-config', 'billing-status'],
+    queryFn: () => apiAdminGetBillingStatus().then((res) => res.data),
+  })
+  const billingEnabled = billingStatus?.featureEnabled ?? false
+  const amountOverrideEnabled = billingStatus?.accountIssueAmountOverrideEnabled ?? false
+  const periodOverrideEnabled = billingStatus?.accountIssuePeriodOverrideEnabled ?? false
+  const accountBillingConfigQuery = useQuery({
+    queryKey: ['admin', 'accounts', account?.id, 'billing-config'],
+    queryFn: () => apiAdminGetAccountBillingConfig(account?.id ?? 0).then((res) => res.data),
+    enabled: billingEnabled && Boolean(account?.id),
+  })
+  const accountBillingConfig = accountBillingConfigQuery.data
+  const hydratedFormKeyRef = useRef<string | null>(null)
 
   // 1. Define your form.
   const form = useForm<AccountFormSchema>({
@@ -125,9 +147,48 @@ export const AccountForm = ({ onOpenChange, account }: AccountFormProps) => {
       ],
       expiredAt: account?.expiredAt ? new Date(account.expiredAt) : undefined,
       admins: [],
+      billingIssueAmount: accountBillingConfig?.issueAmount,
+      billingIssuePeriodMinutes: accountBillingConfig?.issuePeriodMinutes,
       ...(account ? { id: account.id } : {}),
     },
   })
+
+  const hydratedValues = useMemo<AccountFormSchema>(
+    () => ({
+      name: account?.nickname || '',
+      resources:
+        account && resourceDimension
+          ? convertQuotaToForm(account.quota, resourceDimension)
+          : resourceDimension?.map((name) => ({ name })) || [{ name: 'cpu' }, { name: 'memory' }],
+      expiredAt: account?.expiredAt ? new Date(account.expiredAt) : undefined,
+      admins: [],
+      billingIssueAmount: accountBillingConfig?.issueAmount,
+      billingIssuePeriodMinutes: accountBillingConfig?.issuePeriodMinutes,
+      ...(account ? { id: account.id } : {}),
+    }),
+    [account, accountBillingConfig, resourceDimension]
+  )
+  const needsBillingHydration = billingEnabled && Boolean(account?.id)
+  const hydrationReady =
+    resourceDimensionQuery.isFetched &&
+    (!needsBillingHydration || accountBillingConfigQuery.isFetched)
+  const hydrationKey = hydrationReady
+    ? `${account?.id ?? 'create'}:${resourceDimensionQuery.dataUpdatedAt}:${accountBillingConfigQuery.dataUpdatedAt}`
+    : null
+
+  useEffect(() => {
+    if (!hydrationKey) {
+      return
+    }
+    if (hydratedFormKeyRef.current === hydrationKey) {
+      return
+    }
+
+    form.reset(hydratedValues, {
+      keepDirtyValues: true,
+    })
+    hydratedFormKeyRef.current = hydrationKey
+  }, [form, hydratedValues, hydrationKey])
 
   const currentValues = form.watch()
 
@@ -140,36 +201,93 @@ export const AccountForm = ({ onOpenChange, account }: AccountFormProps) => {
     control: form.control,
   })
 
+  const buildBillingConfigPayload = (values: AccountFormSchema) => {
+    const payload: { issueAmount?: number; issuePeriodMinutes?: number } = {}
+    if (billingEnabled && amountOverrideEnabled && values.billingIssueAmount !== undefined) {
+      payload.issueAmount = values.billingIssueAmount
+    }
+    if (billingEnabled && periodOverrideEnabled && values.billingIssuePeriodMinutes !== undefined) {
+      payload.issuePeriodMinutes = values.billingIssuePeriodMinutes
+    }
+    return payload
+  }
+
+  const saveAccountBillingConfig = async (
+    accountId: number,
+    values: AccountFormSchema
+  ): Promise<string | null> => {
+    const billingPayload = buildBillingConfigPayload(values)
+    if (Object.keys(billingPayload).length === 0) {
+      return null
+    }
+
+    try {
+      await apiAdminUpdateAccountBillingConfig(accountId, billingPayload)
+      return null
+    } catch (error) {
+      if (error instanceof Error && error.message) {
+        return error.message
+      }
+      return 'unknown error'
+    }
+  }
+
   const { mutate: createAccount, isPending: isCreatePending } = useMutation({
-    mutationFn: (values: AccountFormSchema) =>
-      apiAccountCreate({
+    mutationFn: async (values: AccountFormSchema) => {
+      const resp = await apiAccountCreate({
         name: values.name,
         quota: convertFormToQuota(values.resources),
         expiredAt: values.expiredAt,
         admins: values.admins?.map((id) => parseInt(id)),
         withoutVolcano: scheduler !== 'volcano',
-      }),
-    onSuccess: async (_, { name }) => {
+      })
+      const billingConfigError =
+        resp.data.id && resp.data.id > 0
+          ? await saveAccountBillingConfig(resp.data.id, values)
+          : null
+      return {
+        billingConfigError,
+        resp,
+      }
+    },
+    onSuccess: async ({ billingConfigError }, { name }) => {
       await queryClient.invalidateQueries({
         queryKey: ['admin', 'accounts'],
       })
-      toast.success(t('toast.accountCreated', { name }))
+      if (billingConfigError) {
+        toast.warning(
+          `账户 ${name} 已创建，但 Billing 配置保存失败，请进入账户后重试：${billingConfigError}`
+        )
+      } else {
+        toast.success(t('toast.accountCreated', { name }))
+      }
       onOpenChange(false)
     },
   })
 
   const { mutate: updateAccount, isPending: isUpdatePending } = useMutation({
-    mutationFn: (values: AccountFormSchema) =>
-      apiAccountUpdate(values.id ?? 0, {
+    mutationFn: async (values: AccountFormSchema) => {
+      const resp = await apiAccountUpdate(values.id ?? 0, {
         name: values.name,
         quota: convertFormToQuota(values.resources),
         expiredAt: values.expiredAt,
         admins: values.admins?.map((id) => parseInt(id)),
         withoutVolcano: scheduler !== 'volcano',
-      }),
+      })
+      if ((values.id ?? 0) > 0) {
+        const billingConfigError = await saveAccountBillingConfig(values.id ?? 0, values)
+        if (billingConfigError) {
+          throw new Error(billingConfigError)
+        }
+      }
+      return resp
+    },
     onSuccess: async (_, { name }) => {
       await queryClient.invalidateQueries({
         queryKey: ['admin', 'accounts'],
+      })
+      await queryClient.invalidateQueries({
+        queryKey: ['admin', 'accounts', account?.id, 'billing-config'],
       })
       toast.success(t('toast.accountUpdated', { name }))
       onOpenChange(false)
@@ -312,6 +430,77 @@ export const AccountForm = ({ onOpenChange, account }: AccountFormProps) => {
                 </FormItem>
               )}
             />
+          )}
+
+          {billingEnabled && (
+            <div className="grid gap-4 md:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="billingIssueAmount"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t('accountForm.billingIssueAmountLabel', {
+                        defaultValue: '周期发放额度',
+                      })}
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={0}
+                        disabled={!amountOverrideEnabled}
+                        value={field.value ?? ''}
+                        onChange={(e) =>
+                          field.onChange(e.target.value === '' ? undefined : Number(e.target.value))
+                        }
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      {amountOverrideEnabled
+                        ? t('accountForm.billingIssueAmountDescription', {
+                            defaultValue: '每个发放周期发放的免费点数额度。',
+                          })
+                        : t('accountForm.billingIssueAmountDisabledDescription', {
+                            defaultValue: '当前由系统默认发放额度控制。',
+                          })}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="billingIssuePeriodMinutes"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t('accountForm.billingIssuePeriodMinutesLabel', {
+                        defaultValue: '发放周期（分钟）',
+                      })}
+                    </FormLabel>
+                    <FormControl>
+                      <BillingPeriodFields
+                        totalMinutes={field.value ?? 0}
+                        disabled={!periodOverrideEnabled}
+                        onChange={(value) => {
+                          field.onChange(value.totalMinutes)
+                        }}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      {periodOverrideEnabled
+                        ? t('accountForm.billingIssuePeriodMinutesDescription', {
+                            defaultValue: '填 0 表示关闭该账户的周期发放。',
+                          })
+                        : t('accountForm.billingIssuePeriodMinutesDisabledDescription', {
+                            defaultValue: '当前由系统默认发放周期控制。',
+                          })}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
           )}
           <div className="space-y-2">
             {resourcesFields.length > 0 && <FormLabel>{t('accountForm.quotaLabel')}</FormLabel>}

--- a/frontend/src/routes/admin/accounts/-components/account-form.ts
+++ b/frontend/src/routes/admin/accounts/-components/account-form.ts
@@ -32,6 +32,8 @@ export const formSchema = z.object({
   resources: quotaSchema,
   expiredAt: z.date().optional(),
   admins: z.array(z.string()).optional(),
+  billingIssueAmount: z.number().int().nonnegative().optional(),
+  billingIssuePeriodMinutes: z.number().int().nonnegative().optional(),
 })
 
 export type AccountFormSchema = z.infer<typeof formSchema>

--- a/frontend/src/routes/admin/cluster/resources/index.tsx
+++ b/frontend/src/routes/admin/cluster/resources/index.tsx
@@ -19,8 +19,17 @@ import { useQueryClient } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { ColumnDef } from '@tanstack/react-table'
 import { EllipsisVerticalIcon as DotsHorizontalIcon } from 'lucide-react'
-import { BoxIcon, CpuIcon, NetworkIcon, RefreshCcwIcon, TagIcon, Trash2Icon } from 'lucide-react'
-import { type FC, useMemo, useState } from 'react'
+import {
+  BoxIcon,
+  CheckIcon,
+  CpuIcon,
+  NetworkIcon,
+  RefreshCcwIcon,
+  TagIcon,
+  Trash2Icon,
+  XIcon,
+} from 'lucide-react'
+import { type FC, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -44,11 +53,18 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 
 import { DataTable } from '@/components/query-table'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
 import { DataTableToolbarConfig } from '@/components/query-table/toolbar'
 
+import {
+  BillingPriceResource,
+  apiAdminUpdateResourceUnitPrice,
+  apiBillingPriceList,
+} from '@/services/api/billing'
 import {
   Resource,
   apiAdminResourceDelete,
@@ -57,7 +73,9 @@ import {
   apiResourceList,
   apiResourceNetworks,
 } from '@/services/api/resource'
+import { apiAdminGetBillingStatus } from '@/services/api/system-config'
 
+import { formatBillingPoints } from '@/utils/billing'
 import { formatBytes } from '@/utils/formatter'
 
 import { UpdateResourceForm } from './-components/form'
@@ -124,6 +142,93 @@ const VGPUCell: FC<{ resourceId: number; resourceType?: string }> = ({
           )}
         </Badge>
       ))}
+    </div>
+  )
+}
+
+const UnitPriceCell: FC<{ resourceId: number; unitPrice: number }> = ({
+  resourceId,
+  unitPrice,
+}) => {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [nextPrice, setNextPrice] = useState<number>(unitPrice)
+  const isValidPrice =
+    Number.isFinite(nextPrice) &&
+    nextPrice >= 0 &&
+    Math.abs(nextPrice * 100 - Math.round(nextPrice * 100)) < 1e-8
+
+  useEffect(() => {
+    setNextPrice(unitPrice)
+  }, [unitPrice])
+
+  const { mutate: updateUnitPrice, isPending } = useMutation({
+    mutationFn: (next: number) => apiAdminUpdateResourceUnitPrice(resourceId, next),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['resources', 'billing-prices'],
+      })
+      toast.success(
+        t('resources.unitPrice.updateSuccess', {
+          defaultValue: '资源单价已更新',
+        })
+      )
+      setOpen(false)
+    },
+  })
+
+  return (
+    <div className="flex items-center">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Badge
+            className="hover:bg-primary hover:text-primary-foreground cursor-pointer font-mono select-none"
+            variant="secondary"
+          >
+            {formatBillingPoints(unitPrice)}
+          </Badge>
+        </PopoverTrigger>
+        <PopoverContent className="w-72 space-y-3 p-4">
+          <div className="text-sm font-medium">
+            {t('resources.unitPrice.editTitle', {
+              defaultValue: '修改小时单价',
+            })}
+          </div>
+          <p className="text-muted-foreground text-xs">资源单价单位为点数 / 单位 / 小时。</p>
+          <Input
+            type="number"
+            min={0}
+            step={0.01}
+            value={Number.isFinite(nextPrice) ? nextPrice : 0}
+            onChange={(e) => setNextPrice(Number(e.target.value))}
+          />
+          {!isValidPrice ? (
+            <p className="text-destructive text-xs">请输入非负的小时单价，最多保留两位小数。</p>
+          ) : null}
+          <div className="flex justify-end gap-2">
+            <Button
+              size="icon"
+              variant="outline"
+              className="h-8 w-8"
+              onClick={() => {
+                setNextPrice(unitPrice)
+                setOpen(false)
+              }}
+            >
+              <XIcon className="size-4" />
+            </Button>
+            <Button
+              size="icon"
+              className="h-8 w-8"
+              disabled={isPending || !isValidPrice}
+              onClick={() => updateUnitPrice(nextPrice)}
+            >
+              <CheckIcon className="size-4" />
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
     </div>
   )
 }
@@ -238,6 +343,21 @@ const ActionsCell: FC<{ resource: Resource }> = ({ resource }) => {
 function Resources() {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const { data: billingStatus } = useQuery({
+    queryKey: ['admin', 'system-config', 'billing-status'],
+    queryFn: () => apiAdminGetBillingStatus().then((res) => res.data),
+  })
+  const billingEnabled = billingStatus?.featureEnabled ?? false
+  const billingPricesQuery = useQuery({
+    queryKey: ['resources', 'billing-prices'],
+    queryFn: () => apiBillingPriceList(),
+    select: (res) =>
+      res.data.reduce<Record<number, BillingPriceResource>>((acc, item) => {
+        acc[item.id] = item
+        return acc
+      }, {}),
+    enabled: billingEnabled,
+  })
 
   const toolbarConfig: DataTableToolbarConfig = useMemo(() => {
     return {
@@ -368,13 +488,34 @@ function Resources() {
           </Badge>
         ),
       },
+      ...(billingEnabled
+        ? [
+            {
+              accessorKey: 'unitPrice',
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  column={column}
+                  title={t('resources.columns.unitPrice', {
+                    defaultValue: '单价（点/单位/小时）',
+                  })}
+                />
+              ),
+              cell: ({ row }) => (
+                <UnitPriceCell
+                  resourceId={row.original.ID}
+                  unitPrice={billingPricesQuery.data?.[row.original.ID]?.unitPrice ?? 0}
+                />
+              ),
+            } as ColumnDef<Resource>,
+          ]
+        : []),
       {
         id: 'actions',
         enableHiding: false,
         cell: ({ row }) => <ActionsCell resource={row.original} />,
       },
     ]
-  }, [t])
+  }, [billingEnabled, billingPricesQuery.data, t])
 
   const query = useQuery({
     queryKey: ['resource', 'list'],

--- a/frontend/src/routes/admin/cronjobs/index.tsx
+++ b/frontend/src/routes/admin/cronjobs/index.tsx
@@ -18,7 +18,7 @@ import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { t } from 'i18next'
 import { AlarmClockIcon } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -27,7 +27,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 import TipBadge from '@/components/badge/tip-badge'
 
-import { apiAdminGetGpuAnalysisStatus } from '@/services/api/system-config'
+import {
+  apiAdminGetBillingStatus,
+  apiAdminGetGpuAnalysisStatus,
+} from '@/services/api/system-config'
 import {
   CronJobConfig,
   CronJobConfigStatus,
@@ -71,6 +74,11 @@ const JOB_CONFIGS = [
     jobName: 'cronPolicy.gpuAnalysisTitle',
     jobType: 'patrol_function',
   },
+  {
+    jobId: 'biling-base-loop',
+    jobName: 'cronPolicy.billingBaseLoopTitle',
+    jobType: 'patrol_function',
+  },
 ]
 
 function CronPolicy({ className }: { className?: string }) {
@@ -82,8 +90,15 @@ function CronPolicy({ className }: { className?: string }) {
     queryFn: () => apiAdminGetGpuAnalysisStatus().then((res) => res.data),
     staleTime: 1000 * 60 * 5,
   })
+  const { data: billingStatus } = useQuery({
+    queryKey: ['admin', 'system-config', 'billing-status'],
+    queryFn: () => apiAdminGetBillingStatus().then((res) => res.data),
+    staleTime: 1000 * 60 * 5,
+  })
 
   const showGpuAnalysis = gpuStatus?.enabled ?? false
+  const showBilling = billingStatus?.featureEnabled ?? false
+  const showPatrolTab = showGpuAnalysis || showBilling
 
   const jobsQuery = useQuery({
     queryKey: ['admin', 'cronjobs', 'configs'],
@@ -104,21 +119,42 @@ function CronPolicy({ className }: { className?: string }) {
   const statusQuery = useQuery({
     queryKey: ['admin', 'cronjobs', 'status'],
     queryFn: async () => {
+      const visibleNames = JOB_CONFIGS.filter((job) => {
+        if (job.jobId === 'trigger-gpu-analysis-job') return showGpuAnalysis
+        if (job.jobId === 'biling-base-loop') return showBilling
+        return true
+      }).map((job) => job.jobId)
       const res = await apiAdminCronJobConfigStatus({
-        name: JOB_CONFIGS.map((job) => job.jobId),
+        name: visibleNames,
       })
       return res.data || {}
     },
     refetchInterval: 5000,
   })
 
-  const cleanerJobs = JOB_CONFIGS.filter((job) => job.jobType === 'cleaner_function')
-  const patrolJobs = JOB_CONFIGS.filter((job) => job.jobType === 'patrol_function')
-
+  const cleanerJobs = useMemo(
+    () => JOB_CONFIGS.filter((job) => job.jobType === 'cleaner_function'),
+    []
+  )
+  const patrolJobs = useMemo(
+    () =>
+      JOB_CONFIGS.filter((job) => job.jobType === 'patrol_function').filter((job) => {
+        if (job.jobId === 'trigger-gpu-analysis-job') return showGpuAnalysis
+        if (job.jobId === 'biling-base-loop') return showBilling
+        return true
+      }),
+    [showBilling, showGpuAnalysis]
+  )
   const tabToJobNames: Record<string, string[]> = {
     cleaner_function: cleanerJobs.map((j) => j.jobId),
     patrol_function: patrolJobs.map((j) => j.jobId),
   }
+
+  useEffect(() => {
+    if (!showPatrolTab && activeTab === 'patrol_function') {
+      setActiveTab('cleaner_function')
+    }
+  }, [activeTab, showPatrolTab])
 
   const renderJobCards = (jobs: typeof JOB_CONFIGS) => {
     if (jobsQuery.isLoading) {
@@ -171,11 +207,9 @@ function CronPolicy({ className }: { className?: string }) {
               {t('cronPolicy.title')}
               <TipBadge />
             </CardTitle>
-            <TabsList
-              className={cn('grid w-full', showGpuAnalysis ? 'grid-cols-2' : 'grid-cols-1')}
-            >
+            <TabsList className={cn('grid w-full', showPatrolTab ? 'grid-cols-2' : 'grid-cols-1')}>
               <TabsTrigger value="cleaner_function">{t('cronPolicy.cleanerJobsTitle')}</TabsTrigger>
-              {showGpuAnalysis && (
+              {showPatrolTab && (
                 <TabsTrigger value="patrol_function">{t('cronPolicy.patrolJobsTitle')}</TabsTrigger>
               )}
             </TabsList>
@@ -184,7 +218,7 @@ function CronPolicy({ className }: { className?: string }) {
             <TabsContent value="cleaner_function" className="mt-0">
               {renderJobCards(cleanerJobs)}
             </TabsContent>
-            {showGpuAnalysis && (
+            {showPatrolTab && (
               <TabsContent value="patrol_function" className="mt-0">
                 {renderJobCards(patrolJobs)}
               </TabsContent>

--- a/frontend/src/routes/admin/more/-components/billing-settings.tsx
+++ b/frontend/src/routes/admin/more/-components/billing-settings.tsx
@@ -1,0 +1,511 @@
+import { Link } from '@tanstack/react-router'
+import { ArrowRightIcon, CoinsIcon, Loader2Icon, SaveIcon, SparklesIcon } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import { Switch } from '@/components/ui/switch'
+
+import CronJobStatusBadge from '@/components/badge/cronjob-status-badge'
+import { BillingPeriodFields } from '@/components/form/billing-period-fields'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui-custom/alert-dialog'
+
+import {
+  IBillingStatus,
+  IGrantAllUsersExtraBalanceReq,
+  ISetBillingStatusReq,
+} from '@/services/api/system-config'
+
+interface BillingSettingsProps {
+  status?: IBillingStatus
+  isSaving: boolean
+  isResettingAll?: boolean
+  isGrantingAllExtra?: boolean
+  onSave: (payload: ISetBillingStatusReq) => void
+  onResetAll: () => void
+  onGrantAllExtra: (payload: IGrantAllUsersExtraBalanceReq) => void
+}
+
+interface BillingFormState {
+  featureEnabled: boolean
+  active: boolean
+  runningSettlementEnabled: boolean
+  runningSettlementIntervalMinutes: number
+  jobFreeMinutes: number
+  defaultIssueAmount: number
+  defaultIssuePeriodMinutes: number
+  accountIssueAmountOverrideEnabled: boolean
+  accountIssuePeriodOverrideEnabled: boolean
+  baseLoopCronStatus: string
+  baseLoopCronEnabled: boolean
+}
+
+const DEFAULT_FORM_STATE: BillingFormState = {
+  featureEnabled: false,
+  active: false,
+  runningSettlementEnabled: false,
+  runningSettlementIntervalMinutes: 5,
+  jobFreeMinutes: 0,
+  defaultIssueAmount: 1000,
+  defaultIssuePeriodMinutes: 43200,
+  accountIssueAmountOverrideEnabled: false,
+  accountIssuePeriodOverrideEnabled: false,
+  baseLoopCronStatus: 'unknown',
+  baseLoopCronEnabled: false,
+}
+
+export function BillingSettings({
+  status,
+  isSaving,
+  isResettingAll = false,
+  isGrantingAllExtra = false,
+  onSave,
+  onResetAll,
+  onGrantAllExtra,
+}: BillingSettingsProps) {
+  const { t } = useTranslation()
+  const [form, setForm] = useState<BillingFormState>(DEFAULT_FORM_STATE)
+  const [periodDialogOpen, setPeriodDialogOpen] = useState(false)
+  const [pendingPeriodMinutes, setPendingPeriodMinutes] = useState(43200)
+  const [grantDialogOpen, setGrantDialogOpen] = useState(false)
+  const [grantDelta, setGrantDelta] = useState(100)
+  const [grantReason, setGrantReason] = useState('')
+
+  useEffect(() => {
+    if (status == null) {
+      return
+    }
+    setForm({
+      featureEnabled: Boolean(status.featureEnabled),
+      active: Boolean(status.active),
+      runningSettlementEnabled: Boolean(status.runningSettlementEnabled),
+      runningSettlementIntervalMinutes: status.runningSettlementIntervalMinutes || 5,
+      jobFreeMinutes: status.jobFreeMinutes || 0,
+      defaultIssueAmount: status.defaultIssueAmount ?? 1000,
+      defaultIssuePeriodMinutes: status.defaultIssuePeriodMinutes || 43200,
+      accountIssueAmountOverrideEnabled: Boolean(status.accountIssueAmountOverrideEnabled),
+      accountIssuePeriodOverrideEnabled: Boolean(status.accountIssuePeriodOverrideEnabled),
+      baseLoopCronStatus: status.baseLoopCronStatus || 'unknown',
+      baseLoopCronEnabled: Boolean(status.baseLoopCronEnabled),
+    })
+    setPendingPeriodMinutes(status.defaultIssuePeriodMinutes || 43200)
+  }, [status])
+
+  const setNumberField = (field: keyof BillingFormState, value: string) => {
+    const num = Number(value)
+    setForm((prev) => ({
+      ...prev,
+      [field]: Number.isFinite(num) ? num : 0,
+    }))
+  }
+
+  const saveFeatureOnly = (enabled: boolean) => {
+    setForm((prev) => ({ ...prev, featureEnabled: enabled }))
+    onSave({ featureEnabled: enabled })
+  }
+
+  const submitAll = () => {
+    onSave({
+      featureEnabled: form.featureEnabled,
+      active: form.active,
+      runningSettlementEnabled: form.runningSettlementEnabled,
+      runningSettlementIntervalMinutes: form.runningSettlementIntervalMinutes,
+      jobFreeMinutes: form.jobFreeMinutes,
+      defaultIssueAmount: form.defaultIssueAmount,
+      defaultIssuePeriodMinutes: form.defaultIssuePeriodMinutes,
+      accountIssueAmountOverrideEnabled: form.accountIssueAmountOverrideEnabled,
+      accountIssuePeriodOverrideEnabled: form.accountIssuePeriodOverrideEnabled,
+    })
+  }
+
+  const canSubmitGrant =
+    Number.isFinite(grantDelta) &&
+    Math.abs(grantDelta * 100 - Math.round(grantDelta * 100)) < 1e-8 &&
+    grantDelta > 0 &&
+    !isGrantingAllExtra
+
+  return (
+    <>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <CoinsIcon className="text-primary h-5 w-5" />
+          <CardTitle>
+            {t('systemConfig.billing.title', {
+              defaultValue: 'Billing 设置',
+            })}
+          </CardTitle>
+        </div>
+        <CardDescription>
+          {t('systemConfig.billing.description', {
+            defaultValue: '控制计费开关、运行中结算和默认周期发放参数。',
+          })}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between rounded-lg border p-4 shadow-sm">
+          <div className="space-y-0.5">
+            <Label className="text-base">
+              {t('systemConfig.billing.featureSwitch', {
+                defaultValue: '开启 Billing 功能',
+              })}
+            </Label>
+            <p className="text-muted-foreground text-[0.8rem]">
+              {t('systemConfig.billing.featureSwitchDesc', {
+                defaultValue: '关闭时，Billing 相关字段与操作不显示。',
+              })}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {isSaving && <Loader2Icon className="text-muted-foreground h-4 w-4 animate-spin" />}
+            <Switch
+              checked={form.featureEnabled}
+              disabled={isSaving}
+              onCheckedChange={saveFeatureOnly}
+            />
+          </div>
+        </div>
+
+        {form.featureEnabled && (
+          <>
+            <Separator />
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="flex items-center justify-between rounded-lg border p-4">
+                <div className="space-y-0.5">
+                  <Label className="text-base">
+                    {t('systemConfig.billing.active', {
+                      defaultValue: '计费生效',
+                    })}
+                  </Label>
+                  <p className="text-muted-foreground text-[0.8rem]">
+                    {t('systemConfig.billing.activeDesc', {
+                      defaultValue: '开启后，作业创建和结算进入计费逻辑。',
+                    })}
+                  </p>
+                </div>
+                <Switch
+                  checked={form.active}
+                  disabled={isSaving}
+                  onCheckedChange={(checked) =>
+                    setForm((prev) => ({
+                      ...prev,
+                      active: checked,
+                      runningSettlementEnabled: checked ? prev.runningSettlementEnabled : false,
+                    }))
+                  }
+                />
+              </div>
+
+              <div className="flex items-center justify-between rounded-lg border p-4">
+                <div className="space-y-0.5">
+                  <Label className="text-base">
+                    {t('systemConfig.billing.runningSettlementEnabled', {
+                      defaultValue: '开启运行中结算',
+                    })}
+                  </Label>
+                  <p className="text-muted-foreground text-[0.8rem]">
+                    {t('systemConfig.billing.runningSettlementEnabledDesc', {
+                      defaultValue: '开启后按小周期结算 Running 作业。',
+                    })}
+                  </p>
+                </div>
+                <Switch
+                  checked={form.runningSettlementEnabled}
+                  disabled={
+                    isSaving ||
+                    !form.active ||
+                    (!form.baseLoopCronEnabled && !form.runningSettlementEnabled)
+                  }
+                  onCheckedChange={(checked) =>
+                    setForm((prev) => ({ ...prev, runningSettlementEnabled: checked }))
+                  }
+                />
+              </div>
+            </div>
+            <div className="rounded-lg border p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="space-y-0.5">
+                  <Label className="text-base">
+                    {t('systemConfig.billing.baseLoopTitle', {
+                      defaultValue: 'Billing 基础循环',
+                    })}
+                  </Label>
+                  <p className="text-muted-foreground text-[0.8rem]">
+                    {t('systemConfig.billing.baseLoopDesc', {
+                      defaultValue: '负责周期发放和运行中结算触发。',
+                    })}
+                  </p>
+                </div>
+                <CronJobStatusBadge status={form.baseLoopCronStatus} />
+              </div>
+              <div className="mt-3">
+                <Button variant="secondary" asChild>
+                  <Link to="/admin/cronjobs">
+                    {t('systemConfig.billing.goToCronPolicy', {
+                      defaultValue: '前往 CronPolicy 配置',
+                    })}
+                    <ArrowRightIcon className="ml-2 h-4 w-4" />
+                  </Link>
+                </Button>
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="flex items-center justify-between rounded-lg border p-4">
+                <div className="space-y-0.5">
+                  <Label className="text-base">
+                    {t('systemConfig.billing.accountIssueAmountOverrideEnabled', {
+                      defaultValue: '允许账户独立配置发放额度',
+                    })}
+                  </Label>
+                  <p className="text-muted-foreground text-[0.8rem]">
+                    {t('systemConfig.billing.accountIssueAmountOverrideEnabledDesc', {
+                      defaultValue: '关闭时所有账户统一使用系统默认发放额度。',
+                    })}
+                  </p>
+                </div>
+                <Switch
+                  checked={form.accountIssueAmountOverrideEnabled}
+                  disabled={isSaving}
+                  onCheckedChange={(checked) =>
+                    setForm((prev) => ({ ...prev, accountIssueAmountOverrideEnabled: checked }))
+                  }
+                />
+              </div>
+              <div className="flex items-center justify-between rounded-lg border p-4">
+                <div className="space-y-0.5">
+                  <Label className="text-base">
+                    {t('systemConfig.billing.accountIssuePeriodOverrideEnabled', {
+                      defaultValue: '允许账户独立配置发放周期',
+                    })}
+                  </Label>
+                  <p className="text-muted-foreground text-[0.8rem]">
+                    {t('systemConfig.billing.accountIssuePeriodOverrideEnabledDesc', {
+                      defaultValue: '关闭时所有账户统一使用系统默认发放周期。',
+                    })}
+                  </p>
+                </div>
+                <Switch
+                  checked={form.accountIssuePeriodOverrideEnabled}
+                  disabled={isSaving}
+                  onCheckedChange={(checked) =>
+                    setForm((prev) => ({ ...prev, accountIssuePeriodOverrideEnabled: checked }))
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label>
+                  {t('systemConfig.billing.runningSettlementIntervalMinutes', {
+                    defaultValue: '运行中结算周期（分钟）',
+                  })}
+                </Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={form.runningSettlementIntervalMinutes}
+                  disabled={isSaving || !form.active || !form.runningSettlementEnabled}
+                  onChange={(e) =>
+                    setNumberField('runningSettlementIntervalMinutes', e.target.value)
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>
+                  {t('systemConfig.billing.jobFreeMinutes', {
+                    defaultValue: '作业开始免费时长（分钟）',
+                  })}
+                </Label>
+                <Input
+                  type="number"
+                  min={0}
+                  value={form.jobFreeMinutes}
+                  disabled={isSaving}
+                  onChange={(e) => setNumberField('jobFreeMinutes', e.target.value)}
+                />
+                <p className="text-muted-foreground text-xs">
+                  {t('systemConfig.billing.jobFreeMinutesDesc', {
+                    defaultValue: '作业开始后可先免费运行的分钟数。',
+                  })}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label>
+                  {t('systemConfig.billing.defaultIssueAmount', {
+                    defaultValue: '默认周期发放额度',
+                  })}
+                </Label>
+                <Input
+                  type="number"
+                  min={0}
+                  step={0.01}
+                  value={form.defaultIssueAmount}
+                  onChange={(e) => setNumberField('defaultIssueAmount', e.target.value)}
+                />
+                <p className="text-muted-foreground text-xs">单位为点数，最多保留两位小数。</p>
+              </div>
+              <div className="space-y-2">
+                <Label>
+                  {t('systemConfig.billing.defaultIssuePeriodMinutes', {
+                    defaultValue: '默认发放周期（分钟）',
+                  })}
+                </Label>
+                <Button
+                  variant="outline"
+                  type="button"
+                  onClick={() => {
+                    setPendingPeriodMinutes(form.defaultIssuePeriodMinutes)
+                    setPeriodDialogOpen(true)
+                  }}
+                >
+                  编辑默认发放周期（当前 {form.defaultIssuePeriodMinutes} 分钟）
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isSaving || isGrantingAllExtra}
+                onClick={() => setGrantDialogOpen(true)}
+              >
+                {isGrantingAllExtra ? (
+                  <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <SparklesIcon className="mr-2 h-4 w-4" />
+                )}
+                给所有用户发放 extra 点数
+              </Button>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button type="button" variant="outline" disabled={isSaving || isResettingAll}>
+                    {isResettingAll ? <Loader2Icon className="mr-2 h-4 w-4 animate-spin" /> : null}
+                    重置全平台免费额度
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>确认重置全平台免费额度？</AlertDialogTitle>
+                    <p className="text-muted-foreground text-sm">
+                      这会重置所有账户成员的本周期免费额度。
+                    </p>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>取消</AlertDialogCancel>
+                    <AlertDialogAction onClick={onResetAll} disabled={isResettingAll}>
+                      确认重置
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+              <Button type="button" disabled={isSaving} onClick={submitAll}>
+                {isSaving ? (
+                  <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <SaveIcon className="mr-2 h-4 w-4" />
+                )}
+                {t('common.save')}
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+      <Dialog open={periodDialogOpen} onOpenChange={setPeriodDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>默认发放周期</DialogTitle>
+          </DialogHeader>
+          <BillingPeriodFields
+            totalMinutes={pendingPeriodMinutes}
+            onChange={(value) => setPendingPeriodMinutes(value.totalMinutes)}
+          />
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setPeriodDialogOpen(false)}>
+              取消
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                setForm((prev) => ({ ...prev, defaultIssuePeriodMinutes: pendingPeriodMinutes }))
+                setPeriodDialogOpen(false)
+              }}
+            >
+              应用
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={grantDialogOpen} onOpenChange={setGrantDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>给所有用户发放 extra 点数</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>发放额度</Label>
+              <Input
+                type="number"
+                min={0}
+                step={0.01}
+                value={Number.isFinite(grantDelta) ? grantDelta : 0}
+                onChange={(e) => setGrantDelta(Number(e.target.value))}
+              />
+              <p className="text-muted-foreground text-xs">单位为 extra 点数，最多保留两位小数。</p>
+            </div>
+            <div className="space-y-2">
+              <Label>原因备注</Label>
+              <Input
+                value={grantReason}
+                placeholder="例如：节日奖励 / 系统补偿"
+                onChange={(e) => setGrantReason(e.target.value)}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setGrantDialogOpen(false)}>
+              取消
+            </Button>
+            <Button
+              type="button"
+              disabled={!canSubmitGrant}
+              onClick={() => {
+                onGrantAllExtra({
+                  delta: grantDelta,
+                  reason: grantReason.trim() || undefined,
+                })
+                setGrantDialogOpen(false)
+              }}
+            >
+              {isGrantingAllExtra ? <Loader2Icon className="mr-2 h-4 w-4 animate-spin" /> : null}
+              确认发放
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/routes/admin/more/index.tsx
+++ b/frontend/src/routes/admin/more/index.tsx
@@ -23,10 +23,14 @@ import {
   apiAdminUpdateQueueQuota,
 } from '@/services/api/queue-quota'
 import {
+  apiAdminGetBillingStatus,
   apiAdminGetGpuAnalysisStatus,
   apiAdminGetLLMConfig,
   apiAdminGetPrequeueConfig,
+  apiAdminGrantAllUsersExtraBalance,
+  apiAdminResetAllBillingBalances,
   apiAdminResetLLMConfig,
+  apiAdminSetBillingStatus,
   apiAdminSetGpuAnalysisStatus,
   apiAdminUpdateLLMConfig,
   apiAdminUpdatePrequeueConfig,
@@ -34,7 +38,10 @@ import {
 import { ERROR_BUSINESS_LOGIC_ERROR } from '@/services/error_code'
 import { IErrorResponse } from '@/services/types'
 
+import { showErrorToast } from '@/utils/toast'
+
 import { BasicSettings } from './-components/basic-settings'
+import { BillingSettings } from './-components/billing-settings'
 import { GpuAnalysis } from './-components/gpu-analysis'
 import { LlmFormSchema, LlmSettings, createLlmSettingsSchema } from './-components/llm-settings'
 import { PrequeueSettings } from './-components/prequeue-settings'
@@ -84,6 +91,11 @@ function RouteComponent() {
   const { data: resourceLimitData } = useQuery({
     queryKey: ['admin', 'queue-quotas'],
     queryFn: () => apiAdminGetQueueQuotas().then((res) => res.data),
+  })
+
+  const { data: billingStatusData } = useQuery({
+    queryKey: ['admin', 'system-config', 'billing-status'],
+    queryFn: () => apiAdminGetBillingStatus().then((res) => res.data),
   })
 
   const [backfillEnabled, setBackfillEnabled] = useState(false)
@@ -177,6 +189,49 @@ function RouteComponent() {
       toast.success(message)
     },
     onError: handleError,
+  })
+
+  const updateBillingMutation = useMutation({
+    mutationFn: apiAdminSetBillingStatus,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'system-config', 'billing-status'] })
+      toast.success(
+        t('systemConfig.billing.saveSuccess', {
+          defaultValue: 'Billing 配置已更新',
+        })
+      )
+    },
+    onError: showErrorToast,
+  })
+
+  const resetAllBillingMutation = useMutation({
+    mutationFn: apiAdminResetAllBillingBalances,
+    onSuccess: async (res) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['admin', 'system-config', 'billing-status'] }),
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin', 'userlist'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin', 'users'] }),
+        queryClient.invalidateQueries({ queryKey: ['context', 'billing-summary'] }),
+      ])
+      toast.success(
+        `已重置 ${res.data.accountsAffected} 个账户、${res.data.userAccountsAffected} 条成员免费额度`
+      )
+    },
+    onError: showErrorToast,
+  })
+
+  const grantAllUsersExtraMutation = useMutation({
+    mutationFn: apiAdminGrantAllUsersExtraBalance,
+    onSuccess: async (res) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['admin', 'userlist'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin', 'users'] }),
+        queryClient.invalidateQueries({ queryKey: ['context', 'billing-summary'] }),
+      ])
+      toast.success(`已为 ${res.data.usersAffected} 个用户发放 ${res.data.delta} 点 extra 额度`)
+    },
+    onError: showErrorToast,
   })
 
   const handleLlmSubmit = (values: LlmFormSchema, validate: boolean) => {
@@ -403,6 +458,18 @@ function RouteComponent() {
           onCreate={handleResourceLimitCreate}
           onUpdate={handleResourceLimitUpdate}
           onRemove={handleResourceLimitRemove}
+        />
+
+        <Separator />
+
+        <BillingSettings
+          status={billingStatusData}
+          isSaving={updateBillingMutation.isPending}
+          isResettingAll={resetAllBillingMutation.isPending}
+          isGrantingAllExtra={grantAllUsersExtraMutation.isPending}
+          onSave={(payload) => updateBillingMutation.mutate(payload)}
+          onResetAll={() => resetAllBillingMutation.mutate()}
+          onGrantAllExtra={(payload) => grantAllUsersExtraMutation.mutate(payload)}
         />
       </Card>
     </div>

--- a/frontend/src/routes/admin/users/index.tsx
+++ b/frontend/src/routes/admin/users/index.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { UseQueryResult, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { ColumnDef } from '@tanstack/react-table'
 import { useAtomValue } from 'jotai'
@@ -44,6 +44,7 @@ import { Input } from '@/components/ui/input'
 
 import UserRoleBadge from '@/components/badge/user-role-badge'
 import UserStatusBadge from '@/components/badge/user-status-badge'
+import { UserPointsTooltip } from '@/components/custom/user-points-tooltip'
 import UserLabel from '@/components/label/user-label'
 import { DataTable } from '@/components/query-table'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
@@ -69,6 +70,12 @@ import {
   apiAdminUserUpdateRole,
 } from '@/services/api/admin/user'
 import { Role } from '@/services/api/auth'
+import {
+  AdjustUserExtraBalanceReq,
+  apiAdminAdjustUserExtraBalance,
+  apiAdminGetUserBillingSummary,
+} from '@/services/api/billing'
+import { apiAdminGetBillingStatus } from '@/services/api/system-config'
 
 import { atomUserInfo } from '@/utils/store'
 import { showErrorToast } from '@/utils/toast'
@@ -82,6 +89,10 @@ interface TUser {
   name: string
   role: string
   status: string
+  extraBalance?: number
+  periodFreeTotal?: number
+  totalIssueAmount?: number
+  totalAvailable?: number
   attributes: IUserAttributes
 }
 
@@ -299,12 +310,154 @@ function UserEditDialog({ open, onOpenChange, user }: UserEditDialogProps) {
   )
 }
 
+const adjustBalanceFormSchema = z.object({
+  delta: z.number(),
+  reason: z.string().optional(),
+})
+
+type AdjustBalanceFormValues = z.infer<typeof adjustBalanceFormSchema>
+
+interface UserAdjustBalanceDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  user: TUser | null
+}
+
+function UserAdjustBalanceDialog({ open, onOpenChange, user }: UserAdjustBalanceDialogProps) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  const form = useForm<AdjustBalanceFormValues>({
+    resolver: zodResolver(adjustBalanceFormSchema),
+    defaultValues: {
+      delta: 0,
+      reason: '',
+    },
+  })
+
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        delta: 0,
+        reason: '',
+      })
+    }
+  }, [form, open])
+
+  const { mutate: adjustBalance, isPending } = useMutation({
+    mutationFn: (values: AdjustUserExtraBalanceReq) => {
+      if (!user) throw new Error('No user selected')
+      return apiAdminAdjustUserExtraBalance(user.name, values)
+    },
+    onSuccess: (_, values) => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'userlist'] })
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users', 'billing-summary'] })
+      toast.success(
+        t('userTable.adjustBalance.success', {
+          defaultValue: '点数调整成功',
+        }) + ` (${values.delta > 0 ? '+' : ''}${values.delta})`
+      )
+      onOpenChange(false)
+    },
+    onError: () => {
+      toast.error(
+        t('userTable.adjustBalance.error', {
+          defaultValue: '点数调整失败',
+        })
+      )
+    },
+  })
+
+  const onSubmit = (values: AdjustBalanceFormValues) => {
+    adjustBalance(values)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>
+            {t('userTable.adjustBalance.title', {
+              defaultValue: '调整额外点数',
+            })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('userTable.adjustBalance.description', {
+              defaultValue: '按增量调整用户 extra 点数，可输入正数或负数。',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="delta"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t('userTable.adjustBalance.delta', {
+                      defaultValue: '变更值',
+                    })}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      value={field.value ?? 0}
+                      onChange={(e) => field.onChange(Number(e.target.value))}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="reason"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t('userTable.adjustBalance.reason', {
+                      defaultValue: '原因',
+                    })}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t('userTable.adjustBalance.reasonPlaceholder', {
+                        defaultValue: '可选，便于审计',
+                      })}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? t('common.saving') : t('common.saveChanges')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 function UserList() {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const userInfo = useAtomValue(atomUserInfo)
   const [editUser, setEditUser] = useState<TUser | null>(null)
   const [editDialogOpen, setEditDialogOpen] = useState(false)
+  const [adjustUser, setAdjustUser] = useState<TUser | null>(null)
+  const [adjustDialogOpen, setAdjustDialogOpen] = useState(false)
+
+  const { data: billingStatus } = useQuery({
+    queryKey: ['admin', 'system-config', 'billing-status'],
+    queryFn: () => apiAdminGetBillingStatus().then((res) => res.data),
+  })
+  const billingEnabled = billingStatus?.featureEnabled ?? false
 
   const userQuery = useQuery({
     queryKey: ['admin', 'userlist'],
@@ -315,9 +468,43 @@ function UserList() {
         name: item.name,
         role: item.role.toString(),
         status: item.status.toString(),
+        extraBalance: item.extraBalance,
         attributes: item.attributes,
       })),
   })
+  const billingSummaryQuery = useQuery({
+    queryKey: ['admin', 'users', 'billing-summary'],
+    queryFn: () => apiAdminGetUserBillingSummary().then((res) => res.data),
+    enabled: billingEnabled,
+  })
+  const mergedUserQuery = useMemo(
+    () =>
+      ({
+        data: (userQuery.data ?? []).map((user) => {
+          const summary = (billingSummaryQuery.data ?? []).find((item) => item.userId === user.id)
+          return {
+            ...user,
+            extraBalance: summary?.extraBalance ?? user.extraBalance,
+            periodFreeTotal: summary?.periodFreeTotal ?? 0,
+            totalIssueAmount: summary?.totalIssueAmount ?? 0,
+            totalAvailable: summary?.totalAvailable ?? 0,
+          }
+        }),
+        isLoading: userQuery.isLoading || (billingEnabled && billingSummaryQuery.isLoading),
+        dataUpdatedAt: Math.max(userQuery.dataUpdatedAt, billingSummaryQuery.dataUpdatedAt),
+        refetch: userQuery.refetch,
+      }) as unknown as UseQueryResult<TUser[], Error>,
+    [
+      billingEnabled,
+      billingSummaryQuery.data,
+      billingSummaryQuery.dataUpdatedAt,
+      billingSummaryQuery.isLoading,
+      userQuery.data,
+      userQuery.dataUpdatedAt,
+      userQuery.isLoading,
+      userQuery.refetch,
+    ]
+  )
 
   const { mutate: deleteUser } = useMutation({
     mutationFn: (userName: string) => apiAdminUserDelete(userName),
@@ -337,7 +524,7 @@ function UserList() {
   })
 
   const columns = useMemo<ColumnDef<TUser>[]>(() => {
-    return [
+    const baseColumns: ColumnDef<TUser>[] = [
       {
         accessorKey: 'name',
         header: ({ column }) => (
@@ -391,6 +578,31 @@ function UserList() {
           return (value as string[]).includes(row.getValue(id))
         },
       },
+      ...(billingEnabled
+        ? [
+            {
+              accessorKey: 'totalAvailable',
+              header: ({ column }) => (
+                <DataTableColumnHeader
+                  column={column}
+                  title={t('userTable.headers.totalPoints', { defaultValue: '点数' })}
+                />
+              ),
+              cell: ({ row }) => (
+                <UserPointsTooltip
+                  userName={row.original.name}
+                  totalPoints={row.original.totalAvailable ?? 0}
+                  extraPoints={row.original.extraBalance ?? 0}
+                  periodFreePoints={row.original.periodFreeTotal ?? 0}
+                  effectiveIssueAmount={row.original.totalIssueAmount ?? 0}
+                  showInlineBreakdown
+                  inlineVariant="minimal"
+                  fetchDetail
+                />
+              ),
+            } as ColumnDef<TUser>,
+          ]
+        : []),
       {
         id: 'actions',
         enableHiding: false,
@@ -417,6 +629,20 @@ function UserList() {
                     >
                       {t('userTable.editInfo')}
                     </DropdownMenuItem>
+                    {billingEnabled && (
+                      <>
+                        <DropdownMenuItem
+                          onClick={() => {
+                            setAdjustUser(user)
+                            setAdjustDialogOpen(true)
+                          }}
+                        >
+                          {t('userTable.adjustBalance.action', {
+                            defaultValue: '调整额外点数',
+                          })}
+                        </DropdownMenuItem>
+                      </>
+                    )}
                     <DropdownMenuSub>
                       <DropdownMenuSubTrigger>{t('userTable.roleLabel')}</DropdownMenuSubTrigger>
                       <DropdownMenuSubContent>
@@ -475,7 +701,8 @@ function UserList() {
         },
       },
     ]
-  }, [deleteUser, userInfo, updateRole, t])
+    return baseColumns
+  }, [billingEnabled, deleteUser, userInfo, updateRole, t])
 
   return (
     <>
@@ -485,11 +712,16 @@ function UserList() {
           description: t('userTable.description'),
         }}
         storageKey="admin_user"
-        query={userQuery}
+        query={mergedUserQuery as UseQueryResult<TUser[], Error>}
         columns={columns}
         toolbarConfig={toolbarConfig}
       />
       <UserEditDialog open={editDialogOpen} onOpenChange={setEditDialogOpen} user={editUser} />
+      <UserAdjustBalanceDialog
+        open={adjustDialogOpen}
+        onOpenChange={setAdjustDialogOpen}
+        user={adjustUser}
+      />
     </>
   )
 }

--- a/frontend/src/routes/portal/account/member.tsx
+++ b/frontend/src/routes/portal/account/member.tsx
@@ -21,6 +21,7 @@ import { useMemo } from 'react'
 
 import { Skeleton } from '@/components/ui/skeleton'
 
+import { AccountBillingActions } from '@/components/account/account-billing-actions'
 import { AccountMemberTable } from '@/components/account/account-member-table'
 import PageTitle from '@/components/layout/page-title'
 
@@ -101,7 +102,14 @@ function RouteComponent() {
       <PageTitle
         title={t('navigation.memberManagement')}
         description={t('accountDetail.tabs.users')}
-      />
+        className="h-auto flex-wrap items-start sm:h-12 sm:flex-nowrap sm:items-center"
+      >
+        <AccountBillingActions
+          accountId={accountId}
+          isAdminView={false}
+          editable={accountContext?.roleQueue === Role.Admin}
+        />
+      </PageTitle>
       <AccountMemberTable
         accountId={accountId}
         editable={accountContext?.roleQueue === Role.Admin}

--- a/frontend/src/routes/portal/jobs/inter/index.tsx
+++ b/frontend/src/routes/portal/jobs/inter/index.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { UseQueryResult, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, createFileRoute } from '@tanstack/react-router'
 import { ColumnDef } from '@tanstack/react-table'
 import { t } from 'i18next'
@@ -30,6 +30,7 @@ import NodeBadges from '@/components/badge/node-badges'
 import ResourceBadges from '@/components/badge/resource-badges'
 import ScheduleTypeLabel from '@/components/badge/schedule-type-badge'
 import DocsButton from '@/components/button/docs-button'
+import { BillingPointsBadge } from '@/components/custom/billing-points-badge'
 import { TimeDistance } from '@/components/custom/time-distance'
 import CodeServerIcon from '@/components/icon/code-server-icon'
 import JupyterIcon from '@/components/icon/jupyter-icon'
@@ -42,6 +43,8 @@ import SimpleTooltip from '@/components/label/simple-tooltip'
 import { DataTable } from '@/components/query-table'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
 
+import { apiJobBillingList } from '@/services/api/billing'
+import { apiGetBillingStatus } from '@/services/api/system-config'
 import {
   IJobInfo,
   JobPhase,
@@ -53,6 +56,7 @@ import {
   isInteracitveJob,
 } from '@/services/api/vcjob'
 
+import { isBillingVisibleForUser } from '@/utils/billing-visibility'
 import { logger } from '@/utils/loglevel'
 
 import { REFETCH_INTERVAL } from '@/lib/constants'
@@ -66,9 +70,16 @@ export const Route = createFileRoute('/portal/jobs/inter/')({
   component: RouteComponent,
 })
 
+type JobTableRow = IJobInfo & { billedPointsTotal?: number }
+
 function RouteComponent() {
   const { t: translate } = useTranslation()
   const queryClient = useQueryClient()
+  const { data: billingStatus } = useQuery({
+    queryKey: ['system-config', 'billing-status'],
+    queryFn: () => apiGetBillingStatus().then((res) => res.data),
+  })
+  const billingVisible = isBillingVisibleForUser(billingStatus)
 
   const interactiveQuery = useQuery({
     queryKey: ['job', 'interactive'],
@@ -76,6 +87,42 @@ function RouteComponent() {
     select: (res) => res.data.filter((task) => isInteracitveJob(task.jobType)),
     refetchInterval: REFETCH_INTERVAL,
   })
+  const billingQuery = useQuery({
+    queryKey: ['job', 'billing'],
+    queryFn: apiJobBillingList,
+    select: (res) =>
+      res.data.reduce<Record<string, number>>((acc, item) => {
+        acc[item.jobName] = item.billedPointsTotal
+        return acc
+      }, {}),
+    refetchInterval: REFETCH_INTERVAL,
+    enabled: billingVisible,
+  })
+  const mergedInteractiveQuery = useMemo(
+    () =>
+      ({
+        data: (interactiveQuery.data ?? []).map((job) => ({
+          ...job,
+          billedPointsTotal: billingQuery.data?.[job.jobName] ?? 0,
+        })),
+        isLoading: interactiveQuery.isLoading || (billingVisible && billingQuery.isLoading),
+        dataUpdatedAt: Math.max(
+          interactiveQuery.dataUpdatedAt,
+          billingVisible ? billingQuery.dataUpdatedAt : 0
+        ),
+        refetch: interactiveQuery.refetch,
+      }) as unknown as UseQueryResult<JobTableRow[], Error>,
+    [
+      billingVisible,
+      billingQuery.data,
+      billingQuery.dataUpdatedAt,
+      billingQuery.isLoading,
+      interactiveQuery.data,
+      interactiveQuery.dataUpdatedAt,
+      interactiveQuery.isLoading,
+      interactiveQuery.refetch,
+    ]
+  )
 
   const refetchTaskList = async () => {
     try {
@@ -83,6 +130,9 @@ function RouteComponent() {
       await Promise.all([
         new Promise((resolve) => setTimeout(resolve, 200)).then(() =>
           queryClient.invalidateQueries({ queryKey: ['job'] })
+        ),
+        new Promise((resolve) => setTimeout(resolve, 200)).then(() =>
+          queryClient.invalidateQueries({ queryKey: ['job', 'billing'] })
         ),
         new Promise((resolve) => setTimeout(resolve, 200)).then(() =>
           queryClient.invalidateQueries({ queryKey: ['context', 'quota'] })
@@ -104,7 +154,7 @@ function RouteComponent() {
     },
   })
 
-  const interColumns = useMemo<ColumnDef<IJobInfo>[]>(
+  const interColumns = useMemo<ColumnDef<JobTableRow>[]>(
     () => [
       {
         accessorKey: 'jobType',
@@ -162,6 +212,15 @@ function RouteComponent() {
           return <ResourceBadges resources={resources} />
         },
       },
+      ...(billingVisible
+        ? [
+            {
+              accessorKey: 'billedPointsTotal',
+              header: ({ column }) => <DataTableColumnHeader column={column} title="累计点数" />,
+              cell: ({ row }) => <BillingPointsBadge value={row.original.billedPointsTotal ?? 0} />,
+            } as ColumnDef<JobTableRow>,
+          ]
+        : []),
       {
         accessorKey: 'createdAt',
         header: ({ column }) => (
@@ -245,7 +304,7 @@ function RouteComponent() {
         },
       },
     ],
-    [deleteTask]
+    [billingVisible, deleteTask]
   )
 
   return (
@@ -255,7 +314,7 @@ function RouteComponent() {
         description: '提供开箱即用的 Jupyter Lab， 可用于测试、调试等',
       }}
       storageKey="portal_job_interactive"
-      query={interactiveQuery}
+      query={mergedInteractiveQuery}
       columns={interColumns}
       toolbarConfig={jobToolbarConfig}
       briefChildren={<JobResourceSummary />}

--- a/frontend/src/routes/portal/jobs/new/emias-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/emias-job.tsx
@@ -55,12 +55,15 @@ import { OtherOptionsFormCard } from '@/components/form/other-options-form-field
 import { ResourceFormFields } from '@/components/form/resource-form-field'
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormCustom } from '@/components/form/types'
-import { JobSubmitButton } from '@/components/job/job-submit-button'
+import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
+import { JobSubmitButton } from '@/components/job/job-submit-button
 import { publishValidateSearch } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'
 
 import { ITrainingCreate, apiTrainingCreate } from '@/services/api/vcjob'
+
+import { useJobCreateBillingBlockDialog } from '@/hooks/use-job-create-billing-block'
 
 import {
   VolumeMountType,
@@ -76,6 +79,7 @@ import {
   volumeMountsSchema,
 } from '@/utils/form'
 import { atomUserInfo } from '@/utils/store'
+import { showErrorToast } from '@/utils/toast'
 
 export const Route = createFileRoute('/portal/jobs/new/emias-job')({
   validateSearch: publishValidateSearch,
@@ -152,6 +156,8 @@ function RouteComponent() {
   const router = useRouter()
   const queryClient = useQueryClient()
   const user = useAtomValue(atomUserInfo)
+  const { billingBlockDialogOpen, setBillingBlockDialogOpen, handleJobCreateError } =
+    useJobCreateBillingBlockDialog()
 
   const { mutate: createTask, isPending } = useMutation({
     mutationFn: (values: FormSchema) =>
@@ -185,6 +191,12 @@ function RouteComponent() {
       ])
       toast.success(`作业 ${jobName} 创建成功`)
       router.history.back()
+    },
+    onError: (error) => {
+      if (handleJobCreateError(error)) {
+        return
+      }
+      showErrorToast(error)
     },
   })
 
@@ -232,6 +244,10 @@ function RouteComponent() {
 
   return (
     <>
+      <CreateBillingBlockDialog
+        open={billingBlockDialogOpen}
+        onOpenChange={setBillingBlockDialogOpen}
+      />
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}

--- a/frontend/src/routes/portal/jobs/new/emias-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/emias-job.tsx
@@ -56,7 +56,7 @@ import { ResourceFormFields } from '@/components/form/resource-form-field'
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormCustom } from '@/components/form/types'
 import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
-import { JobSubmitButton } from '@/components/job/job-submit-button
+import { JobSubmitButton } from '@/components/job/job-submit-button'
 import { publishValidateSearch } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'

--- a/frontend/src/routes/portal/jobs/new/emias-jupyter-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/emias-jupyter-job.tsx
@@ -48,7 +48,7 @@ import { ResourceFormFields } from '@/components/form/resource-form-field'
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormJupyterEmias } from '@/components/form/types'
 import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
-import { JobSubmitButton } from '@/components/job/job-submit-button
+import { JobSubmitButton } from '@/components/job/job-submit-button'
 import { PublishConfigForm, publishValidateSearch } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'

--- a/frontend/src/routes/portal/jobs/new/emias-jupyter-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/emias-jupyter-job.tsx
@@ -47,12 +47,15 @@ import { OtherOptionsFormCard } from '@/components/form/other-options-form-field
 import { ResourceFormFields } from '@/components/form/resource-form-field'
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormJupyterEmias } from '@/components/form/types'
-import { JobSubmitButton } from '@/components/job/job-submit-button'
+import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
+import { JobSubmitButton } from '@/components/job/job-submit-button
 import { PublishConfigForm, publishValidateSearch } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'
 
 import { JobType, apiJobTemplate, apiJupyterCreate } from '@/services/api/vcjob'
+
+import { useJobCreateBillingBlockDialog } from '@/hooks/use-job-create-billing-block'
 
 import {
   VolumeMountType,
@@ -68,6 +71,7 @@ import {
   volumeMountsSchema,
 } from '@/utils/form'
 import { atomUserInfo } from '@/utils/store'
+import { showErrorToast } from '@/utils/toast'
 
 export const Route = createFileRoute('/portal/jobs/new/emias-jupyter-job')({
   validateSearch: publishValidateSearch,
@@ -136,6 +140,8 @@ function RouteComponent() {
   const router = useRouter()
   const queryClient = useQueryClient()
   const user = useAtomValue(atomUserInfo)
+  const { billingBlockDialogOpen, setBillingBlockDialogOpen, handleJobCreateError } =
+    useJobCreateBillingBlockDialog()
 
   const { mutate: createTask, isPending } = useMutation({
     mutationFn: (values: FormSchema) => {
@@ -167,6 +173,12 @@ function RouteComponent() {
       ])
       toast.success(`作业 ${jobName} 创建成功`)
       router.history.back()
+    },
+    onError: (error) => {
+      if (handleJobCreateError(error)) {
+        return
+      }
+      showErrorToast(error)
     },
   })
 
@@ -260,6 +272,10 @@ function RouteComponent() {
 
   return (
     <>
+      <CreateBillingBlockDialog
+        open={billingBlockDialogOpen}
+        onOpenChange={setBillingBlockDialogOpen}
+      />
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}

--- a/frontend/src/routes/portal/jobs/new/jupyter-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/jupyter-job.tsx
@@ -48,13 +48,16 @@ import { ResourceFormFields } from '@/components/form/resource-form-field'
 import { ScheduleTypeFormField } from '@/components/form/schedule-type-form-field'
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormJupyter } from '@/components/form/types'
-import { JobSubmitButton } from '@/components/job/job-submit-button'
+import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
+import { JobSubmitButton } from '@/components/job/job-submit-button
 import { PublishConfigForm, publishValidateSearch } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'
 
 import { apiContextPrequeueStatus } from '@/services/api/context'
 import { ScheduleType, apiJupyterCreate } from '@/services/api/vcjob'
+
+import { useJobCreateBillingBlockDialog } from '@/hooks/use-job-create-billing-block'
 
 import {
   VolumeMountType,
@@ -70,6 +73,7 @@ import {
   volumeMountsSchema,
 } from '@/utils/form'
 import { atomUserInfo } from '@/utils/store'
+import { showErrorToast } from '@/utils/toast'
 
 export const Route = createFileRoute('/portal/jobs/new/jupyter-job')({
   validateSearch: publishValidateSearch,
@@ -147,6 +151,8 @@ function RouteComponent() {
     queryFn: () => apiContextPrequeueStatus().then((res) => res.data),
   })
   const isBackfillEnabled = prequeueStatusData?.backfillEnabled ?? false
+  const { billingBlockDialogOpen, setBillingBlockDialogOpen, handleJobCreateError } =
+    useJobCreateBillingBlockDialog()
 
   const { mutate: createTask, isPending } = useMutation({
     mutationFn: (values: FormSchema) => {
@@ -180,6 +186,12 @@ function RouteComponent() {
       navigate({
         to: '/portal/jobs/inter',
       })
+    },
+    onError: (error) => {
+      if (handleJobCreateError(error)) {
+        return
+      }
+      showErrorToast(error)
     },
   })
 
@@ -256,6 +268,10 @@ function RouteComponent() {
 
   return (
     <>
+      <CreateBillingBlockDialog
+        open={billingBlockDialogOpen}
+        onOpenChange={setBillingBlockDialogOpen}
+      />
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}

--- a/frontend/src/routes/portal/jobs/new/jupyter-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/jupyter-job.tsx
@@ -49,7 +49,7 @@ import { ScheduleTypeFormField } from '@/components/form/schedule-type-form-fiel
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormJupyter } from '@/components/form/types'
 import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
-import { JobSubmitButton } from '@/components/job/job-submit-button
+import { JobSubmitButton } from '@/components/job/job-submit-button'
 import { PublishConfigForm, publishValidateSearch } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'

--- a/frontend/src/routes/portal/jobs/new/pytorch-ddp-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/pytorch-ddp-job.tsx
@@ -51,7 +51,7 @@ import { ResourceFormFields } from '@/components/form/resource-form-field'
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormPytorch } from '@/components/form/types'
 import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
-import { JobSubmitButton } from '@/components/job/job-submit-button
+import { JobSubmitButton } from '@/components/job/job-submit-button'
 import { publishValidateSearch } from '@/components/job/publish'
 import { PublishConfigForm } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'

--- a/frontend/src/routes/portal/jobs/new/pytorch-ddp-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/pytorch-ddp-job.tsx
@@ -50,13 +50,16 @@ import { OtherOptionsFormCard } from '@/components/form/other-options-form-field
 import { ResourceFormFields } from '@/components/form/resource-form-field'
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormPytorch } from '@/components/form/types'
-import { JobSubmitButton } from '@/components/job/job-submit-button'
+import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
+import { JobSubmitButton } from '@/components/job/job-submit-button
 import { publishValidateSearch } from '@/components/job/publish'
 import { PublishConfigForm } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'
 
 import { apiPytorchCreate } from '@/services/api/vcjob'
+
+import { useJobCreateBillingBlockDialog } from '@/hooks/use-job-create-billing-block'
 
 import {
   VolumeMountType,
@@ -72,6 +75,7 @@ import {
   volumeMountsSchema,
 } from '@/utils/form'
 import { atomUserInfo } from '@/utils/store'
+import { showErrorToast } from '@/utils/toast'
 
 export const Route = createFileRoute('/portal/jobs/new/pytorch-ddp-job')({
   validateSearch: publishValidateSearch,
@@ -216,6 +220,8 @@ function RouteComponent() {
   const router = useRouter()
   const queryClient = useQueryClient()
   const user = useAtomValue(atomUserInfo)
+  const { billingBlockDialogOpen, setBillingBlockDialogOpen, handleJobCreateError } =
+    useJobCreateBillingBlockDialog()
 
   const { mutate: createTask, isPending } = useMutation({
     mutationFn: (values: FormSchema) =>
@@ -264,6 +270,12 @@ function RouteComponent() {
       ])
       toast.success(`作业 ${taskname} 创建成功`)
       router.history.back()
+    },
+    onError: (error) => {
+      if (handleJobCreateError(error)) {
+        return
+      }
+      showErrorToast(error)
     },
   })
 
@@ -358,6 +370,10 @@ function RouteComponent() {
 
   return (
     <>
+      <CreateBillingBlockDialog
+        open={billingBlockDialogOpen}
+        onOpenChange={setBillingBlockDialogOpen}
+      />
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit, onInvalid)}

--- a/frontend/src/routes/portal/jobs/new/seacs-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/seacs-job.tsx
@@ -45,6 +45,7 @@ import { EnvFormCard } from '@/components/form/env-form-field'
 import FormLabelMust from '@/components/form/form-label-must'
 import { ImageFormField } from '@/components/form/image-form-field'
 import { OtherOptionsFormCard } from '@/components/form/other-options-form-field'
+import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
 import { JobSubmitButton } from '@/components/job/job-submit-button'
 import { publishValidateSearch } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
@@ -52,6 +53,8 @@ import { ProgressBar } from '@/components/ui-custom/colorful-progress'
 
 import { IDlAnalyze, apiDlAnalyze } from '@/services/api/recommend/dl-task'
 import { apiJobTemplate, apiSparseCreate } from '@/services/api/vcjob'
+
+import { useJobCreateBillingBlockDialog } from '@/hooks/use-job-create-billing-block'
 
 import {
   VolumeMountType,
@@ -66,6 +69,7 @@ import {
   volumeMountsSchema,
 } from '@/utils/form'
 import { atomUserInfo } from '@/utils/store'
+import { showErrorToast } from '@/utils/toast'
 
 import { cn } from '@/lib/utils'
 
@@ -119,6 +123,8 @@ function RouteComponent() {
   const [otherOpen, setOtherOpen] = useState<boolean>(false)
   const router = useRouter()
   const queryClient = useQueryClient()
+  const { billingBlockDialogOpen, setBillingBlockDialogOpen, handleJobCreateError } =
+    useJobCreateBillingBlockDialog()
   const user = useAtomValue(atomUserInfo)
 
   const { mutate: createTask, isPending } = useMutation({
@@ -167,6 +173,12 @@ function RouteComponent() {
       ])
       toast.success(`作业 ${jobName} 创建成功`)
       router.history.back()
+    },
+    onError: (error) => {
+      if (handleJobCreateError(error)) {
+        return
+      }
+      showErrorToast(error)
     },
   })
 
@@ -294,6 +306,10 @@ function RouteComponent() {
 
   return (
     <>
+      <CreateBillingBlockDialog
+        open={billingBlockDialogOpen}
+        onOpenChange={setBillingBlockDialogOpen}
+      />
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}

--- a/frontend/src/routes/portal/jobs/new/single-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/single-job.tsx
@@ -57,13 +57,16 @@ import { ResourceFormFields } from '@/components/form/resource-form-field'
 import { ScheduleTypeFormField } from '@/components/form/schedule-type-form-field'
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormCustom } from '@/components/form/types'
-import { JobSubmitButton } from '@/components/job/job-submit-button'
+import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
+import { JobSubmitButton } from '@/components/job/job-submit-button
 import { PublishConfigForm, publishValidateSearch } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'
 
 import { apiContextPrequeueStatus } from '@/services/api/context'
 import { ScheduleType, apiTrainingCreate } from '@/services/api/vcjob'
+
+import { useJobCreateBillingBlockDialog } from '@/hooks/use-job-create-billing-block'
 
 import {
   VolumeMountType,
@@ -79,6 +82,7 @@ import {
   volumeMountsSchema,
 } from '@/utils/form'
 import { atomUserInfo } from '@/utils/store'
+import { showErrorToast } from '@/utils/toast'
 
 export const Route = createFileRoute('/portal/jobs/new/single-job')({
   validateSearch: publishValidateSearch,
@@ -153,6 +157,8 @@ function RouteComponent() {
     queryFn: () => apiContextPrequeueStatus().then((res) => res.data),
   })
   const isBackfillEnabled = prequeueStatusData?.backfillEnabled ?? false
+  const { billingBlockDialogOpen, setBillingBlockDialogOpen, handleJobCreateError } =
+    useJobCreateBillingBlockDialog()
   const { mutate: createTask, isPending } = useMutation({
     mutationFn: (values: FormSchema) =>
       apiTrainingCreate({
@@ -189,6 +195,12 @@ function RouteComponent() {
       navigate({
         to: '/portal/jobs/custom',
       })
+    },
+    onError: (error) => {
+      if (handleJobCreateError(error)) {
+        return
+      }
+      showErrorToast(error)
     },
   })
 
@@ -241,6 +253,10 @@ function RouteComponent() {
 
   return (
     <>
+      <CreateBillingBlockDialog
+        open={billingBlockDialogOpen}
+        onOpenChange={setBillingBlockDialogOpen}
+      />
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}

--- a/frontend/src/routes/portal/jobs/new/single-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/single-job.tsx
@@ -58,7 +58,7 @@ import { ScheduleTypeFormField } from '@/components/form/schedule-type-form-fiel
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormCustom } from '@/components/form/types'
 import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
-import { JobSubmitButton } from '@/components/job/job-submit-button
+import { JobSubmitButton } from '@/components/job/job-submit-button'
 import { PublishConfigForm, publishValidateSearch } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'

--- a/frontend/src/routes/portal/jobs/new/tensorflow-ps-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/tensorflow-ps-job.tsx
@@ -51,7 +51,7 @@ import { ResourceFormFields } from '@/components/form/resource-form-field'
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormTensorflow } from '@/components/form/types'
 import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
-import { JobSubmitButton } from '@/components/job/job-submit-button
+import { JobSubmitButton } from '@/components/job/job-submit-button'
 import { publishValidateSearch } from '@/components/job/publish'
 import { PublishConfigForm } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'

--- a/frontend/src/routes/portal/jobs/new/tensorflow-ps-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/tensorflow-ps-job.tsx
@@ -50,13 +50,16 @@ import { OtherOptionsFormCard } from '@/components/form/other-options-form-field
 import { ResourceFormFields } from '@/components/form/resource-form-field'
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormTensorflow } from '@/components/form/types'
-import { JobSubmitButton } from '@/components/job/job-submit-button'
+import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
+import { JobSubmitButton } from '@/components/job/job-submit-button
 import { publishValidateSearch } from '@/components/job/publish'
 import { PublishConfigForm } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'
 
 import { apiTensorflowCreate } from '@/services/api/vcjob'
+
+import { useJobCreateBillingBlockDialog } from '@/hooks/use-job-create-billing-block'
 
 import {
   VolumeMountType,
@@ -71,6 +74,7 @@ import {
   volumeMountsSchema,
 } from '@/utils/form'
 import { atomUserInfo } from '@/utils/store'
+import { showErrorToast } from '@/utils/toast'
 
 export const Route = createFileRoute('/portal/jobs/new/tensorflow-ps-job')({
   validateSearch: publishValidateSearch,
@@ -275,6 +279,8 @@ function RouteComponent() {
   const router = useRouter()
   const queryClient = useQueryClient()
   const user = useAtomValue(atomUserInfo)
+  const { billingBlockDialogOpen, setBillingBlockDialogOpen, handleJobCreateError } =
+    useJobCreateBillingBlockDialog()
 
   const { mutate: createTask, isPending } = useMutation({
     mutationFn: (values: FormSchema) =>
@@ -323,6 +329,12 @@ function RouteComponent() {
       ])
       toast.success(`作业 ${taskname} 创建成功`)
       router.history.back()
+    },
+    onError: (error) => {
+      if (handleJobCreateError(error)) {
+        return
+      }
+      showErrorToast(error)
     },
   })
 
@@ -413,6 +425,10 @@ function RouteComponent() {
 
   return (
     <>
+      <CreateBillingBlockDialog
+        open={billingBlockDialogOpen}
+        onOpenChange={setBillingBlockDialogOpen}
+      />
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}

--- a/frontend/src/routes/portal/jobs/new/webide-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/webide-job.tsx
@@ -48,13 +48,16 @@ import { ResourceFormFields } from '@/components/form/resource-form-field'
 import { ScheduleTypeFormField } from '@/components/form/schedule-type-form-field'
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormWebIDE } from '@/components/form/types'
-import { JobSubmitButton } from '@/components/job/job-submit-button'
+import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
+import { JobSubmitButton } from '@/components/job/job-submit-button
 import { PublishConfigForm, publishValidateSearch } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'
 
 import { apiContextPrequeueStatus } from '@/services/api/context'
 import { ScheduleType, apiWebIDECreate } from '@/services/api/vcjob'
+
+import { useJobCreateBillingBlockDialog } from '@/hooks/use-job-create-billing-block'
 
 import {
   VolumeMountType,
@@ -69,6 +72,7 @@ import {
   volumeMountsSchema,
 } from '@/utils/form'
 import { atomUserInfo } from '@/utils/store'
+import { showErrorToast } from '@/utils/toast'
 
 export const Route = createFileRoute('/portal/jobs/new/webide-job')({
   validateSearch: publishValidateSearch,
@@ -124,6 +128,8 @@ function RouteComponent() {
     queryFn: () => apiContextPrequeueStatus().then((res) => res.data),
   })
   const isBackfillEnabled = prequeueStatusData?.backfillEnabled ?? false
+  const { billingBlockDialogOpen, setBillingBlockDialogOpen, handleJobCreateError } =
+    useJobCreateBillingBlockDialog()
 
   const { mutate: createTask, isPending } = useMutation({
     mutationFn: (values: FormSchema) => {
@@ -156,6 +162,12 @@ function RouteComponent() {
       navigate({
         to: '/portal/jobs/inter',
       })
+    },
+    onError: (error) => {
+      if (handleJobCreateError(error)) {
+        return
+      }
+      showErrorToast(error)
     },
   })
 
@@ -236,6 +248,10 @@ function RouteComponent() {
 
   return (
     <>
+      <CreateBillingBlockDialog
+        open={billingBlockDialogOpen}
+        onOpenChange={setBillingBlockDialogOpen}
+      />
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}

--- a/frontend/src/routes/portal/jobs/new/webide-job.tsx
+++ b/frontend/src/routes/portal/jobs/new/webide-job.tsx
@@ -49,7 +49,7 @@ import { ScheduleTypeFormField } from '@/components/form/schedule-type-form-fiel
 import { TemplateInfo } from '@/components/form/template-info'
 import { MetadataFormWebIDE } from '@/components/form/types'
 import { CreateBillingBlockDialog } from '@/components/job/create-billing-block-dialog'
-import { JobSubmitButton } from '@/components/job/job-submit-button
+import { JobSubmitButton } from '@/components/job/job-submit-button'
 import { PublishConfigForm, publishValidateSearch } from '@/components/job/publish'
 import CardTitle from '@/components/label/card-title'
 import PageTitle from '@/components/layout/page-title'

--- a/frontend/src/routes/portal/more/user.tsx
+++ b/frontend/src/routes/portal/more/user.tsx
@@ -122,7 +122,6 @@ function RouteComponent() {
     queryFn: () => apiUserEmailVerified(),
     select: (res) => res.data,
   })
-
   const { mutate: updateUser } = useMutation({
     mutationFn: (values: IUserAttributes) => apiContextUpdateUserAttributes(values),
     onSuccess: (_data, values) => {

--- a/frontend/src/routes/portal/overview/index.tsx
+++ b/frontend/src/routes/portal/overview/index.tsx
@@ -55,7 +55,7 @@ import {
   ScheduleType,
   apiJobAllList,
   getUnifiedJobPhase,
-} from '@/services/api/vcjob
+} from '@/services/api/vcjob'
 import { queryNodes } from '@/services/query/node'
 import { queryResources } from '@/services/query/resource'
 

--- a/frontend/src/routes/portal/overview/index.tsx
+++ b/frontend/src/routes/portal/overview/index.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useQuery } from '@tanstack/react-query'
+import { UseQueryResult, useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { ColumnDef } from '@tanstack/react-table'
 import { type Locale, enUS, ja, ko, zhCN } from 'date-fns/locale'
@@ -30,6 +30,8 @@ import ScheduleTypeLabel from '@/components/badge/schedule-type-badge'
 import DocsButton from '@/components/button/docs-button'
 import NivoPie from '@/components/chart/nivo-pie'
 import PieCard from '@/components/chart/pie-card'
+import { BillingPointsBadge } from '@/components/custom/billing-points-badge'
+import { BillingSummaryCards } from '@/components/custom/billing-summary-cards'
 import { TimeDistance } from '@/components/custom/time-distance'
 import ListedNewJobButton from '@/components/job/new-job-button'
 import { getHeader } from '@/components/job/overview/admin-jobs'
@@ -43,6 +45,9 @@ import { DataTable } from '@/components/query-table'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
 import { DataTableToolbarConfig } from '@/components/query-table/toolbar'
 
+import { apiJobAllBillingList } from '@/services/api/billing'
+import { apiContextBillingSummary } from '@/services/api/context'
+import { apiGetBillingStatus } from '@/services/api/system-config'
 import {
   IJobInfo,
   JobPhase,
@@ -50,10 +55,11 @@ import {
   ScheduleType,
   apiJobAllList,
   getUnifiedJobPhase,
-} from '@/services/api/vcjob'
+} from '@/services/api/vcjob
 import { queryNodes } from '@/services/query/node'
 import { queryResources } from '@/services/query/resource'
 
+import { isBillingVisibleForUser } from '@/utils/billing-visibility'
 import { getUserPseudonym } from '@/utils/pseudonym'
 import { atomUserInfo, globalHideUsername } from '@/utils/store'
 
@@ -89,11 +95,18 @@ const toolbarConfig: DataTableToolbarConfig = {
   getHeader: getHeader,
 }
 
+type JobTableRow = IJobInfo & { billedPointsTotal?: number }
+
 function Overview() {
   const { i18n, t } = useTranslation()
   const userInfo = useAtomValue(atomUserInfo)
   const nodeQuery = useQuery(queryNodes(true))
   const { getNicknameByName } = useAccountNameLookup()
+  const { data: billingStatus } = useQuery({
+    queryKey: ['system-config', 'billing-status'],
+    queryFn: () => apiGetBillingStatus().then((res) => res.data),
+  })
+  const billingVisible = isBillingVisibleForUser(billingStatus)
 
   // 获取当前语言对应的 date-fns locale
   const getDateLocale = useCallback((): Locale => {
@@ -109,7 +122,7 @@ function Overview() {
     }
   }, [i18n.language])
 
-  const jobColumns = useMemo<ColumnDef<IJobInfo>[]>(
+  const jobColumns = useMemo<ColumnDef<JobTableRow>[]>(
     () => [
       {
         accessorKey: 'jobType',
@@ -178,6 +191,15 @@ function Overview() {
           return 0
         },
       },
+      ...(billingVisible
+        ? [
+            {
+              accessorKey: 'billedPointsTotal',
+              header: ({ column }) => <DataTableColumnHeader column={column} title="累计点数" />,
+              cell: ({ row }) => <BillingPointsBadge value={row.original.billedPointsTotal ?? 0} />,
+            } as ColumnDef<JobTableRow>,
+          ]
+        : []),
       {
         accessorFn: (row) => getUnifiedJobPhase(row.status),
         id: 'status',
@@ -222,7 +244,7 @@ function Overview() {
         sortingFn: 'datetime',
       },
     ],
-    []
+    [billingVisible]
   )
 
   const jobQuery = useQuery({
@@ -231,12 +253,53 @@ function Overview() {
     select: (res) => res.data,
     refetchInterval: REFETCH_INTERVAL,
   })
+  const jobBillingQuery = useQuery({
+    queryKey: ['overview', 'joblist', 'billing'],
+    queryFn: () => apiJobAllBillingList(),
+    select: (res) =>
+      res.data.reduce<Record<string, number>>((acc, item) => {
+        acc[item.jobName] = item.billedPointsTotal
+        return acc
+      }, {}),
+    refetchInterval: REFETCH_INTERVAL,
+    enabled: billingVisible,
+  })
+  const mergedJobQuery = useMemo(
+    () =>
+      ({
+        data: (jobQuery.data ?? []).map((job) => ({
+          ...job,
+          billedPointsTotal: jobBillingQuery.data?.[job.jobName] ?? 0,
+        })),
+        isLoading: jobQuery.isLoading || (billingVisible && jobBillingQuery.isLoading),
+        dataUpdatedAt: Math.max(
+          jobQuery.dataUpdatedAt,
+          billingVisible ? jobBillingQuery.dataUpdatedAt : 0
+        ),
+        refetch: jobQuery.refetch,
+      }) as unknown as UseQueryResult<JobTableRow[], Error>,
+    [
+      billingVisible,
+      jobBillingQuery.data,
+      jobBillingQuery.dataUpdatedAt,
+      jobBillingQuery.isLoading,
+      jobQuery.data,
+      jobQuery.dataUpdatedAt,
+      jobQuery.isLoading,
+      jobQuery.refetch,
+    ]
+  )
 
   const resourcesQuery = useQuery(
     queryResources(true, (resource) => {
       return resource.type == 'gpu'
     })
   )
+  const billingSummaryQuery = useQuery({
+    queryKey: ['context', 'billing-summary', 'overview'],
+    queryFn: () => apiContextBillingSummary().then((res) => res.data),
+    enabled: billingVisible,
+  })
 
   const jobStatus = useMemo(() => {
     if (!jobQuery.data) {
@@ -346,7 +409,15 @@ function Overview() {
           description="使用异构集群管理平台 Crater 加速您的科研工作"
           className="lg:col-span-2"
         >
-          <div className="flex flex-row gap-3">
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            {billingVisible ? (
+              <BillingSummaryCards
+                summary={billingSummaryQuery.data}
+                emphasis="inline"
+                compact
+                className="shrink-0"
+              />
+            ) : null}
             <DocsButton title="平台文档" url="" />
             <ListedNewJobButton mode="all" />
           </div>
@@ -416,7 +487,7 @@ function Overview() {
           description: '查看近 7 天集群作业的运行情况',
         }}
         storageKey="overview_joblist"
-        query={jobQuery}
+        query={mergedJobQuery}
         columns={jobColumns}
         toolbarConfig={toolbarConfig}
       />

--- a/frontend/src/services/api/account.ts
+++ b/frontend/src/services/api/account.ts
@@ -86,7 +86,7 @@ export interface IUserInAccountUpdateReq {
   uid: number
   role: string
   accessmode: string
-  quota?: Record<string, string>
+  quota?: IQuota
 }
 
 export interface IUserInAccountUpdateResp {
@@ -146,6 +146,12 @@ export const apiUserUpdateAccountMember = async (aid: number, user: IUserInAccou
     role: user.role,
     accessmode: user.accessmode,
   })
+
+export const apiUserUpdateAccountMemberPartial = (
+  aid: number,
+  uid: number,
+  data: { uid?: number; role?: string; accessmode?: string; quota?: IQuota }
+) => apiV1Put<IResponse<IUserInAccountUpdateResp>>(`accounts/${aid}/users/${uid}`, data)
 
 export const apiUserRemoveAccountMember = async (aid: number, user: IUserInAccountCreate) =>
   apiV1Delete<IResponse<IUserInAccount>>(`accounts/${aid}/users/${user.id}`)

--- a/frontend/src/services/api/admin/user.ts
+++ b/frontend/src/services/api/admin/user.ts
@@ -38,6 +38,7 @@ export interface IUser {
   name: string
   role: Role
   status: ProjectStatus
+  extraBalance?: number
   attributes: IUserAttributes
 }
 

--- a/frontend/src/services/api/billing.ts
+++ b/frontend/src/services/api/billing.ts
@@ -1,0 +1,190 @@
+import { getDefaultStore } from 'jotai'
+
+import { apiV1Get, apiV1Post, apiV1Put } from '@/services/client'
+
+import { globalJobUrl } from '@/utils/store'
+
+import { IResponse } from '../types'
+
+const store = getDefaultStore()
+const JOB_URL = store.get(globalJobUrl)
+
+export interface BillingSummaryResp {
+  periodFreeBalance: number
+  extraBalance: number
+  totalAvailable: number
+  lastIssuedAt?: string
+  nextIssueAt?: string
+  effectiveIssueAmount: number
+  effectiveIssuePeriodMinutes: number
+}
+
+export interface UserBillingAccount {
+  accountId: number
+  accountName: string
+  accountNickname: string
+  periodFreeBalance: number
+  extraBalance: number
+  totalAvailable: number
+  lastIssuedAt?: string
+  nextIssueAt?: string
+  effectiveIssueAmount: number
+  effectiveIssuePeriodMinutes: number
+}
+
+export interface UserBillingSummary {
+  userId: number
+  username: string
+  extraBalance: number
+  periodFreeTotal: number
+  totalIssueAmount: number
+  totalAvailable: number
+}
+
+export interface AccountBillingConfig {
+  issueAmount?: number
+  issuePeriodMinutes?: number
+  effectiveIssueAmount: number
+  effectiveIssuePeriodMinutes: number
+  lastIssuedAt?: string
+}
+
+export interface AccountBillingMember {
+  issueAmountOverride?: number | null
+  userId: number
+  username: string
+  nickname: string
+  periodFreeBalance: number
+  extraBalance: number
+  totalAvailable: number
+  lastIssuedAt?: string
+  nextIssueAt?: string
+  effectiveIssueAmount: number
+  effectiveIssuePeriodMinutes: number
+}
+
+export interface BillingPriceResource {
+  id: number
+  name: string
+  label: string
+  unitPrice: number
+}
+
+export interface JobBillingInfo {
+  jobName: string
+  name: string
+  billedPointsTotal: number
+}
+
+export interface AdjustUserExtraBalanceResp {
+  userId: number
+  username: string
+  beforeBalance: number
+  delta: number
+  afterBalance: number
+}
+
+export interface AdjustUserExtraBalanceReq {
+  delta: number
+  reason?: string
+}
+
+export interface UpdateAccountBillingMemberIssueAmountReq {
+  issueAmountOverride: number | null
+}
+
+export const apiContextBillingSummary = () =>
+  apiV1Get<IResponse<BillingSummaryResp>>('context/billing/summary')
+
+export const apiAdminAdjustUserExtraBalance = (userName: string, data: AdjustUserExtraBalanceReq) =>
+  apiV1Post<IResponse<AdjustUserExtraBalanceResp>>(
+    `admin/users/${userName}/billing/extra-balance`,
+    data
+  )
+
+export const apiAdminGetUserBillingAccounts = (userName: string) =>
+  apiV1Get<IResponse<UserBillingAccount[]>>(`admin/users/${userName}/billing/accounts`)
+
+export const apiAdminGetUserBillingSummary = () =>
+  apiV1Get<IResponse<UserBillingSummary[]>>('admin/users/billing/summary')
+
+export const apiAdminGetAccountBillingConfig = (accountId: number) =>
+  apiV1Get<IResponse<AccountBillingConfig>>(`admin/accounts/${accountId}/billing/config`)
+
+export const apiGetAccountBillingConfig = (accountId: number) =>
+  apiV1Get<IResponse<AccountBillingConfig>>(`accounts/${accountId}/billing/config`)
+
+export const apiAdminUpdateAccountBillingConfig = (
+  accountId: number,
+  data: { issueAmount?: number; issuePeriodMinutes?: number }
+) => apiV1Put<IResponse<AccountBillingConfig>>(`admin/accounts/${accountId}/billing/config`, data)
+
+export const apiUpdateAccountBillingConfig = (
+  accountId: number,
+  data: { issueAmount?: number; issuePeriodMinutes?: number }
+) => apiV1Put<IResponse<AccountBillingConfig>>(`accounts/${accountId}/billing/config`, data)
+
+export const apiAdminGetAccountBillingMembers = (accountId: number) =>
+  apiV1Get<IResponse<AccountBillingMember[]>>(`admin/accounts/${accountId}/billing/members`)
+
+export const apiGetAccountBillingMembers = (accountId: number) =>
+  apiV1Get<IResponse<AccountBillingMember[]>>(`accounts/${accountId}/billing/members`)
+
+export const apiAdminUpdateAccountBillingMemberIssueAmount = (
+  accountId: number,
+  userId: number,
+  data: UpdateAccountBillingMemberIssueAmountReq
+) =>
+  apiV1Put<IResponse<AccountBillingMember>>(
+    `admin/accounts/${accountId}/billing/members/${userId}`,
+    data
+  )
+
+export const apiUpdateAccountBillingMemberIssueAmount = (
+  accountId: number,
+  userId: number,
+  data: UpdateAccountBillingMemberIssueAmountReq
+) =>
+  apiV1Put<IResponse<AccountBillingMember>>(`accounts/${accountId}/billing/members/${userId}`, data)
+
+export const apiAdminResetAccountBillingBalance = (accountId: number) =>
+  apiV1Post<IResponse<string>>(`admin/accounts/${accountId}/billing/reset`)
+
+export const apiResetAccountBillingBalance = (accountId: number) =>
+  apiV1Post<IResponse<string>>(`accounts/${accountId}/billing/reset`)
+
+export const apiAdminResetAllBillingBalances = () =>
+  apiV1Post<
+    IResponse<{ accountsAffected: number; userAccountsAffected: number; issuedAt: string }>
+  >('admin/system-config/billing/reset-all')
+
+export const apiBillingPriceList = () =>
+  apiV1Get<IResponse<BillingPriceResource[]>>('resources/billing/prices')
+
+export const apiAdminUpdateResourceUnitPrice = (id: number, unitPrice: number) =>
+  apiV1Put<IResponse<unknown>>(`admin/resources/${id}/billing/unit-price`, { unitPrice })
+
+export const apiJobBillingList = () => apiV1Get<IResponse<JobBillingInfo[]>>(`${JOB_URL}/billing`)
+
+export const apiJobAllBillingList = (days?: number) =>
+  apiV1Get<IResponse<JobBillingInfo[]>>(`${JOB_URL}/billing/all`, {
+    searchParams: days === undefined ? undefined : { days },
+  })
+
+export const apiAdminGetJobBillingList = (days: number) =>
+  apiV1Get<IResponse<JobBillingInfo[]>>(`admin/${JOB_URL}/billing`, {
+    searchParams: { days },
+  })
+
+export const apiAdminGetUserJobBillingList = (username: string, days: number = 30) =>
+  apiV1Get<IResponse<JobBillingInfo[]>>(`admin/${JOB_URL}/billing/user/${username}`, {
+    searchParams: { days },
+  })
+
+export const apiGetUserJobBillingList = (username: string, days: number = 30) =>
+  apiV1Get<IResponse<JobBillingInfo[]>>(`${JOB_URL}/billing/user/${username}`, {
+    searchParams: { days },
+  })
+
+export const apiJobBillingDetail = (jobName: string) =>
+  apiV1Get<IResponse<JobBillingInfo>>(`${JOB_URL}/${jobName}/billing`)

--- a/frontend/src/services/api/context.ts
+++ b/frontend/src/services/api/context.ts
@@ -67,6 +67,16 @@ export interface PrequeueFeatureStatusResp {
   backfillEnabled: boolean
 }
 
+export interface BillingSummaryResp {
+  periodFreeBalance: number
+  extraBalance: number
+  totalAvailable: number
+  lastIssuedAt?: string
+  nextIssueAt?: string
+  effectiveIssueAmount: number
+  effectiveIssuePeriodMinutes: number
+}
+
 const store = getDefaultStore()
 const { scheduler } = store.get(globalSettings)
 
@@ -82,6 +92,9 @@ export const apiContextJobResourceSummary = (scope: JobResourceSummaryScope = 'p
   apiV1Get<IResponse<JobResourceSummaryResp>>('context/job-resource-summary', {
     searchParams: { scope },
   })
+
+export const apiContextBillingSummary = () =>
+  apiV1Get<IResponse<BillingSummaryResp>>('context/billing/summary')
 
 export const apiContextUpdateUserAttributes = (data: IUserAttributes) =>
   apiV1Put<IResponse<string>>('context/attributes', data)

--- a/frontend/src/services/api/system-config.ts
+++ b/frontend/src/services/api/system-config.ts
@@ -1,5 +1,5 @@
 // src/services/api/system-config.ts
-import { apiV1Delete, apiV1Get, apiV1Put } from '@/services/client'
+import { apiV1Delete, apiV1Get, apiV1Post, apiV1Put } from '@/services/client'
 
 import { IResponse } from '../types'
 
@@ -23,6 +23,50 @@ export interface IPrequeueConfig {
   normalJobWaitingToleranceSeconds: number
   activateTickerIntervalSeconds: number
   maxTotalActivationsPerRound: number
+}
+
+export interface IBillingStatus {
+  featureEnabled: boolean
+  active: boolean
+  runningSettlementEnabled: boolean
+  runningSettlementIntervalMinutes: number
+  jobFreeMinutes: number
+  defaultIssueAmount: number
+  defaultIssuePeriodMinutes: number
+  accountIssueAmountOverrideEnabled: boolean
+  accountIssuePeriodOverrideEnabled: boolean
+  baseLoopCronStatus: string
+  baseLoopCronEnabled: boolean
+}
+
+export interface ISetBillingStatusReq {
+  featureEnabled?: boolean
+  active?: boolean
+  runningSettlementEnabled?: boolean
+  runningSettlementIntervalMinutes?: number
+  jobFreeMinutes?: number
+  defaultIssueAmount?: number
+  defaultIssuePeriodMinutes?: number
+  accountIssueAmountOverrideEnabled?: boolean
+  accountIssuePeriodOverrideEnabled?: boolean
+}
+
+export interface IResetAllBillingBalancesResp {
+  accountsAffected: number
+  userAccountsAffected: number
+  issuedAt: string
+}
+
+export interface IGrantAllUsersExtraBalanceReq {
+  delta: number
+  reason?: string
+}
+
+export interface IGrantAllUsersExtraBalanceResp {
+  usersAffected: number
+  delta: number
+  reason?: string
+  issuedAt: string
 }
 
 /** 获取 LLM 配置 */
@@ -51,3 +95,30 @@ export const apiAdminGetPrequeueConfig = () =>
 /** 更新预排队配置 */
 export const apiAdminUpdatePrequeueConfig = (data: IPrequeueConfig) =>
   apiV1Put<IResponse<string>>('admin/system-config/prequeue', data)
+
+/** 获取 Billing 开关状态 */
+export const apiGetBillingStatus = () =>
+  apiV1Get<IResponse<IBillingStatus>>('system-config/billing')
+
+/** 获取 Billing 开关状态 */
+export const apiAdminGetBillingStatus = () =>
+  apiV1Get<IResponse<IBillingStatus>>('admin/system-config/billing')
+
+/** 设置 Billing 开关状态 */
+export const apiAdminSetBillingStatus = (data: ISetBillingStatusReq) =>
+  apiV1Put<IResponse<string>>('admin/system-config/billing', data)
+
+/** 手动执行一次 Billing 基础循环 */
+export const apiAdminTriggerBillingReconcile = () =>
+  apiV1Post<IResponse<unknown>>('admin/system-config/billing/reconcile')
+
+/** 重置全平台所有账户成员的免费额度 */
+export const apiAdminResetAllBillingBalances = () =>
+  apiV1Post<IResponse<IResetAllBillingBalancesResp>>('admin/system-config/billing/reset-all')
+
+/** 给所有用户发放额外点数 */
+export const apiAdminGrantAllUsersExtraBalance = (data: IGrantAllUsersExtraBalanceReq) =>
+  apiV1Post<IResponse<IGrantAllUsersExtraBalanceResp>>(
+    'admin/system-config/billing/extra-balance-all',
+    data
+  )

--- a/frontend/src/utils/billing-visibility.ts
+++ b/frontend/src/utils/billing-visibility.ts
@@ -1,0 +1,15 @@
+import { IBillingStatus } from '@/services/api/system-config'
+
+type BillingStatusLike = Pick<IBillingStatus, 'featureEnabled' | 'active'> | null | undefined
+
+export function isBillingVisibleForAdmin(status: BillingStatusLike) {
+  return Boolean(status?.featureEnabled)
+}
+
+export function isBillingVisibleForUser(status: BillingStatusLike) {
+  return Boolean(status?.featureEnabled && status?.active)
+}
+
+export function isBillingVisible(status: BillingStatusLike, audience: 'admin' | 'user') {
+  return audience === 'admin' ? isBillingVisibleForAdmin(status) : isBillingVisibleForUser(status)
+}

--- a/frontend/src/utils/billing.ts
+++ b/frontend/src/utils/billing.ts
@@ -1,0 +1,75 @@
+import { V1ResourceList, convertKResourceToResource } from './resource'
+
+export interface BillingPriceSource {
+  label: string
+  unitPrice: number
+}
+
+export interface BillingPriceEntryInput {
+  label?: string
+  multiplier?: number
+  resourceList?: V1ResourceList
+}
+
+export interface BillingResourceCostItem {
+  name: string
+  label: string
+  amount: number
+  unitPrice: number
+  costPerHour: number
+}
+
+export interface BillingPriceEntrySummary {
+  label?: string
+  multiplier: number
+  subtotalPerHour: number
+  items: BillingResourceCostItem[]
+}
+
+export const formatBillingPoints = (value?: number) =>
+  new Intl.NumberFormat('zh-CN', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value ?? 0)
+
+export const calcBillingAmount = (resourceName: string, rawValue?: string) => {
+  if (!rawValue) {
+    return 0
+  }
+  const normalized = convertKResourceToResource(resourceName, rawValue)
+  if (normalized == null || Number.isNaN(normalized)) {
+    return 0
+  }
+  return normalized
+}
+
+export const summarizeBillingPriceEntries = (
+  entries: BillingPriceEntryInput[],
+  priceSources: Record<string, BillingPriceSource>
+): BillingPriceEntrySummary[] =>
+  entries.map((entry) => {
+    const multiplier = Math.max(1, entry.multiplier ?? 1)
+    const resourceList = entry.resourceList ?? {}
+    const items = Object.entries(resourceList)
+      .map(([resourceName, rawValue]) => {
+        const source = priceSources[resourceName]
+        const unitPrice = source?.unitPrice ?? 0
+        const amount = calcBillingAmount(resourceName, rawValue)
+        const costPerHour = amount * unitPrice * multiplier
+        return {
+          name: resourceName,
+          label: source?.label ?? resourceName,
+          amount,
+          unitPrice,
+          costPerHour,
+        }
+      })
+      .filter((item) => item.unitPrice > 0 && item.amount > 0)
+
+    return {
+      label: entry.label,
+      multiplier,
+      subtotalPerHour: items.reduce((sum, item) => sum + item.costPerHour, 0),
+      items,
+    }
+  })


### PR DESCRIPTION
## 变更背景

本次改动为系统补齐 billing 能力，打通“计费配置 -> 额度发放 -> 作业结算 -> 前端展示 -> 管理端操作”的完整链路，并修复 rebase 后产生的 lint / 编译回归问题。

## 主要改动

- 后端新增 BillingService，统一管理 billing 相关系统配置，包括功能开关、激活状态、运行中周期结算、免费时长、默认发放额度与发放周期等。
- 新增 billing 启用前校验逻辑，避免在配置不完整或状态不合法时直接激活计费能力。
- 支持运行中作业的周期性结算，以及作业结束、删除时的最终结算，保证账单数据更完整。
- 新增管理接口，支持查询和更新 billing 状态、手动触发一次 reconcile、重置所有余额、给全体用户发放额外余额。
- 新增作业 billing 查询接口，支持查看个人作业账单、指定用户作业账单、全量作业账单以及单个作业的 billing 明细。
- 账户、用户、资源等相关接口补充 billing 字段与可见性控制，支持按系统开关决定用户侧是否展示 billing 信息。
- 前端新增 billing API 封装及一批展示组件，包括余额/积分徽标、价格预览、账单摘要、余额进度展示等。
- 管理端新增 billing 设置页，支持计费开关配置、结算参数调整、全量余额重置、全员额外余额发放等操作。
- 用户侧补充 billing 展示与创建前拦截逻辑，在余额不足时阻止作业创建并给出明确提示。
- 补充 billing 相关测试，覆盖 service、handler 和 vcjob 相关场景。

## 修复内容

- 修复 rebase 后 `CheckResourcesBeforeCreateJob` 调用签名变化带来的 handler 侧 lint / 编译问题。
- 补齐部分 swagger 生成产物与格式问题，消除 rebase 后的 lint 回归。
- 对个别 handler 注释、`nolint` 标记和前端引用做同步修正，保证主流程可正常构建。

## 影响范围

- 后端 billing 配置与结算逻辑
- 作业创建、删除、结束结算流程
- 管理端 billing 配置页
- 用户侧概览页、作业页和账户相关展示
- Swagger 接口文档生成产物
