### PR TITLE
fix(frontend): stabilize table filter and pagination state

### DIFF
--- a/frontend/src/components/query-table/faceted-filter.tsx
+++ b/frontend/src/components/query-table/faceted-filter.tsx
@@ -26,7 +26,6 @@ import {
   Command,
   CommandEmpty,
   CommandGroup,
-  // CommandInput,
   CommandItem,
   CommandList,
   CommandSeparator,
@@ -58,16 +57,20 @@ export function DataTableFacetedFilter<TData, TValue>({
   const { t } = useTranslation()
   const facets = column?.getFacetedUniqueValues()
   const selectedValues = new Set(column?.getFilterValue() as string[])
+  const defaultValuesApplied = React.useRef(false)
 
-  // set default filter option
   useEffect(() => {
-    if (defaultValues) {
-      column?.setFilterValue(defaultValues)
+    if (!column || !defaultValues || defaultValuesApplied.current) {
+      return
+    }
+    defaultValuesApplied.current = true
+
+    if (column.getFilterValue() === undefined) {
+      column.setFilterValue(defaultValues)
     }
   }, [defaultValues, column])
 
   const options = useMemo(() => {
-    // 如果没有 Options，则从 facets 中生成
     if (!rawOptions || rawOptions.length === 0) {
       return facets
         ? Array.from(facets.keys())
@@ -128,7 +131,6 @@ export function DataTableFacetedFilter<TData, TValue>({
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-0" align="start">
         <Command shouldFilter={false}>
-          {/* <CommandInput placeholder={title} /> */}
           <CommandList>
             <CommandEmpty>{t('dataTableFacetedFilter.noResults')}</CommandEmpty>
             <CommandGroup>

--- a/frontend/src/hooks/use-pagination-with-storage.tsx
+++ b/frontend/src/hooks/use-pagination-with-storage.tsx
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 import { PaginationState } from '@tanstack/react-table'
-import { useState } from 'react'
 import { useLocalStorage } from 'usehooks-ts'
 
 const usePaginationWithStorage = (tableKey: string = 'default-table') => {
-  const [pageIndex, setPageIndex] = useState(0)
+  const [pageIndex, setPageIndex] = useLocalStorage(`${tableKey}-page-index`, 0)
   const [pageSize, setPageSize] = useLocalStorage(`${tableKey}-page-size`, 10)
 
   const pagination: PaginationState = {


### PR DESCRIPTION
- 修复表格默认筛选值在组件重渲染后反复覆盖用户选择的问题
- 默认筛选现在只会在 filter 尚未初始化时应用一次
- 将表格分页页码 `pageIndex` 按 `tableKey` 持久化到 localStorage
- 清理 `DataTableFacetedFilter` 中已废弃的注释代码

此前带有默认筛选值的表格中，用户手动修改或清空筛选后，组件重新渲染可能会再次写入默认筛选值，导致筛选状态无法稳定保持。

同时，分页只持久化了 `pageSize`，`pageIndex` 在页面刷新或组件重新挂载后会回到第一页，影响表格浏览体验。