### PR TITLE
fix: 支持多 kubeconfig 的状态输出

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,6 @@
 KUBECONFIG_PATH := $(if $(KUBECONFIG),$(KUBECONFIG),${PWD}/kubeconfig)
+KUBECONFIG_FILES := $(subst :, ,$(KUBECONFIG_PATH))
+MISSING_KUBECONFIG_FILES := $(filter-out $(wildcard $(KUBECONFIG_FILES)),$(KUBECONFIG_FILES))
 CONFIG_FILE := ./etc/debug-config.yaml
 CACHE_DIR := $(PWD)/.cache
 GOCACHE ?= $(CACHE_DIR)/go-build
@@ -34,8 +36,8 @@ CYAN := \033[36m
 WHITE := \033[37m
 RESET := \033[0m
 
-ifeq ($(wildcard $(KUBECONFIG_PATH)),)
-$(warning KUBECONFIG file not found at: $(KUBECONFIG_PATH))
+ifneq ($(strip $(MISSING_KUBECONFIG_FILES)),)
+$(warning KUBECONFIG file(s) not found: $(MISSING_KUBECONFIG_FILES))
 $(warning Please ensure the kubeconfig file exists or set KUBECONFIG environment variable)
 endif
 
@@ -76,10 +78,17 @@ help: ## Display this help.
 show-kubeconfig: ## Display current KUBECONFIG path
 	@echo "$(CYAN)KUBECONFIG environment variable:$(RESET) $(if $(KUBECONFIG),$(KUBECONFIG),$(YELLOW)Not set$(RESET))"
 	@echo "$(CYAN)Using KUBECONFIG path:$(RESET) $(KUBECONFIG_PATH)"
-	@if [ -f "$(KUBECONFIG_PATH)" ]; then \
-		echo "$(GREEN)✅ KUBECONFIG file exists$(RESET)"; \
+	@printf '%s\n' "$(KUBECONFIG_PATH)" | tr ':' '\n' | while IFS= read -r path; do \
+		if [ -f "$$path" ]; then \
+			echo "$(GREEN)✅ KUBECONFIG file exists:$(RESET) $$path"; \
+		else \
+			echo "$(RED)❌ KUBECONFIG file does NOT exist:$(RESET) $$path"; \
+		fi; \
+	done
+	@if command -v kubectl >/dev/null 2>&1; then \
+		echo "$(CYAN)Current Kubernetes context:$(RESET) $$(KUBECONFIG="$(KUBECONFIG_PATH)" kubectl config current-context 2>/dev/null || echo "$(YELLOW)Unavailable$(RESET)")"; \
 	else \
-		echo "$(RED)❌ KUBECONFIG file does NOT exist$(RESET)"; \
+		echo "$(YELLOW)kubectl not found; cannot display current Kubernetes context$(RESET)"; \
 	fi
 
 .PHONY: prepare


### PR DESCRIPTION
## 背景

本地开发时可以通过 Kubernetes 标准的 `KUBECONFIG` 多文件列表管理多个集群，例如：

```bash
KUBECONFIG=/home/cx330/.kube/config:/home/cx330/.kube/configs/config_crater:/home/cx330/.kube/configs/config_gpu
```

`kubectl` 和 client-go 都支持这种冒号分隔的 kubeconfig 列表，会合并多个文件后读取 `current-context`，因此后端实际运行时可以正常连接当前 context 对应的集群。

但 `backend/Makefile` 之前的诊断输出把整个冒号分隔字符串当成一个单独文件路径检查，导致 `make run` / `make show-kubeconfig` 打印误导性日志：

```text
❌ KUBECONFIG file does NOT exist
```

即使列表中的每个 kubeconfig 文件都真实存在，仍然会误报。

## 修改前流程

1. `KUBECONFIG_PATH` 取 `KUBECONFIG` 环境变量，或回退到 `${PWD}/kubeconfig`。
2. Makefile 使用 `$(wildcard $(KUBECONFIG_PATH))` 做 parse-time 检查。
3. `show-kubeconfig` 使用 `[ -f "$(KUBECONFIG_PATH)" ]` 做 shell 检查。
4. 当 `KUBECONFIG_PATH` 是冒号分隔列表时，上述两处都会把整个字符串当成单个文件名，所以误报不存在。
5. `make run` 实际仍把原始 `KUBECONFIG_PATH` 传给 Go，client-go 可以正常处理，所以这是诊断输出问题，不是运行连接问题。

## 修改后流程

1. 保留 `KUBECONFIG_PATH` 原始值不变，`make run` 仍然原样传给 Go：

```make
KUBECONFIG="$(KUBECONFIG_PATH)" go run ...
```

2. 新增 `KUBECONFIG_FILES`，仅用于诊断检查，将 `KUBECONFIG_PATH` 按 `:` 拆成多个文件路径。
3. parse-time warning 改为只报告实际缺失的 kubeconfig 文件。
4. `show-kubeconfig` 逐个打印每个 kubeconfig 文件是否存在。
5. 如果本机有 `kubectl`，额外用同一份 `KUBECONFIG_PATH` 输出当前 Kubernetes context：

```bash
KUBECONFIG="$(KUBECONFIG_PATH)" kubectl config current-context
```

这样输出的 context 和 `make run` 传给 Go 的 kubeconfig 视角一致。

## 影响范围

- 只修改 Makefile 的诊断输出。
- 不改变 `make run` 的实际运行参数。
- 兼容单 kubeconfig 文件。
- 兼容冒号分隔的多 kubeconfig 文件列表。
- 如果 `kubectl` 不存在，只跳过 current-context 展示，不影响运行。

## 验证

- `make -C backend show-kubeconfig`
- `git diff --check`

本地验证输出可以逐个显示 kubeconfig 文件存在，并显示当前 context：

```text
Current Kubernetes context: crater
```
