### PR TITLE
fix(frontend): default dev server port parsing

### DIFF
--- a/frontend/CONTRIBUTING.md
+++ b/frontend/CONTRIBUTING.md
@@ -25,6 +25,8 @@ For most frontend work, debug with the frontend and backend running together. Th
 
 The frontend dev server proxies main backend APIs through `VITE_SERVER_PROXY_BACKEND` to `http://localhost:8088/` by default, and storage APIs through `VITE_SERVER_PROXY_STORAGE` to `http://localhost:7320/` by default. Start the backend storage server with `cd ../backend && make run-storage` when testing storage-related pages or flows such as file management, datasets, models, uploads, or downloads.
 
+`make run` reads the dev server port only from an explicit `PORT=...` entry in `.env.development`. If that entry is missing, it falls back to `5180`. Proxy variables such as `VITE_SERVER_PROXY_BACKEND` and `VITE_SERVER_PROXY_STORAGE` are not treated as port settings.
+
 ```bash
 cd frontend
 pnpm install

--- a/frontend/CONTRIBUTING.zh-CN.md
+++ b/frontend/CONTRIBUTING.zh-CN.md
@@ -25,6 +25,8 @@
 
 前端开发服务默认通过 `VITE_SERVER_PROXY_BACKEND` 将主后端 API 代理到 `http://localhost:8088/`，并通过 `VITE_SERVER_PROXY_STORAGE` 将存储 API 代理到 `http://localhost:7320/`。调试文件管理、数据集、模型、上传或下载等存储相关页面和流程时，需要先在后端目录运行 `make run-storage` 启动 storage server。
 
+`make run` 只会从 `.env.development` 中显式的 `PORT=...` 配置读取开发服务端口。如果没有该配置，会回退到 `5180`。`VITE_SERVER_PROXY_BACKEND` 和 `VITE_SERVER_PROXY_STORAGE` 等代理变量不会被当作端口配置。
+
 ```bash
 cd frontend
 pnpm install

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -13,7 +13,7 @@ RESET := \033[0m
 PYTHON ?= $(shell if command -v python3 >/dev/null 2>&1 && python3 -c "import sys" >/dev/null 2>&1; then echo python3; elif command -v python >/dev/null 2>&1; then echo python; fi)
 
 # 设置端口号变量
-PORT := $(shell if [ -f .env.development ]; then grep PORT .env.development | cut -d '=' -f2; else echo "5180"; fi)
+PORT := $(shell if [ -f .env.development ]; then awk -F '=' '/^PORT[[:space:]]*=/ {print $$2; found=1; exit} END {if (!found) print "5180"}' .env.development | awk '{print $$1}'; else echo "5180"; fi)
 .PHONY: help
 help: ## 💡 Display this help message
 	@echo "$(CYAN)🌋 Crater Frontend Development Commands$(RESET)"


### PR DESCRIPTION
## Summary

Fix the frontend `make run` port parsing logic so it falls back to the default dev server port when `.env.development` does not define `PORT`.

## Problem

`frontend/Makefile` previously used:

```makefile
grep PORT .env.development | cut -d '=' -f2
```

This matches proxy settings such as:

```env
VITE_SERVER_PROXY_BACKEND=http://localhost:8088
VITE_SERVER_PROXY_STORAGE=http://localhost:7320
```

When `.env.development` does not contain an explicit `PORT=...` line, the parsed value can become empty, and `make run` executes:

```bash
pnpm dev --port
```

Vite then fails with:

```text
CACError: option `--port <port>` value is missing
```

## Changes

- Parse only lines that start with `PORT=`.
- Ignore non-port environment variables that merely contain the word `PORT`.
- Fall back to `5180` when `.env.development` is missing or has no explicit `PORT`.
- Preserve support for the generated template format:

```env
PORT=5180           # Dev server port
```
- Document the fallback behavior in both English and Chinese frontend CONTRIBUTING docs.

## Verification

- `make -n run` with no `.env.development` resolves to `pnpm dev --port 5180`.
- `make -n run` with only `VITE_SERVER_PROXY_BACKEND` / `VITE_SERVER_PROXY_STORAGE` resolves to `pnpm dev --port 5180`.
- `make -n run` with `PORT=5173           # Dev server port` resolves to `pnpm dev --port 5173`.
- `git diff --check` passes.

## 摘要

修复前端 `make run` 的端口解析逻辑：当 `.env.development` 没有显式定义 `PORT` 时，正确回退到默认开发端口。

## 问题

之前 `frontend/Makefile` 通过 `grep PORT .env.development` 读取端口，会误匹配 `VITE_SERVER_PROXY_BACKEND`、`VITE_SERVER_PROXY_STORAGE` 这类包含 `PORT` 字符串的代理配置。

当 `.env.development` 没有 `PORT=...` 行时，解析结果可能为空，最终执行：

```bash
pnpm dev --port
```

Vite 会报错：

```text
CACError: option `--port <port>` value is missing
```

## 变更内容

- 只解析以 `PORT=` 开头的配置行。
- 不再误匹配包含 `PORT` 字符串的其他环境变量。
- 当 `.env.development` 不存在或没有显式 `PORT` 时，回退到 `5180`。
- 保留对生成模板格式 `PORT=5180           # Dev server port` 的支持。
- 在前端中英文 CONTRIBUTING 文档中补充 fallback 逻辑说明。

## 验证

- 无 `.env.development` 时，`make -n run` 解析为 `pnpm dev --port 5180`。
- 只有 `VITE_SERVER_PROXY_BACKEND` / `VITE_SERVER_PROXY_STORAGE` 时，`make -n run` 解析为 `pnpm dev --port 5180`。
- 有 `PORT=5173           # Dev server port` 时，`make -n run` 解析为 `pnpm dev --port 5173`。
- `git diff --check` 通过。
