### PR TITLE
ci: align build workflow lint with make lint

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -54,11 +54,15 @@ jobs:
           go env -w GOPROXY=https://goproxy.cn,direct
           go mod download
 
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
-          working-directory: backend
+      - name: Prepare upstream base for lint-diff
+        run: |
+          if ! git remote get-url upstream >/dev/null 2>&1; then
+            git remote add upstream https://github.com/raids-lab/crater.git
+          fi
+          git fetch upstream main:refs/remotes/upstream/main --depth=1
+
+      - name: Run make lint
+        run: make lint
 
   build_backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/storage-build.yml
+++ b/.github/workflows/storage-build.yml
@@ -58,11 +58,15 @@ jobs:
           go env -w GOPROXY=https://goproxy.cn,direct
           go mod download
 
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
-          working-directory: backend
+      - name: Prepare upstream base for lint-diff
+        run: |
+          if ! git remote get-url upstream >/dev/null 2>&1; then
+            git remote add upstream https://github.com/raids-lab/crater.git
+          fi
+          git fetch upstream main:refs/remotes/upstream/main --depth=1
+
+      - name: Run make lint
+        run: make lint
 
   build_storage_server:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 背景

#373 合入后，GitHub Actions 的 `Backend Build` 和 `Storage Build` 在 `main` 分支 push workflow 中失败。

这里失败的不是 PR check，也不是业务代码编译失败。#373 的 PR check 能通过，是因为 `backend-pr.yml` 和 `storage-pr.yml` 已经改为执行项目统一入口：

- `make lint`
- `lint-full` 使用 `backend/.golangci-full.yml`
- `lint-diff` 使用 `backend/.golangci-diff.yml`

但合入后触发的 push build workflow 仍然直接调用 `golangci/golangci-lint-action@v8`。#373 已经把原来的默认 lint 配置拆成了 full/diff 两套配置，build workflow 没同步后，就没有走项目定义的 lint 入口，导致 CI 对历史代码执行了全量默认检查。

因此 Actions 中暴露的是既有历史问题，例如：

- `errcheck`：历史代码里部分 `Close()` / `fmt.Fprintf()` 返回的 error 没有处理。
- `staticcheck`：历史代码里仍有 deprecated 的 `resputil.*` 调用。

这些问题不属于本次 PR 的新增 diff，也不是 #373 的 runtime 修复引入的错误。

## 修改内容

本 PR 将 push build workflow 的 lint 入口与 PR workflow 对齐：

- `Backend Build`：准备 `upstream/main` 后执行 `make lint`。
- `Storage Build`：准备 `upstream/main` 后执行 `make lint`。

这样 build workflow 和 PR workflow 会使用同一套 lint 规则，避免 merge 后因为入口不一致再次扫出历史全量问题。

## 验证

本地已完成以下验证：

```bash
git diff --check
```

并将本地 `refs/remotes/upstream/main` 刷新到当前 upstream `main` 后执行：

```bash
cd backend
make lint
```

结果：

- `lint-full`: `0 issues`
- `lint-diff`: `0 issues`