### PR TITLE
fix: fallback to stored job events

### DIFF
--- a/backend/internal/handler/vcjob/vcjob.go
+++ b/backend/internal/handler/vcjob/vcjob.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/raids-lab/crater/dao/model"
 	"github.com/raids-lab/crater/dao/query"
+	"github.com/raids-lab/crater/internal/bizerr"
 	"github.com/raids-lab/crater/internal/handler"
 	"github.com/raids-lab/crater/internal/resputil"
 	"github.com/raids-lab/crater/internal/service"
@@ -978,10 +979,7 @@ func (mgr *VolcanojobMgr) GetJobDetail(c *gin.Context) {
 		scheduleData = job.ScheduleData.Data()
 	}
 
-	var events []v1.Event
-	if job.Events != nil {
-		events = job.Events.Data()
-	}
+	events := getStoredJobEvents(job)
 
 	var terminatedStates []v1.ContainerStateTerminated
 	if job.TerminatedStates != nil {
@@ -1348,6 +1346,14 @@ func (mgr *VolcanojobMgr) GetJobEvents(c *gin.Context) {
 		return
 	}
 	vcjob := job.Attributes.Data()
+	storedEvents := getStoredJobEvents(job)
+	fallbackToStoredEvents := func(err error) {
+		if len(storedEvents) > 0 {
+			resputil.Success(c, storedEvents)
+			return
+		}
+		resputil.HandleError(c, err)
+	}
 
 	// get job events
 	jobEvents, err := mgr.kubeClient.CoreV1().Events(vcjob.Namespace).List(c, metav1.ListOptions{
@@ -1355,7 +1361,7 @@ func (mgr *VolcanojobMgr) GetJobEvents(c *gin.Context) {
 		TypeMeta:      metav1.TypeMeta{Kind: "Job", APIVersion: "batch.volcano.sh/v1alpha1"},
 	})
 	if err != nil {
-		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		fallbackToStoredEvents(bizerr.Internal.K8sServiceError.Wrap(err, "failed to list job events"))
 		return
 	}
 	events := jobEvents.Items
@@ -1364,13 +1370,13 @@ func (mgr *VolcanojobMgr) GetJobEvents(c *gin.Context) {
 	// get pod events
 	var podList = &v1.PodList{}
 	if value, ok := vcjob.Labels[crclient.LabelKeyBaseURL]; !ok {
-		resputil.Error(c, "label not found", resputil.NotSpecified)
+		fallbackToStoredEvents(bizerr.Internal.K8sServiceError.New("job label not found"))
 		return
 	} else {
 		labels := client.MatchingLabels{crclient.LabelKeyBaseURL: value}
 		err = mgr.client.List(c, podList, client.InNamespace(vcjob.Namespace), labels)
 		if err != nil {
-			resputil.Error(c, err.Error(), resputil.NotSpecified)
+			fallbackToStoredEvents(bizerr.Internal.K8sServiceError.Wrap(err, "failed to list job pods"))
 			return
 		}
 	}
@@ -1382,7 +1388,7 @@ func (mgr *VolcanojobMgr) GetJobEvents(c *gin.Context) {
 			TypeMeta:      metav1.TypeMeta{Kind: "Pod"},
 		})
 		if err != nil {
-			resputil.Error(c, err.Error(), resputil.NotSpecified)
+			fallbackToStoredEvents(bizerr.Internal.K8sServiceError.Wrap(err, "failed to list pod events"))
 			return
 		}
 		// 如果存在 Pod 事件，则不返回 Job 事件
@@ -1393,7 +1399,18 @@ func (mgr *VolcanojobMgr) GetJobEvents(c *gin.Context) {
 		events = append(events, podEvents.Items...)
 	}
 
+	if len(events) == 0 && len(storedEvents) > 0 {
+		resputil.Success(c, storedEvents)
+		return
+	}
 	resputil.Success(c, events)
+}
+
+func getStoredJobEvents(job *model.Job) []v1.Event {
+	if job.Events == nil {
+		return nil
+	}
+	return job.Events.Data()
 }
 
 // ToggleAlertState godoc

--- a/frontend/src/components/codeblock/dialog.tsx
+++ b/frontend/src/components/codeblock/dialog.tsx
@@ -25,6 +25,7 @@ interface FetchContentProps<T> {
   name: string
   type: string
   fetchData: (name: string) => Promise<IResponse<T>>
+  fallbackData?: T
   renderData: (data: T) => React.ReactNode
 }
 
@@ -33,19 +34,26 @@ type FetchDialogProps<T> = React.HTMLAttributes<HTMLDivElement> &
     trigger: React.ReactNode
   }
 
-export function LazyContent<T>({ name, type, fetchData, renderData }: FetchContentProps<T>) {
+export function LazyContent<T>({
+  name,
+  type,
+  fetchData,
+  fallbackData,
+  renderData,
+}: FetchContentProps<T>) {
   const { data } = useQuery({
     queryKey: ['code', type, name],
     queryFn: () => fetchData(name),
     select: (res) => res.data,
     enabled: !!name,
   })
+  const displayData = data ?? fallbackData
 
-  if (!data) {
+  if (!displayData) {
     return <Nothing />
   }
 
-  return <>{renderData(data)}</>
+  return <>{renderData(displayData)}</>
 }
 
 export function FetchSheet<T>({ trigger, name, type, fetchData, renderData }: FetchDialogProps<T>) {

--- a/frontend/src/components/job/detail/index.tsx
+++ b/frontend/src/components/job/detail/index.tsx
@@ -470,6 +470,7 @@ export default function BaseCore({ jobName, ...props }: DetailPageCoreProps & { 
               name={jobName}
               type="event"
               fetchData={apiJobGetEvent}
+              fallbackData={data.events ?? []}
               renderData={(events) => (
                 <>
                   {events.length > 0 ? (


### PR DESCRIPTION
## 背景问题

作业详情页的事件展示存在一个历史事件兜底缺口：数据库里的 `jobs.events` 已经保存了 reconciler 采集到的历史事件，但前端事件 tab 会优先请求 `/api/v1/vcjobs/{name}/event` 获取实时 Kubernetes events。当作业已经停止、Pod 已经被删除，或 Kubernetes events 已经过期/查询失败时，这个实时接口可能返回错误或没有事件，页面就容易显示空白。

这对“已停止/历史作业”尤其明显：用户看到作业已经没有运行时 Pod，但数据库中理论上仍有历史 events，页面却没有稳定地展示出来。

## 修改前流程

### 前端

1. 作业详情页请求 `/api/v1/vcjobs/{name}/detail`，响应中包含数据库保存的 `events`。
2. 切到“作业事件/历史事件”tab 时，`LazyContent` 再请求 `/api/v1/vcjobs/{name}/event`。
3. 如果 event 接口成功返回非空数组，展示 event 接口返回的实时 Kubernetes events。
4. 如果 event 接口成功返回空数组，才在 `renderData` 内回退展示详情接口里的 `data.events`。
5. 如果 event 接口请求失败，`LazyContent` 拿不到 data，会直接显示空态，不会进入 `renderData`，因此不会使用详情接口中的 `data.events`。

### 后端

`GetJobEvents` 的处理流程是：

1. 从数据库查 job 记录，用于获取 namespace、labels 等元信息。
2. 查询 Kubernetes Job events。
3. 根据 job label 查询关联 Pod 列表。
4. 对每个 Pod 查询 Kubernetes Pod events。
5. 如果找到 Pod events，则清掉 Job events，只返回 Pod events。
6. 过程中任一 Kubernetes 查询失败、label 缺失、pod list 失败或 pod events 查询失败，都会直接返回错误。
7. 即使数据库中的 `job.Events` 有历史事件，`/event` 接口也不会读取它作为 fallback。

因此，原来的 fallback 只覆盖“实时接口成功但返回空数组”的窄场景，不能覆盖“Pod 已删除 / K8s events 过期 / K8s 查询失败”的常见历史作业场景。

## 修改后流程

### 后端

`GetJobEvents` 现在仍然优先查询实时 Kubernetes events，但会提前从数据库记录中读取 `job.Events` 作为 `storedEvents`：

1. 从数据库查 job 记录。
2. 读取数据库保存的 `storedEvents`。
3. 优先查询 Kubernetes Job events 和 Pod events。
4. 如果 Kubernetes 查询链路中任一步失败：
   - `storedEvents` 非空时，返回数据库历史 events；
   - `storedEvents` 为空时，返回原始 K8s 业务错误。
5. 如果 Kubernetes 查询成功但最终 events 为空：
   - `storedEvents` 非空时，返回数据库历史 events；
   - 否则返回空数组。

同时复用 `getStoredJobEvents`，让详情接口和事件接口读取数据库 events 的方式保持一致。

### 前端

`LazyContent` 新增可选 `fallbackData`：

1. 事件 tab 仍然请求 `/api/v1/vcjobs/{name}/event`。
2. 作业详情页把 `/detail` 中已有的 `data.events ?? []` 传给 `LazyContent` 作为 fallback。
3. 如果 event 接口有可用数据，继续展示 event 接口数据。
4. 如果 event 接口没有可用 data，展示 `fallbackData`。

这样前后端都具备兜底能力：后端保证 API 调用方优先拿到历史 events；前端也能在请求失败时用详情接口已有数据避免空态。

## 验证

- `CRATER_DEBUG_CONFIG_PATH=/home/cx330/devspace/crater/crater/backend/etc/debug-config.yaml go test ./internal/handler/vcjob`
- `corepack pnpm lint`
- `./bin/golangci-lint run -c .golangci-full.yml --timeout 5m`
- `./bin/golangci-lint run -c .golangci-diff.yml --new-from-rev=origin/main --timeout 5m`
