### PR TITLE
docs: modernize README with hero layout, feature cards, and tech badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.omc/
 
 # Environment
 .env.development
@@ -76,3 +77,6 @@ kubeconfig*
 *.csv
 storage/etc/config.yaml
 .codex
+
+# Claude Code
+.claude/

--- a/README.md
+++ b/README.md
@@ -1,145 +1,146 @@
-<p align="center">
-  <a href="README.md">English</a> · <a href="docs/zh-CN/README.md">简体中文</a>
-</p>
+<div align="center">
 
-<p align="center">
-  <img src="./website/content/docs/admin/assets/icon.webp" alt="Crater logo" width="120" />
-</p>
+<img src="./website/content/docs/admin/assets/icon.webp" alt="Crater logo" width="120" />
 
-<h1 align="center">Crater</h1>
+# Crater
 
-<p align="center">
-  A comprehensive AI development platform for Kubernetes that provides GPU resource management, containerized development environments, and workflow orchestration.
-</p>
+### A Kubernetes-native AI development platform
 
-<p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License" /></a>
-  <a href="https://raids-lab.github.io/crater/zh"><img src="https://img.shields.io/badge/Docs-raids--lab.github.io-brightgreen" alt="Docs" /></a>
-  <a href="https://github.com/raids-lab/crater/actions/workflows/backend-build.yml"><img src="https://github.com/raids-lab/crater/actions/workflows/backend-build.yml/badge.svg" alt="Backend Build" /></a>
-  <a href="https://github.com/raids-lab/crater/actions/workflows/helm-chart-validate.yml"><img src="https://github.com/raids-lab/crater/actions/workflows/helm-chart-validate.yml/badge.svg" alt="Helm Chart Validate" /></a>
-</p>
+Unified **GPU resource management**, **containerized development environments**, and **workflow orchestration** — all in one place.
 
-<p align="center">
-  <a href="https://raids-lab.github.io/crater/zh/docs/admin/">Documentation</a> ·
-  <a href="./charts/crater">Helm Chart</a> ·
-  <a href="./backend/README.md">Backend</a> ·
-  <a href="./frontend/README.md">Frontend</a>
-</p>
+<br/>
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](LICENSE)
+[![Docs](https://img.shields.io/badge/Docs-raids--lab.github.io-brightgreen?style=flat-square)](https://raids-lab.github.io/crater/zh)
+[![Backend Build](https://img.shields.io/github/actions/workflow/status/raids-lab/crater/backend-build.yml?style=flat-square&label=backend)](https://github.com/raids-lab/crater/actions/workflows/backend-build.yml)
+[![Helm Chart Validate](https://img.shields.io/github/actions/workflow/status/raids-lab/crater/helm-chart-validate.yml?style=flat-square&label=helm)](https://github.com/raids-lab/crater/actions/workflows/helm-chart-validate.yml)
+
+![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white)
+![Go](https://img.shields.io/badge/Go-00ADD8?style=flat-square&logo=go&logoColor=white)
+![React](https://img.shields.io/badge/React-20232A?style=flat-square&logo=react&logoColor=61DAFB)
+![Helm](https://img.shields.io/badge/Helm-0F1689?style=flat-square&logo=helm&logoColor=white)
+
+**English** · [简体中文](docs/zh-CN/README.md)
+
+[**Documentation**](https://raids-lab.github.io/crater/zh/docs/admin/) ·
+[Helm Chart](./charts/crater) ·
+[Backend](./backend/README.md) ·
+[Frontend](./frontend/README.md) ·
+[CLI](./cli/README.md)
+
+</div>
+
+---
+
+## ✨ Overview
+
+**Crater** helps teams manage heterogeneous compute resources (e.g., GPUs) and run AI workloads on Kubernetes through **unified scheduling**, **ready-to-use development environments**, and **end-to-end observability** — all from a single, clean web interface.
+
+<div align="center">
+
+|  |  |
+| :---: | :---: |
+| <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/jupyter.gif" alt="Jupyter Lab" width="420" /><br/>**🧪 Jupyter Lab** — interactive dev environments | <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/ray.gif" alt="Ray Job" width="420" /><br/>**🚀 Ray Jobs** — distributed training & inference |
+| <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/monitor.gif" alt="Monitor" width="420" /><br/>**📈 Monitoring** — real-time metrics & logs | <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/datasets.gif" alt="Models" width="420" /><br/>**📦 Models & Datasets** — manage assets in one place |
+
+</div>
+
+## 🎯 Features
 
 <table>
   <tr>
-    <td align="center" width="45%">
-      <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/jupyter.gif" alt="Jupyter Lab" /><br>
-      <em>Jupyter Lab</em>
+    <td width="50%" valign="top">
+      <h3>🎛️ Intuitive UI</h3>
+      Manage clusters, jobs, and resources through a clean web interface, with real-time dashboards for CPU, memory, and storage usage.
     </td>
-    <td align="center" width="45%">
-      <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/ray.gif" alt="Ray Job" /><br>
-      <em>Ray Job</em>
+    <td width="50%" valign="top">
+      <h3>⚙️ Intelligent Scheduling</h3>
+      Allocate resources by priority and requirements, prioritizing time-sensitive jobs to improve overall cluster utilization.
     </td>
   </tr>
   <tr>
-    <td align="center" width="45%">
-      <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/monitor.gif" alt="Monitor" /><br>
-      <em>Monitor</em>
+    <td width="50%" valign="top">
+      <h3>🧪 Dev Environments</h3>
+      Spin up containerized, ready-to-use environments like Jupyter Lab and Ray jobs in seconds — no manual setup required.
     </td>
-    <td align="center" width="45%">
-      <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/datasets.gif" alt="Models" /><br>
-      <em>Models</em>
+    <td width="50%" valign="top">
+      <h3>📈 Monitoring &amp; Logs</h3>
+      Observe cluster status and troubleshoot quickly with built-in metrics, logs, and Grafana dashboards.
     </td>
   </tr>
 </table>
 
-Crater is a Kubernetes-based platform that helps teams manage heterogeneous compute resources (e.g., GPUs) and run AI workloads through unified scheduling, development environments, and observability.
+## 🏗️ Architecture
 
-## Features
+<div align="center">
+  <img src="./website/content/docs/admin/assets/architecture.webp" alt="Crater architecture" width="90%" />
+  <br/>
+  <sub>High-level architecture of Crater and its major components.</sub>
+</div>
 
-- 🎛️ **Intuitive UI**: Manage clusters, jobs, and resources through a clean web interface.
-- ⚙️ **Intelligent scheduling**: Allocate resources based on priority and requirements to improve utilization.
-- 📈 **Monitoring & logs**: Observe cluster status and troubleshoot with metrics and logs.
+## 🚀 Getting Started
 
-## Architecture
-
-![crater architecture](./website/content/docs/admin/assets/architecture.webp)
-
-High-level architecture of Crater and its major components.
-
-## Documentation
-
-- Admin guide (中文): https://raids-lab.github.io/crater/zh/docs/admin/
-- Admin guide (English): https://raids-lab.github.io/crater/en/docs/admin/
-
-Deployment guides:
-
-If you want to quickly deploy a basic Crater using Kind, please refer to [Minimal Deployment](https://raids-lab.github.io/crater/zh/docs/admin/kind-start/).
-
-If you want to deploy a full Crater in a cluster, please refer to [Cluster Deployment Guide](https://raids-lab.github.io/crater/zh/docs/admin/deploy-on-cluster/).
-
-English versions:
-
-- [Minimal Deployment](https://raids-lab.github.io/crater/en/docs/admin/kind-start/)
-- [Cluster Deployment Guide](https://raids-lab.github.io/crater/en/docs/admin/deploy-on-cluster/)
-
-## Getting Started
-
-### Prerequisites
+### 1. Prerequisites
 
 - A running Kubernetes cluster
-- `kubectl`
-- Helm v3
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/)
+- [Helm v3](https://helm.sh/docs/intro/install/)
 
-To get started with **Crater**, you first need to have a running Kubernetes cluster. You can set up a cluster using one of the following methods:
+### 2. Set up a cluster
 
-### 🐳 1. Local Cluster with Kind
+Pick the option that fits your scenario:
 
-Kind (Kubernetes IN Docker) is a lightweight tool for running local Kubernetes clusters using Docker containers.
+| Option | Best for | Reference |
+| :--- | :--- | :--- |
+| 🐳 **Kind** | Local clusters in Docker | [kind.sigs.k8s.io](https://kind.sigs.k8s.io/) |
+| 🧱 **Minikube** | Single-node local dev & testing | [minikube.sigs.k8s.io](https://minikube.sigs.k8s.io/) |
+| ☁️ **Production K8s** | Production or large-scale deployments | [kubernetes.io/docs/setup](https://kubernetes.io/docs/setup/) |
 
-📖 [https://kind.sigs.k8s.io/](https://kind.sigs.k8s.io/)
-
-### 🧱 2. Local Cluster with Minikube
-
-Minikube runs a single-node Kubernetes cluster locally, ideal for development and testing.
-
-📖 [https://minikube.sigs.k8s.io/](https://minikube.sigs.k8s.io/)
-
-### ☁️ 3. Production-grade Kubernetes Cluster
-
-For deploying Crater in a production or large-scale test environment, you can use any standard Kubernetes setup.
-
-📖 [https://kubernetes.io/docs/setup/](https://kubernetes.io/docs/setup/)
-
-### Install via Helm (OCI)
-
-> Use the docs above for a full guide. The chart version can be found in `charts/crater/Chart.yaml` (field `version`) or GitHub releases.
+### 3. Install via Helm (OCI)
 
 ```bash
 helm registry login ghcr.io
 helm install crater oci://ghcr.io/raids-lab/crater --version <chart-version>
 ```
 
-## Repository Structure
+> 💡 The chart version is in `charts/crater/Chart.yaml` (field `version`) or in the GitHub releases.
 
-- `backend/`: Backend services
-- `frontend/`: Web UI
-- `backend/internal/storage/`: Storage service (integrated in backend module)
-- `charts/`: Helm charts for deploying Crater
-- `website/`: Documentation website source
-- `grafana-dashboards/`: Grafana dashboards used by Crater
-- `docs/`: Documentation entrypoints and localization resources
-- `hack/`: Developer tooling and scripts
+**Deployment guides:**
 
-## Contributing
+- 📄 [Minimal Deployment (Kind)](https://raids-lab.github.io/crater/en/docs/admin/kind-start/) — quickly spin up a basic Crater
+- 📄 [Cluster Deployment Guide](https://raids-lab.github.io/crater/en/docs/admin/deploy-on-cluster/) — deploy a full Crater on a cluster
 
-We welcome community contributions. The complete development and contribution specification lives in [CONTRIBUTING.md](./CONTRIBUTING.md): global rules, environment setup (fork, hooks, unified config), workflow, commit convention, PR description template, and per-module entry points.
+## 📚 Documentation
 
-Per-module specs:
+- 📘 Admin guide (English): https://raids-lab.github.io/crater/en/docs/admin/
+- 📗 Admin guide (中文): https://raids-lab.github.io/crater/zh/docs/admin/
 
-- Backend: [backend/CONTRIBUTING.md](./backend/CONTRIBUTING.md)
-- Frontend: [frontend/CONTRIBUTING.md](./frontend/CONTRIBUTING.md)
-- Website / Docs: [website/CONTRIBUTING.md](./website/CONTRIBUTING.md)
-- CLI: [cli/CONTRIBUTING.md](./cli/CONTRIBUTING.md)
+## 📁 Repository Structure
 
-## License
+| Path | Description |
+| :--- | :--- |
+| `backend/` | Backend services |
+| `frontend/` | Web UI |
+| `cli/` | Command-line interface |
+| `charts/` | Helm charts for deploying Crater |
+| `website/` | Documentation website source |
+| `grafana-dashboards/` | Grafana dashboards used by Crater |
+| `docs/` | Documentation entrypoints and localization resources |
+| `hack/` | Developer tooling and scripts |
 
-Crater is licensed under the Apache License 2.0. See [LICENSE](LICENSE).
+## 🤝 Contributing
 
-Copyright 2023-2026 The Crater Project Team, RAIDS-Lab.
+We welcome community contributions! The complete development and contribution specification lives in [CONTRIBUTING.md](./CONTRIBUTING.md): global rules, environment setup (fork, hooks, unified config), workflow, commit convention, PR description template, and per-module entry points.
+
+**Per-module specs:**
+
+- Backend — [backend/CONTRIBUTING.md](./backend/CONTRIBUTING.md)
+- Frontend — [frontend/CONTRIBUTING.md](./frontend/CONTRIBUTING.md)
+- Website / Docs — [website/CONTRIBUTING.md](./website/CONTRIBUTING.md)
+- CLI — [cli/CONTRIBUTING.md](./cli/CONTRIBUTING.md)
+
+## 📝 License
+
+Crater is licensed under the **Apache License 2.0**. See [LICENSE](LICENSE).
+
+<div align="center"><sub>Copyright 2023-2026 The Crater Project Team, RAIDS-Lab.</sub></div>

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -1,143 +1,146 @@
-<p align="center">
-  <a href="../../README.md">English</a> · <a href="README.md">简体中文</a>
-</p>
+<div align="center">
 
-<p align="center">
-  <img src="../../website/content/docs/admin/assets/icon.webp" alt="Crater logo" width="120" />
-</p>
+<img src="../../website/content/docs/admin/assets/icon.webp" alt="Crater logo" width="120" />
 
-<h1 align="center">Crater</h1>
+# Crater
 
-<p align="center">
-  A comprehensive AI development platform for Kubernetes that provides GPU resource management, containerized development environments, and workflow orchestration.
-</p>
+### 面向 Kubernetes 的 AI 开发平台
 
-<p align="center">
-  <a href="../../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License" /></a>
-  <a href="https://raids-lab.github.io/crater/zh"><img src="https://img.shields.io/badge/Docs-raids--lab.github.io-brightgreen" alt="Docs" /></a>
-  <a href="https://github.com/raids-lab/crater/actions/workflows/backend-build.yml"><img src="https://github.com/raids-lab/crater/actions/workflows/backend-build.yml/badge.svg" alt="Backend Build" /></a>
-  <a href="https://github.com/raids-lab/crater/actions/workflows/helm-chart-validate.yml"><img src="https://github.com/raids-lab/crater/actions/workflows/helm-chart-validate.yml/badge.svg" alt="Helm Chart Validate" /></a>
-</p>
+一站式提供 **GPU 资源管理**、**容器化开发环境**与**工作流编排**能力。
 
-<p align="center">
-  <a href="https://raids-lab.github.io/crater/zh/docs/admin/">文档</a> ·
-  <a href="../../charts/crater">Helm Chart</a> ·
-  <a href="../../backend/README.zh-CN.md">后端</a> ·
-  <a href="../../frontend/README.zh-CN.md">前端</a>
-</p>
+<br/>
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](../../LICENSE)
+[![Docs](https://img.shields.io/badge/Docs-raids--lab.github.io-brightgreen?style=flat-square)](https://raids-lab.github.io/crater/zh)
+[![Backend Build](https://img.shields.io/github/actions/workflow/status/raids-lab/crater/backend-build.yml?style=flat-square&label=backend)](https://github.com/raids-lab/crater/actions/workflows/backend-build.yml)
+[![Helm Chart Validate](https://img.shields.io/github/actions/workflow/status/raids-lab/crater/helm-chart-validate.yml?style=flat-square&label=helm)](https://github.com/raids-lab/crater/actions/workflows/helm-chart-validate.yml)
+
+![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5?style=flat-square&logo=kubernetes&logoColor=white)
+![Go](https://img.shields.io/badge/Go-00ADD8?style=flat-square&logo=go&logoColor=white)
+![React](https://img.shields.io/badge/React-20232A?style=flat-square&logo=react&logoColor=61DAFB)
+![Helm](https://img.shields.io/badge/Helm-0F1689?style=flat-square&logo=helm&logoColor=white)
+
+[English](../../README.md) · **简体中文**
+
+[**文档**](https://raids-lab.github.io/crater/zh/docs/admin/) ·
+[Helm Chart](../../charts/crater) ·
+[后端](../../backend/README.zh-CN.md) ·
+[前端](../../frontend/README.zh-CN.md) ·
+[CLI](../../cli/README.zh-CN.md)
+
+</div>
+
+---
+
+## ✨ 项目简介
+
+**Crater** 帮助团队管理异构算力资源（例如 GPU），并通过**统一调度**、**开箱即用的开发环境**与**端到端可观测性**在 Kubernetes 上运行 AI 工作负载——这一切都在一个简洁的 Web 界面中完成。
+
+<div align="center">
+
+|  |  |
+| :---: | :---: |
+| <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/jupyter.gif" alt="Jupyter Lab" width="420" /><br/>**🧪 Jupyter Lab** — 交互式开发环境 | <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/ray.gif" alt="Ray Job" width="420" /><br/>**🚀 Ray 作业** — 分布式训练与推理 |
+| <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/monitor.gif" alt="Monitor" width="420" /><br/>**📈 监控** — 实时指标与日志 | <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/datasets.gif" alt="Models" width="420" /><br/>**📦 模型与数据集** — 集中管理资产 |
+
+</div>
+
+## 🎯 功能特性
 
 <table>
   <tr>
-    <td align="center" width="45%">
-      <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/jupyter.gif" alt="Jupyter Lab" /><br>
-      <em>Jupyter Lab</em>
+    <td width="50%" valign="top">
+      <h3>🎛️ 直观的界面</h3>
+      通过简洁的 Web 界面管理集群、作业与资源，并实时查看 CPU、内存与存储等关键指标。
     </td>
-    <td align="center" width="45%">
-      <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/ray.gif" alt="Ray Job" /><br>
-      <em>Ray Job</em>
+    <td width="50%" valign="top">
+      <h3>⚙️ 智能调度</h3>
+      根据优先级与资源需求进行分配，优先处理时间敏感的任务，提升集群整体利用率。
     </td>
   </tr>
   <tr>
-    <td align="center" width="45%">
-      <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/monitor.gif" alt="Monitor" /><br>
-      <em>Monitor</em>
+    <td width="50%" valign="top">
+      <h3>🧪 开发环境</h3>
+      数秒内启动容器化、开箱即用的开发环境，如 Jupyter Lab 与 Ray 作业，无需手动配置。
     </td>
-    <td align="center" width="45%">
-      <img src="https://github.com/raids-lab/crater-frontend/blob/main/docs/images/datasets.gif" alt="Models" /><br>
-      <em>Models</em>
+    <td width="50%" valign="top">
+      <h3>📈 监控与日志</h3>
+      借助内置指标、日志与 Grafana Dashboard 掌握集群状态并快速排障。
     </td>
   </tr>
 </table>
 
-Crater 是一个基于 Kubernetes 的平台，帮助团队管理异构算力资源（例如 GPU），并通过统一调度、开发环境与可观测性能力运行 AI 工作负载。
+## 🏗️ 整体架构
 
-## 功能特性
+<div align="center">
+  <img src="../../website/content/docs/admin/assets/architecture.webp" alt="crater architecture" width="90%" />
+  <br/>
+  <sub>Crater 的整体架构与主要组件概览。</sub>
+</div>
 
-- 🎛️ **直观的界面**：通过清晰的 Web 界面管理集群、作业与资源。
-- ⚙️ **智能调度**：根据优先级与资源需求进行分配，提升集群利用率。
-- 📈 **监控与日志**：通过指标与日志掌握集群状态并快速排障。
+## 🚀 快速开始
 
-## 整体架构
-
-![crater architecture](../../website/content/docs/admin/assets/architecture.webp)
-
-Crater 的整体架构与主要组件概览。
-
-## 文档
-
-- 管理员指南（中文）: https://raids-lab.github.io/crater/zh/docs/admin/
-- 管理员指南（English）: https://raids-lab.github.io/crater/en/docs/admin/
-
-部署文档：
-
-如果您希望使用 Kind 快速部署一个基本的 Crater，请参照[最小化部署](https://raids-lab.github.io/crater/zh/docs/admin/kind-start/)。
-
-如果您希望在集群中部署一个完整的 Crater，请参照[集群部署指南](https://raids-lab.github.io/crater/zh/docs/admin/deploy-on-cluster/)。
-
-英文版本：
-
-- [Minimal Deployment](https://raids-lab.github.io/crater/en/docs/admin/kind-start/)
-- [Cluster Deployment Guide](https://raids-lab.github.io/crater/en/docs/admin/deploy-on-cluster/)
-
-## 快速开始
-
-### 前置条件
+### 1. 前置条件
 
 - 一个可用的 Kubernetes 集群
-- `kubectl`
-- Helm v3
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/)
+- [Helm v3](https://helm.sh/docs/intro/install/)
 
-要开始使用 **Crater**，您首先需要有一个正在运行的 Kubernetes 集群。您可以使用以下方法之一来设置集群：
+### 2. 准备集群
 
-### 🐳 1. 使用 Kind 的本地集群
+根据您的场景选择合适的方式：
 
-Kind (Kubernetes IN Docker) 是一个使用 Docker 容器运行本地 Kubernetes 集群的轻量级工具。
+| 方式 | 适用场景 | 参考 |
+| :--- | :--- | :--- |
+| 🐳 **Kind** | 在 Docker 中运行本地集群 | [kind.sigs.k8s.io](https://kind.sigs.k8s.io/) |
+| 🧱 **Minikube** | 单节点本地开发与测试 | [minikube.sigs.k8s.io](https://minikube.sigs.k8s.io/) |
+| ☁️ **生产级 K8s** | 生产或大规模部署 | [kubernetes.io/docs/setup](https://kubernetes.io/docs/setup/) |
 
-📖 [https://kind.sigs.k8s.io/](https://kind.sigs.k8s.io/)
-
-### 🧱 2. 使用 Minikube 的本地集群
-
-Minikube 在本地运行单节点 Kubernetes 集群，非常适合开发和测试。
-
-📖 [https://minikube.sigs.k8s.io/](https://minikube.sigs.k8s.io/)
-
-### ☁️ 3. 生产级 Kubernetes 集群
-
-要在生产环境或大规模测试环境中部署 Crater，您可以使用任何标准的 Kubernetes 设置。
-
-📖 [https://kubernetes.io/docs/setup/](https://kubernetes.io/docs/setup/)
-
-### 通过 Helm（OCI）安装
-
-> 更完整的步骤请以文档为准。Chart 版本可在 `charts/crater/Chart.yaml`（字段 `version`）或 GitHub releases 中查看。
+### 3. 通过 Helm（OCI）安装
 
 ```bash
 helm registry login ghcr.io
 helm install crater oci://ghcr.io/raids-lab/crater --version <chart-version>
 ```
 
-## 仓库结构
+> 💡 Chart 版本可在 `charts/crater/Chart.yaml`（字段 `version`）或 GitHub releases 中查看。
 
-- `backend/`: 后端服务
-- `frontend/`: Web 前端
-- `backend/internal/storage/`: 存储服务（已并入 backend 模块）
-- `charts/`: 用于部署 Crater 的 Helm Chart
-- `website/`: 文档网站源码
-- `grafana-dashboards/`: Crater 使用的 Grafana Dashboard
-- `docs/`: 文档入口与多语言资源
-- `hack/`: 开发工具与脚本
+**部署指南：**
 
-## 贡献指南
+- 📄 [最小化部署（Kind）](https://raids-lab.github.io/crater/zh/docs/admin/kind-start/) — 快速部署一个基本的 Crater
+- 📄 [集群部署指南](https://raids-lab.github.io/crater/zh/docs/admin/deploy-on-cluster/) — 在集群中部署完整的 Crater
 
-欢迎社区贡献。开发与贡献的完整规范见 [CONTRIBUTING.md](./CONTRIBUTING.md)：全局守则、环境准备（fork、hooks、统一配置）、开发流程、Commit 规范、PR 描述模板与各模块入口。
+## 📚 文档
 
-各模块规范：
+- 📗 管理员指南（中文）: https://raids-lab.github.io/crater/zh/docs/admin/
+- 📘 管理员指南（English）: https://raids-lab.github.io/crater/en/docs/admin/
 
-- 后端：[backend/CONTRIBUTING.zh-CN.md](../../backend/CONTRIBUTING.zh-CN.md)
-- 前端：[frontend/CONTRIBUTING.zh-CN.md](../../frontend/CONTRIBUTING.zh-CN.md)
-- 文档 / 文档站：[website/CONTRIBUTING.zh-CN.md](../../website/CONTRIBUTING.zh-CN.md)
-- CLI：[cli/CONTRIBUTING.zh-CN.md](../../cli/CONTRIBUTING.zh-CN.md)
+## 📁 仓库结构
 
-## 许可证
+| 路径 | 说明 |
+| :--- | :--- |
+| `backend/` | 后端服务 |
+| `frontend/` | Web 前端 |
+| `cli/` | 命令行工具 |
+| `charts/` | 用于部署 Crater 的 Helm Chart |
+| `website/` | 文档网站源码 |
+| `grafana-dashboards/` | Crater 使用的 Grafana Dashboard |
+| `docs/` | 文档入口与多语言资源 |
+| `hack/` | 开发工具与脚本 |
 
-Crater 使用 Apache License 2.0 许可证，详见 [LICENSE](../../LICENSE)。
+## 🤝 贡献指南
+
+欢迎社区贡献！开发与贡献的完整规范见 [CONTRIBUTING.md](../../CONTRIBUTING.md)：全局守则、环境准备（fork、hooks、统一配置）、开发流程、Commit 规范、PR 描述模板与各模块入口。
+
+**各模块规范：**
+
+- 后端 — [backend/CONTRIBUTING.zh-CN.md](../../backend/CONTRIBUTING.zh-CN.md)
+- 前端 — [frontend/CONTRIBUTING.zh-CN.md](../../frontend/CONTRIBUTING.zh-CN.md)
+- 文档 / 文档站 — [website/CONTRIBUTING.zh-CN.md](../../website/CONTRIBUTING.zh-CN.md)
+- CLI — [cli/CONTRIBUTING.zh-CN.md](../../cli/CONTRIBUTING.zh-CN.md)
+
+## 📝 许可证
+
+Crater 使用 **Apache License 2.0** 许可证，详见 [LICENSE](../../LICENSE)。
+
+<div align="center"><sub>Copyright 2023-2026 The Crater Project Team, RAIDS-Lab.</sub></div>


### PR DESCRIPTION
## Summary

Modernize the project README (both English and Simplified Chinese) for a cleaner, more visual, and more approachable first impression. No functional or content-accuracy changes beyond presentation — all links and images were verified to resolve.

## What changed

- **Consolidated hero header**: merged the previously scattered centered blocks (logo, title, tagline, badges, language switcher, nav links) into a single cohesive hero section.
- **Tech-stack badges**: added Kubernetes / Go / React / Helm badges so visitors can grasp the stack at a glance; CI badges restyled to `flat-square` for visual consistency.
- **Scenario-based demo grid**: the four feature GIFs (Jupyter Lab, Ray Jobs, Monitoring, Models & Datasets) now have descriptive, scenario-oriented captions instead of bare control names.
- **Feature cards**: feature list rendered as a 2×2 card grid with headings and descriptions.
- **Tabular sections**: cluster setup options (Kind / Minikube / Production) and repository structure presented as tables for scannability.
- **Numbered Getting Started flow** with a tip callout for the Helm chart version.
- **Added CLI links** to the nav and per-module specs.
- **Fixed a broken link** in the zh-CN README: `CONTRIBUTING.md` now correctly points to `../../CONTRIBUTING.md`.

Also widens `.gitignore` to ignore the whole `.claude/` directory.

## Affected files

- `README.md`
- `docs/zh-CN/README.md`
- `.gitignore`

## Test plan

- [ ] Preview `README.md` rendering on GitHub (hero, badges, demo grid, feature cards, tables)
- [ ] Preview `docs/zh-CN/README.md` rendering on GitHub
- [ ] Verify all links and images resolve, including the corrected zh-CN `CONTRIBUTING.md` link