### PR TITLE
refactor: extract time constants and set download job TTL

### DIFF
--- a/.githook/pre-commit
+++ b/.githook/pre-commit
@@ -46,6 +46,8 @@ fi
 # Track if any checks were run
 CHECKS_RUN=0
 
+unset $(git rev-parse --local-env-vars)
+
 # Check if there are website-related changes
 if echo "$STAGED_FILES" | grep -q "^website/"; then
     echo ""

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -11086,6 +11086,10 @@ const docTemplate = `{
                 },
                 "source": {
                     "type": "string"
+                },
+                "token": {
+                    "description": "Token is an optional access token for gated/private repositories on the\nsource site. It is only forwarded to the download Job as an env var and is\nnever persisted on the (shared, deduplicated) download record.",
+                    "type": "string"
                 }
             }
         },
@@ -11427,6 +11431,12 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "creatorId": {
+                    "type": "integer"
+                },
+                "downloadSpeed": {
+                    "type": "string"
+                },
+                "downloadedBytes": {
                     "type": "integer"
                 },
                 "id": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -11078,6 +11078,10 @@
                 },
                 "source": {
                     "type": "string"
+                },
+                "token": {
+                    "description": "Token is an optional access token for gated/private repositories on the\nsource site. It is only forwarded to the download Job as an env var and is\nnever persisted on the (shared, deduplicated) download record.",
+                    "type": "string"
                 }
             }
         },
@@ -11419,6 +11423,12 @@
                     "type": "string"
                 },
                 "creatorId": {
+                    "type": "integer"
+                },
+                "downloadSpeed": {
+                    "type": "string"
+                },
+                "downloadedBytes": {
                     "type": "integer"
                 },
                 "id": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1151,6 +1151,12 @@ definitions:
         type: string
       source:
         type: string
+      token:
+        description: |-
+          Token is an optional access token for gated/private repositories on the
+          source site. It is only forwarded to the download Job as an env var and is
+          never persisted on the (shared, deduplicated) download record.
+        type: string
     required:
     - category
     - name
@@ -1379,6 +1385,10 @@ definitions:
       createdAt:
         type: string
       creatorId:
+        type: integer
+      downloadSpeed:
+        type: string
+      downloadedBytes:
         type: integer
       id:
         type: integer

--- a/backend/internal/handler/modeldownload.go
+++ b/backend/internal/handler/modeldownload.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"k8s.io/client-go/kubernetes"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/raids-lab/crater/internal/resputil"
 	"github.com/raids-lab/crater/internal/util"
 	"github.com/raids-lab/crater/pkg/config"
+	"github.com/raids-lab/crater/pkg/utils"
 )
 
 const (
@@ -916,7 +918,8 @@ func (mgr *ModelDownloadMgr) submitDownloadJob(c *gin.Context, download *model.M
 			},
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: &backoffLimit,
+			TTLSecondsAfterFinished: ptr.To(utils.SevenDaySeconds),
+			BackoffLimit:            &backoffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/backend/internal/handler/vcjob/custom.go
+++ b/backend/internal/handler/vcjob/custom.go
@@ -110,7 +110,7 @@ func (mgr *VolcanojobMgr) CreateTrainingJob(c *gin.Context) {
 			Annotations: jobAnnotations,
 		},
 		Spec: batch.JobSpec{
-			TTLSecondsAfterFinished: ptr.To(SevenDaySeconds),
+			TTLSecondsAfterFinished: ptr.To(utils.SevenDaySeconds),
 			MinAvailable:            1,
 			MaxRetry:                1,
 			SchedulerName:           VolcanoSchedulerName,

--- a/backend/internal/handler/vcjob/jupyter.go
+++ b/backend/internal/handler/vcjob/jupyter.go
@@ -23,10 +23,8 @@ import (
 )
 
 const (
-	ThreeDaySeconds    int32 = 259200
-	SevenDaySeconds    int32 = 604800
-	IngressLabelPrefix       = "ingress.crater.raids.io/" // Annotation Ingress Key
-	NodePortLabelKey         = "nodeport.crater.raids.io/"
+	IngressLabelPrefix = "ingress.crater.raids.io/" // Annotation Ingress Key
+	NodePortLabelKey   = "nodeport.crater.raids.io/"
 )
 
 type (
@@ -144,7 +142,7 @@ func (mgr *VolcanojobMgr) CreateJupyterJob(c *gin.Context) {
 		},
 		Spec: batch.JobSpec{
 			// 3 days
-			TTLSecondsAfterFinished: ptr.To(ThreeDaySeconds),
+			TTLSecondsAfterFinished: ptr.To(utils.ThreeDaySeconds),
 			MinAvailable:            1,
 			MaxRetry:                1,
 			Plugins:                 volcanoPlugins,

--- a/backend/internal/handler/vcjob/pytorch.go
+++ b/backend/internal/handler/vcjob/pytorch.go
@@ -164,7 +164,7 @@ func (mgr *VolcanojobMgr) CreatePytorchJob(c *gin.Context) {
 			Annotations: jobAnnotations,
 		},
 		Spec: batch.JobSpec{
-			TTLSecondsAfterFinished: ptr.To(SevenDaySeconds),
+			TTLSecondsAfterFinished: ptr.To(utils.SevenDaySeconds),
 			MinAvailable:            minAvailable,
 			SchedulerName:           VolcanoSchedulerName,
 			Plugins: map[string][]string{

--- a/backend/internal/handler/vcjob/tensorflow.go
+++ b/backend/internal/handler/vcjob/tensorflow.go
@@ -149,7 +149,7 @@ func (mgr *VolcanojobMgr) CreateTensorflowJob(c *gin.Context) {
 			Annotations: jobAnnotations,
 		},
 		Spec: batch.JobSpec{
-			TTLSecondsAfterFinished: ptr.To(SevenDaySeconds),
+			TTLSecondsAfterFinished: ptr.To(utils.SevenDaySeconds),
 			MinAvailable:            minAvailable,
 			SchedulerName:           VolcanoSchedulerName,
 			Plugins: map[string][]string{

--- a/backend/internal/handler/vcjob/webide.go
+++ b/backend/internal/handler/vcjob/webide.go
@@ -125,7 +125,7 @@ func (mgr *VolcanojobMgr) CreateWebIDEJob(c *gin.Context) {
 		},
 		Spec: batch.JobSpec{
 			// 3 days
-			TTLSecondsAfterFinished: ptr.To(ThreeDaySeconds),
+			TTLSecondsAfterFinished: ptr.To(utils.ThreeDaySeconds),
 			MinAvailable:            1,
 			MaxRetry:                1,
 			Plugins:                 volcanoPlugins,

--- a/backend/pkg/utils/time.go
+++ b/backend/pkg/utils/time.go
@@ -9,7 +9,11 @@ import (
 	"github.com/raids-lab/crater/pkg/config"
 )
 
-const twoDigitYearDivisor = 100
+const (
+	twoDigitYearDivisor       = 100
+	ThreeDaySeconds     int32 = 259200
+	SevenDaySeconds     int32 = 604800
+)
 
 func GetLocalTime() time.Time {
 	timeZone := config.GetConfig().Postgres.TimeZone


### PR DESCRIPTION
- docs: add token and download status fields to model download API
- feat: set TTLSecondsAfterFinished to 7 days for model download jobs
- refactor: move time constants to shared utils package
- fix: unset git env vars in pre-commit hook

Fixes #438 