### PR TITLE
fix: hide unimplemented user page tag

### DIFF
--- a/charts/crater/Chart.yaml
+++ b/charts/crater/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/frontend/src/components/user/index.tsx
+++ b/frontend/src/components/user/index.tsx
@@ -43,6 +43,9 @@ export default function UserDetail({ name, ...props }: DetailPageCoreProps & { n
   const { t } = useTranslation()
   const hideUsername = useAtomValue(globalHideUsername)
   const grafanaUser = useAtomValue(configGrafanaUserAtom)
+  // TODO: 这两个标签页对应的能力尚未实现，先在正式版本中隐藏（管理员/用户视图都隐藏）。
+  // 等 SharedItems / RecentActivity 真实可用后，再把该开关改为可配置项（feature flag / config）。
+  const hideUnimplementedTabs = true
 
   // 1. 获取用户信息
   const { data: user } = useQuery({
@@ -117,20 +120,24 @@ export default function UserDetail({ name, ...props }: DetailPageCoreProps & { n
       children: <UserJobsOverview username={name} />,
       scrollable: true,
     },
-    {
-      key: 'shared',
-      icon: Database,
-      label: t('userDetail.tabs.sharedResources'),
-      children: <SharedItems />,
-      scrollable: true,
-    },
-    {
-      key: 'recent',
-      icon: Calendar,
-      label: t('userDetail.tabs.recentActivity'),
-      children: <RecentActivity />,
-      scrollable: true,
-    },
+    ...(!hideUnimplementedTabs
+      ? ([
+          {
+            key: 'shared',
+            icon: Database,
+            label: t('userDetail.tabs.sharedResources'),
+            children: <SharedItems />,
+            scrollable: true,
+          },
+          {
+            key: 'recent',
+            icon: Calendar,
+            label: t('userDetail.tabs.recentActivity'),
+            children: <RecentActivity />,
+            scrollable: true,
+          },
+        ] as const)
+      : []),
   ]
 
   return <DetailPage {...props} header={header} info={info} tabs={tabs} />


### PR DESCRIPTION
在正式版本中隐藏用户详情页中尚未实现的“分享的资源”和“近期活动”两个标签页，避免暴露未完成入口，并保留后续恢复的 TODO 说明；同时将 Helm Chart 版本对齐到即将发布的正式版。

### 修改

- **用户详情页**：将“分享的资源 / 近期活动”两个未实现标签页在管理员与用户视图中统一隐藏，同时保留相关代码路径，后续实现完成可快速恢复（`frontend/src/components/user/index.tsx`）
- **Helm Chart**：将 Chart `version` 更新为 `1.0.0`，与准备发布的正式版对齐（`charts/crater/Chart.yaml`）

### 测试

- 本地运行前端，打开用户详情页，确认“分享的资源”“近期活动”标签页不再显示

### 其他（可选）

- 代码中已注明隐藏原因与 TODO，便于后续通过 feature flag / 配置项重新启用

---

Hide the unimplemented “Shared resources” and “Recent activity” tabs on the user detail page in production to avoid exposing unfinished entry points, while keeping the code and adding TODO notes for re-enabling later; also align the Helm Chart version with the upcoming stable release.

### Changes

- **User detail page**: Hide the two unimplemented tabs (“Shared resources” / “Recent activity”) for both admin and normal user views, keep the underlying code path, and leave TODO notes for future re-enable (`frontend/src/components/user/index.tsx`)
- **Helm Chart**: Bump the Chart `version` to `1.0.0` to match the upcoming stable release (`charts/crater/Chart.yaml`)

### Testing

- Run the frontend locally, open the user detail page, and verify the two tabs are no longer visible

### Other (optional)

- Added rationale and TODO notes in code for future feature-flag/config-based rollout

---

无关联 Issue

No related issues