### PR TITLE
feat(job): add server-side pagination for Volcano job lists

### DIFF
--- a/backend/cmd/gorm-gen/models/migrate.go
+++ b/backend/cmd/gorm-gen/models/migrate.go
@@ -1154,6 +1154,26 @@ func main() {
 			},
 		},
 		{
+			ID: "202607100100",
+			Migrate: func(tx *gorm.DB) error {
+				for _, index := range jobListIndexes() {
+					if err := tx.Exec(index.create).Error; err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			Rollback: func(tx *gorm.DB) error {
+				indexes := jobListIndexes()
+				for index := len(indexes) - 1; index >= 0; index-- {
+					if err := tx.Exec(indexes[index].drop).Error; err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
+		{
 			ID: "202607111400",
 			Migrate: func(tx *gorm.DB) error {
 				type ModelDownload struct {
@@ -1462,5 +1482,35 @@ func main() {
 
 	if err := m.Migrate(); err != nil {
 		panic(fmt.Errorf("could not migrate: %w", err))
+	}
+}
+
+type jobListIndex struct {
+	create string
+	drop   string
+}
+
+func jobListIndexes() []jobListIndex {
+	return []jobListIndex{
+		{
+			create: `CREATE INDEX IF NOT EXISTS idx_jobs_creation_timestamp ON jobs (creation_timestamp DESC)`,
+			drop:   `DROP INDEX IF EXISTS idx_jobs_creation_timestamp`,
+		},
+		{
+			create: `CREATE INDEX IF NOT EXISTS idx_jobs_account_creation_timestamp ON jobs (account_id, creation_timestamp DESC)`,
+			drop:   `DROP INDEX IF EXISTS idx_jobs_account_creation_timestamp`,
+		},
+		{
+			create: `CREATE INDEX IF NOT EXISTS idx_jobs_user_creation_timestamp ON jobs (user_id, creation_timestamp DESC)`,
+			drop:   `DROP INDEX IF EXISTS idx_jobs_user_creation_timestamp`,
+		},
+		{
+			create: `CREATE INDEX IF NOT EXISTS idx_jobs_status_creation_timestamp ON jobs (status, creation_timestamp DESC)`,
+			drop:   `DROP INDEX IF EXISTS idx_jobs_status_creation_timestamp`,
+		},
+		{
+			create: `CREATE INDEX IF NOT EXISTS idx_jobs_type_creation_timestamp ON jobs (job_type, creation_timestamp DESC)`,
+			drop:   `DROP INDEX IF EXISTS idx_jobs_type_creation_timestamp`,
+		},
 	}
 }

--- a/backend/dao/model/job.go
+++ b/backend/dao/model/job.go
@@ -134,19 +134,20 @@ type Job struct {
 	gorm.Model
 	Name                    string         `gorm:"not null;type:varchar(256);comment:作业名称"`
 	JobName                 string         `gorm:"uniqueIndex;type:varchar(256);not null;comment:作业名称"`
-	UserID                  uint           `gorm:"primaryKey"`
+	UserID                  uint           `gorm:"primaryKey;index:idx_jobs_user_creation_timestamp,priority:1"`
 	User                    User           `gorm:"foreignKey:UserID"`
-	AccountID               uint           `gorm:"primaryKey"`
+	AccountID               uint           `gorm:"primaryKey;index:idx_jobs_account_creation_timestamp,priority:1"`
 	Account                 Account        `gorm:"foreignKey:AccountID"`
-	JobType                 JobType        `gorm:"not null;comment:作业类型"`
+	JobType                 JobType        `gorm:"not null;index:idx_jobs_type_creation_timestamp,priority:1;comment:作业类型"`
 	ScheduleType            *ScheduleType  `gorm:"index:idx_jobs_schedule_type;default:1;not null;comment:调度类型"`
 	WaitingToleranceSeconds *int64         `gorm:"comment:作业等待忍耐时间(秒)"`
-	Status                  batch.JobPhase `gorm:"index:status;not null;comment:作业状态"`
+	Status                  batch.JobPhase `gorm:"index:status;index:idx_jobs_status_creation_timestamp,priority:1;not null;comment:作业状态"`
 	Queue                   string         `gorm:"type:varchar(256);index:idx_jobs_queue;comment:作业提交的volcano队列"`
 	// TODO(perf): Evaluate adding composite indexes for statistics queries:
 	// (user_id, running_timestamp), (account_id, running_timestamp),
 	// and potentially (running_timestamp, completed_timestamp).
-	CreationTimestamp  time.Time                           `gorm:"not null;comment:作业创建时间"`
+	//nolint:lll // GORM requires all composite index declarations on the indexed field.
+	CreationTimestamp  time.Time                           `gorm:"not null;index:idx_jobs_creation_timestamp,sort:desc;index:idx_jobs_account_creation_timestamp,priority:2,sort:desc;index:idx_jobs_user_creation_timestamp,priority:2,sort:desc;index:idx_jobs_status_creation_timestamp,priority:2,sort:desc;index:idx_jobs_type_creation_timestamp,priority:2,sort:desc;comment:作业创建时间"`
 	RunningTimestamp   time.Time                           `gorm:"comment:作业开始运行时间"`
 	CompletedTimestamp time.Time                           `gorm:"comment:作业完成时间"`
 	Nodes              datatypes.JSONType[[]string]        `gorm:"comment:作业运行的节点"`

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -8648,11 +8648,79 @@ const docTemplate = `{
                     "VolcanoJob"
                 ],
                 "summary": "Get the jobs of the user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-200",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort fields",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of days to look back, -1 for all",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Volcano Job List",
                         "schema": {
-                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp"
                         }
                     },
                     "400": {
@@ -8695,13 +8763,73 @@ const docTemplate = `{
                         "description": "Number of days to look back, default is 14",
                         "name": "days",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-200",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort fields",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "admin get Volcano Job List",
                         "schema": {
-                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp"
                         }
                     },
                     "400": {
@@ -8714,6 +8842,154 @@ const docTemplate = `{
                         "description": "Other errors",
                         "schema": {
                             "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/vcjobs/all/facets": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "VolcanoJob"
+                ],
+                "summary": "Get all visible job facets",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of days to look back, -1 for all",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/vcjobs/facets": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "VolcanoJob"
+                ],
+                "summary": "Get job facets for the current user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of days to look back, -1 for all",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse"
                         }
                     }
                 }
@@ -8900,13 +9176,73 @@ const docTemplate = `{
                         "description": "Number of days to look back, default is 30, -1 for all",
                         "name": "days",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-200",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort fields",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "User's Job List",
                         "schema": {
-                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp"
                         }
                     },
                     "400": {
@@ -8931,6 +9267,87 @@ const docTemplate = `{
                         "description": "Other errors",
                         "schema": {
                             "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/vcjobs/user/{username}/facets": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "VolcanoJob"
+                ],
+                "summary": "Get job facets for a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of days to look back, -1 for all",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse"
                         }
                     }
                 }
@@ -10017,6 +10434,31 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_raids-lab_crater_internal_resputil.FacetItem": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_raids-lab_crater_internal_resputil.FacetResponse": {
+            "type": "object",
+            "properties": {
+                "facets": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.FacetItem"
+                        }
+                    }
+                }
+            }
+        },
         "github_com_raids-lab_crater_internal_resputil.List-internal_handler_operations_OperationLogResp": {
             "type": "object",
             "properties": {
@@ -10025,6 +10467,26 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/internal_handler_operations.OperationLogResp"
                     }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_raids-lab_crater_internal_resputil.Page-internal_handler_vcjob_JobResp": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_handler_vcjob.JobResp"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
                 },
                 "total": {
                     "type": "integer"
@@ -10164,6 +10626,21 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "依然保持 int (ErrorCode) 类型",
+                    "type": "integer"
+                },
+                "data": {
+                    "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.FacetResponse"
+                },
+                "msg": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_List-internal_handler_operations_OperationLogResp": {
             "type": "object",
             "properties": {
@@ -10173,6 +10650,21 @@ const docTemplate = `{
                 },
                 "data": {
                     "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.List-internal_handler_operations_OperationLogResp"
+                },
+                "msg": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "依然保持 int (ErrorCode) 类型",
+                    "type": "integer"
+                },
+                "data": {
+                    "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Page-internal_handler_vcjob_JobResp"
                 },
                 "msg": {
                     "type": "string"
@@ -12733,6 +13225,68 @@ const docTemplate = `{
                 },
                 "imageLink": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler_vcjob.JobResp": {
+            "type": "object",
+            "properties": {
+                "billedPointsTotal": {
+                    "type": "number"
+                },
+                "completedAt": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "jobName": {
+                    "type": "string"
+                },
+                "jobType": {
+                    "type": "string"
+                },
+                "locked": {
+                    "type": "boolean"
+                },
+                "lockedTimestamp": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nodes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "permanentLocked": {
+                    "type": "boolean"
+                },
+                "queue": {
+                    "type": "string"
+                },
+                "resources": {
+                    "$ref": "#/definitions/v1.ResourceList"
+                },
+                "scheduleType": {
+                    "$ref": "#/definitions/github_com_raids-lab_crater_dao_model.ScheduleType"
+                },
+                "startedAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "userInfo": {
+                    "$ref": "#/definitions/github_com_raids-lab_crater_dao_model.UserInfo"
+                },
+                "waitingToleranceSeconds": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -8640,11 +8640,79 @@
                     "VolcanoJob"
                 ],
                 "summary": "Get the jobs of the user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-200",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort fields",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of days to look back, -1 for all",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Volcano Job List",
                         "schema": {
-                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp"
                         }
                     },
                     "400": {
@@ -8687,13 +8755,73 @@
                         "description": "Number of days to look back, default is 14",
                         "name": "days",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-200",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort fields",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "admin get Volcano Job List",
                         "schema": {
-                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp"
                         }
                     },
                     "400": {
@@ -8706,6 +8834,154 @@
                         "description": "Other errors",
                         "schema": {
                             "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/vcjobs/all/facets": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "VolcanoJob"
+                ],
+                "summary": "Get all visible job facets",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of days to look back, -1 for all",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/vcjobs/facets": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "VolcanoJob"
+                ],
+                "summary": "Get job facets for the current user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of days to look back, -1 for all",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse"
                         }
                     }
                 }
@@ -8892,13 +9168,73 @@
                         "description": "Number of days to look back, default is 30, -1 for all",
                         "name": "days",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-200",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort fields",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "User's Job List",
                         "schema": {
-                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp"
                         }
                     },
                     "400": {
@@ -8923,6 +9259,87 @@
                         "description": "Other errors",
                         "schema": {
                             "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/vcjobs/user/{username}/facets": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "VolcanoJob"
+                ],
+                "summary": "Get job facets for a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of days to look back, -1 for all",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search jobs",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job types",
+                        "name": "job_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Schedule types",
+                        "name": "schedule_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Job statuses",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Node name",
+                        "name": "node",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse"
                         }
                     }
                 }
@@ -10009,6 +10426,31 @@
                 }
             }
         },
+        "github_com_raids-lab_crater_internal_resputil.FacetItem": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_raids-lab_crater_internal_resputil.FacetResponse": {
+            "type": "object",
+            "properties": {
+                "facets": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.FacetItem"
+                        }
+                    }
+                }
+            }
+        },
         "github_com_raids-lab_crater_internal_resputil.List-internal_handler_operations_OperationLogResp": {
             "type": "object",
             "properties": {
@@ -10017,6 +10459,26 @@
                     "items": {
                         "$ref": "#/definitions/internal_handler_operations.OperationLogResp"
                     }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_raids-lab_crater_internal_resputil.Page-internal_handler_vcjob_JobResp": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_handler_vcjob.JobResp"
+                    }
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
                 },
                 "total": {
                     "type": "integer"
@@ -10156,6 +10618,21 @@
                 }
             }
         },
+        "github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "依然保持 int (ErrorCode) 类型",
+                    "type": "integer"
+                },
+                "data": {
+                    "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.FacetResponse"
+                },
+                "msg": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_List-internal_handler_operations_OperationLogResp": {
             "type": "object",
             "properties": {
@@ -10165,6 +10642,21 @@
                 },
                 "data": {
                     "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.List-internal_handler_operations_OperationLogResp"
+                },
+                "msg": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "依然保持 int (ErrorCode) 类型",
+                    "type": "integer"
+                },
+                "data": {
+                    "$ref": "#/definitions/github_com_raids-lab_crater_internal_resputil.Page-internal_handler_vcjob_JobResp"
                 },
                 "msg": {
                     "type": "string"
@@ -12725,6 +13217,68 @@
                 },
                 "imageLink": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler_vcjob.JobResp": {
+            "type": "object",
+            "properties": {
+                "billedPointsTotal": {
+                    "type": "number"
+                },
+                "completedAt": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "jobName": {
+                    "type": "string"
+                },
+                "jobType": {
+                    "type": "string"
+                },
+                "locked": {
+                    "type": "boolean"
+                },
+                "lockedTimestamp": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "nodes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "permanentLocked": {
+                    "type": "boolean"
+                },
+                "queue": {
+                    "type": "string"
+                },
+                "resources": {
+                    "$ref": "#/definitions/v1.ResourceList"
+                },
+                "scheduleType": {
+                    "$ref": "#/definitions/github_com_raids-lab_crater_dao_model.ScheduleType"
+                },
+                "startedAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "userInfo": {
+                    "$ref": "#/definitions/github_com_raids-lab_crater_dao_model.UserInfo"
+                },
+                "waitingToleranceSeconds": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -376,12 +376,41 @@ definitions:
         description: 'Key: ResourceName, Value: Usage'
         type: object
     type: object
+  github_com_raids-lab_crater_internal_resputil.FacetItem:
+    properties:
+      count:
+        type: integer
+      value:
+        type: string
+    type: object
+  github_com_raids-lab_crater_internal_resputil.FacetResponse:
+    properties:
+      facets:
+        additionalProperties:
+          items:
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.FacetItem'
+          type: array
+        type: object
+    type: object
   github_com_raids-lab_crater_internal_resputil.List-internal_handler_operations_OperationLogResp:
     properties:
       items:
         items:
           $ref: '#/definitions/internal_handler_operations.OperationLogResp'
         type: array
+      total:
+        type: integer
+    type: object
+  github_com_raids-lab_crater_internal_resputil.Page-internal_handler_vcjob_JobResp:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/internal_handler_vcjob.JobResp'
+        type: array
+      page:
+        type: integer
+      page_size:
+        type: integer
       total:
         type: integer
     type: object
@@ -474,6 +503,16 @@ definitions:
       msg:
         type: string
     type: object
+  github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse:
+    properties:
+      code:
+        description: 依然保持 int (ErrorCode) 类型
+        type: integer
+      data:
+        $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.FacetResponse'
+      msg:
+        type: string
+    type: object
   ? github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_List-internal_handler_operations_OperationLogResp
   : properties:
       code:
@@ -481,6 +520,16 @@ definitions:
         type: integer
       data:
         $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.List-internal_handler_operations_OperationLogResp'
+      msg:
+        type: string
+    type: object
+  ? github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp
+  : properties:
+      code:
+        description: 依然保持 int (ErrorCode) 类型
+        type: integer
+      data:
+        $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Page-internal_handler_vcjob_JobResp'
       msg:
         type: string
     type: object
@@ -2185,6 +2234,47 @@ definitions:
         type: array
       imageLink:
         type: string
+    type: object
+  internal_handler_vcjob.JobResp:
+    properties:
+      billedPointsTotal:
+        type: number
+      completedAt:
+        type: string
+      createdAt:
+        type: string
+      jobName:
+        type: string
+      jobType:
+        type: string
+      locked:
+        type: boolean
+      lockedTimestamp:
+        type: string
+      name:
+        type: string
+      nodes:
+        items:
+          type: string
+        type: array
+      owner:
+        type: string
+      permanentLocked:
+        type: boolean
+      queue:
+        type: string
+      resources:
+        $ref: '#/definitions/v1.ResourceList'
+      scheduleType:
+        $ref: '#/definitions/github_com_raids-lab_crater_dao_model.ScheduleType'
+      startedAt:
+        type: string
+      status:
+        type: string
+      userInfo:
+        $ref: '#/definitions/github_com_raids-lab_crater_dao_model.UserInfo'
+      waitingToleranceSeconds:
+        type: integer
     type: object
   internal_handler_vcjob.JupyterTokenResp:
     properties:
@@ -7975,13 +8065,59 @@ paths:
       consumes:
       - application/json
       description: Get the jobs of the user by client-go
+      parameters:
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Page size, 1-200
+        in: query
+        name: page_size
+        type: integer
+      - description: Sort fields
+        in: query
+        name: sort
+        type: string
+      - description: Search jobs
+        in: query
+        name: search
+        type: string
+      - description: Number of days to look back, -1 for all
+        in: query
+        name: days
+        type: integer
+      - collectionFormat: multi
+        description: Job types
+        in: query
+        items:
+          type: string
+        name: job_type
+        type: array
+      - collectionFormat: multi
+        description: Schedule types
+        in: query
+        items:
+          type: integer
+        name: schedule_type
+        type: array
+      - collectionFormat: multi
+        description: Job statuses
+        in: query
+        items:
+          type: string
+        name: status
+        type: array
+      - description: Node name
+        in: query
+        name: node
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: Volcano Job List
           schema:
-            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any'
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp'
         "400":
           description: Request parameter error
           schema:
@@ -8341,13 +8477,54 @@ paths:
         in: query
         name: days
         type: integer
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Page size, 1-200
+        in: query
+        name: page_size
+        type: integer
+      - description: Sort fields
+        in: query
+        name: sort
+        type: string
+      - description: Search jobs
+        in: query
+        name: search
+        type: string
+      - collectionFormat: multi
+        description: Job types
+        in: query
+        items:
+          type: string
+        name: job_type
+        type: array
+      - collectionFormat: multi
+        description: Schedule types
+        in: query
+        items:
+          type: integer
+        name: schedule_type
+        type: array
+      - collectionFormat: multi
+        description: Job statuses
+        in: query
+        items:
+          type: string
+        name: status
+        type: array
+      - description: Node name
+        in: query
+        name: node
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: admin get Volcano Job List
           schema:
-            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any'
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp'
         "400":
           description: admin Request parameter error
           schema:
@@ -8359,6 +8536,102 @@ paths:
       security:
       - Bearer: []
       summary: Get all of the jobs
+      tags:
+      - VolcanoJob
+  /v1/vcjobs/all/facets:
+    get:
+      parameters:
+      - description: Number of days to look back, -1 for all
+        in: query
+        name: days
+        type: integer
+      - description: Search jobs
+        in: query
+        name: search
+        type: string
+      - collectionFormat: multi
+        description: Job types
+        in: query
+        items:
+          type: string
+        name: job_type
+        type: array
+      - collectionFormat: multi
+        description: Schedule types
+        in: query
+        items:
+          type: integer
+        name: schedule_type
+        type: array
+      - collectionFormat: multi
+        description: Job statuses
+        in: query
+        items:
+          type: string
+        name: status
+        type: array
+      - description: Node name
+        in: query
+        name: node
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse'
+      security:
+      - Bearer: []
+      summary: Get all visible job facets
+      tags:
+      - VolcanoJob
+  /v1/vcjobs/facets:
+    get:
+      parameters:
+      - description: Number of days to look back, -1 for all
+        in: query
+        name: days
+        type: integer
+      - description: Search jobs
+        in: query
+        name: search
+        type: string
+      - collectionFormat: multi
+        description: Job types
+        in: query
+        items:
+          type: string
+        name: job_type
+        type: array
+      - collectionFormat: multi
+        description: Schedule types
+        in: query
+        items:
+          type: integer
+        name: schedule_type
+        type: array
+      - collectionFormat: multi
+        description: Job statuses
+        in: query
+        items:
+          type: string
+        name: status
+        type: array
+      - description: Node name
+        in: query
+        name: node
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse'
+      security:
+      - Bearer: []
+      summary: Get job facets for the current user
       tags:
       - VolcanoJob
   /v1/vcjobs/jupyter:
@@ -8472,13 +8745,54 @@ paths:
         in: query
         name: days
         type: integer
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Page size, 1-200
+        in: query
+        name: page_size
+        type: integer
+      - description: Sort fields
+        in: query
+        name: sort
+        type: string
+      - description: Search jobs
+        in: query
+        name: search
+        type: string
+      - collectionFormat: multi
+        description: Job types
+        in: query
+        items:
+          type: string
+        name: job_type
+        type: array
+      - collectionFormat: multi
+        description: Schedule types
+        in: query
+        items:
+          type: integer
+        name: schedule_type
+        type: array
+      - collectionFormat: multi
+        description: Job statuses
+        in: query
+        items:
+          type: string
+        name: status
+        type: array
+      - description: Node name
+        in: query
+        name: node
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: User's Job List
           schema:
-            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-any'
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_Page-internal_handler_vcjob_JobResp'
         "400":
           description: Request parameter error
           schema:
@@ -8498,6 +8812,59 @@ paths:
       security:
       - Bearer: []
       summary: Get jobs of a specific user within days
+      tags:
+      - VolcanoJob
+  /v1/vcjobs/user/{username}/facets:
+    get:
+      parameters:
+      - description: Username
+        in: path
+        name: username
+        required: true
+        type: string
+      - description: Number of days to look back, -1 for all
+        in: query
+        name: days
+        type: integer
+      - description: Search jobs
+        in: query
+        name: search
+        type: string
+      - collectionFormat: multi
+        description: Job types
+        in: query
+        items:
+          type: string
+        name: job_type
+        type: array
+      - collectionFormat: multi
+        description: Schedule types
+        in: query
+        items:
+          type: integer
+        name: schedule_type
+        type: array
+      - collectionFormat: multi
+        description: Job statuses
+        in: query
+        items:
+          type: string
+        name: status
+        type: array
+      - description: Node name
+        in: query
+        name: node
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_raids-lab_crater_internal_resputil.Response-github_com_raids-lab_crater_internal_resputil_FacetResponse'
+      security:
+      - Bearer: []
+      summary: Get job facets for a user
       tags:
       - VolcanoJob
   /v1/vcjobs/webide:

--- a/backend/internal/handler/vcjob/list.go
+++ b/backend/internal/handler/vcjob/list.go
@@ -1,0 +1,357 @@
+package vcjob
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/datatypes"
+	"gorm.io/gen"
+	"gorm.io/gen/field"
+
+	"github.com/raids-lab/crater/dao/model"
+	"github.com/raids-lab/crater/dao/query"
+	"github.com/raids-lab/crater/internal/bizerr"
+	"github.com/raids-lab/crater/internal/resputil"
+	"github.com/raids-lab/crater/internal/util"
+)
+
+const (
+	allJobsDefaultDays  = 7
+	userJobsDefaultDays = 30
+	jobMaxSearchRunes   = 128
+)
+
+type jobListScope struct {
+	UserID    *uint
+	AccountID *uint
+}
+
+type jobListQuery struct {
+	Page          int      `form:"page,default=1" binding:"min=1"`
+	PageSize      int      `form:"page_size,default=10" binding:"min=1,max=200"`
+	Sort          string   `form:"sort"`
+	Search        string   `form:"search"`
+	Days          *int     `form:"days" binding:"omitempty,eq=-1|gt=0"`
+	JobTypes      []string `form:"job_type" binding:"max=20,dive,required"`
+	ScheduleTypes []int    `form:"schedule_type" binding:"max=20,dive,oneof=0 1"`
+	Statuses      []string `form:"status" binding:"max=20,dive,required"`
+	Node          *string  `form:"node"`
+	sorts         []jobSort
+}
+
+type jobSort struct {
+	field      string
+	descending bool
+}
+
+func bindJobListQuery(c *gin.Context, withSort bool) (jobListQuery, error) {
+	var request jobListQuery
+	if err := c.ShouldBindQuery(&request); err != nil {
+		return jobListQuery{}, bizerr.BadRequest.ParameterError.Wrap(err, "invalid job list query")
+	}
+	request.Search = strings.TrimSpace(request.Search)
+	if utf8.RuneCountInString(request.Search) > jobMaxSearchRunes {
+		return jobListQuery{}, bizerr.BadRequest.ParameterError.New("search accepts at most 128 characters")
+	}
+	if request.Node != nil {
+		*request.Node = strings.TrimSpace(*request.Node)
+		if *request.Node == "" {
+			return jobListQuery{}, bizerr.BadRequest.ParameterError.New("node must not be empty")
+		}
+	}
+	if err := validateJobListEnums(&request); err != nil {
+		return jobListQuery{}, err
+	}
+	if request.Page > int(^uint(0)>>1)/request.PageSize {
+		return jobListQuery{}, bizerr.BadRequest.ParameterError.New("page is too large for page_size")
+	}
+	if withSort {
+		sorts, err := parseJobSort(request.Sort)
+		if err != nil {
+			return jobListQuery{}, err
+		}
+		request.sorts = sorts
+	}
+	return request, nil
+}
+
+func (request *jobListQuery) offset() int {
+	return (request.Page - 1) * request.PageSize
+}
+
+func (request *jobListQuery) days(defaultDays int) int {
+	if request.Days == nil {
+		return defaultDays
+	}
+	return *request.Days
+}
+
+func parseJobSort(raw string) ([]jobSort, error) {
+	if raw == "" {
+		return []jobSort{{field: "createdAt", descending: true}, {field: "id", descending: true}}, nil
+	}
+	allowed := map[string]struct{}{
+		"name": {}, "jobName": {}, "owner": {}, "queue": {}, "jobType": {},
+		"scheduleType": {}, "status": {}, "billedPointsTotal": {}, "createdAt": {},
+		"startedAt": {}, "completedAt": {},
+	}
+	parts := strings.Split(raw, ",")
+	if len(parts) > 3 {
+		return nil, bizerr.BadRequest.ParameterError.New("sort accepts at most 3 fields")
+	}
+	seen := make(map[string]struct{}, len(parts)+1)
+	sorts := make([]jobSort, 0, len(parts)+1)
+	for _, part := range parts {
+		descending := strings.HasPrefix(part, "-")
+		name := strings.TrimPrefix(part, "-")
+		if _, ok := allowed[name]; !ok {
+			return nil, bizerr.BadRequest.ParameterError.New("unsupported sort field " + strconv.Quote(name))
+		}
+		if _, ok := seen[name]; ok {
+			return nil, bizerr.BadRequest.ParameterError.New("duplicate sort field " + strconv.Quote(name))
+		}
+		seen[name] = struct{}{}
+		sorts = append(sorts, jobSort{field: name, descending: descending})
+	}
+	sorts = append(sorts, jobSort{field: "id", descending: true})
+	return sorts, nil
+}
+
+//nolint:misspell // Volcano exposes this phase as "Cancelled".
+func validateJobListEnums(request *jobListQuery) error {
+	for _, value := range request.JobTypes {
+		switch value {
+		case "jupyter", "webide", "pytorch", "tensorflow", "kuberay", "deepspeed", "openmpi", "custom":
+		default:
+			return bizerr.BadRequest.ParameterError.New("unsupported job_type " + strconv.Quote(value))
+		}
+	}
+	for _, value := range request.Statuses {
+		switch value {
+		case "Prequeue", "Pending", "Aborting", "Aborted", "Running", "Restarting", "Completing",
+			"Completed", "Terminating", "Terminated", "Failed", "Deleted", "Freed", "Cancelled":
+		default:
+			return bizerr.BadRequest.ParameterError.New("unsupported status " + strconv.Quote(value))
+		}
+	}
+	return nil
+}
+
+func findJobs(
+	ctx context.Context,
+	scope jobListScope,
+	request *jobListQuery,
+	defaultDays int,
+) ([]*model.Job, int64, error) {
+	q := applyJobFilters(ctx, scope, request, defaultDays).
+		Preload(query.Job.User).
+		Preload(query.Job.Account)
+	fields := jobSortFields()
+	for _, sort := range request.sorts {
+		expression := fields[sort.field]
+		if sort.descending {
+			q = q.Order(expression.Desc())
+		} else {
+			q = q.Order(expression.Asc())
+		}
+	}
+	return q.FindByPage(request.offset(), request.PageSize)
+}
+
+func applyJobFilters(
+	ctx context.Context,
+	scope jobListScope,
+	request *jobListQuery,
+	defaultDays int,
+) query.IJobDo {
+	j := query.Job
+	u := query.User
+	a := query.Account
+	q := j.WithContext(ctx).
+		Select(j.ALL).
+		LeftJoin(u, j.UserID.EqCol(u.ID)).
+		LeftJoin(a, j.AccountID.EqCol(a.ID))
+
+	if scope.UserID != nil {
+		q = q.Where(j.UserID.Eq(*scope.UserID))
+	}
+	if scope.AccountID != nil {
+		q = q.Where(j.AccountID.Eq(*scope.AccountID))
+	}
+	if days := request.days(defaultDays); days != -1 {
+		q = q.Where(j.CreationTimestamp.Gte(time.Now().AddDate(0, 0, -days)))
+	}
+	if len(request.JobTypes) > 0 {
+		q = q.Where(j.JobType.In(request.JobTypes...))
+	}
+	if len(request.ScheduleTypes) > 0 {
+		q = q.Where(j.ScheduleType.In(request.ScheduleTypes...))
+	}
+	if len(request.Statuses) > 0 {
+		q = q.Where(j.Status.In(request.Statuses...))
+	}
+	if request.Node != nil {
+		q = q.Where(gen.Cond(datatypes.JSONArrayQuery("nodes").Contains(*request.Node))...)
+	}
+	if request.Search != "" {
+		pattern := util.ContainsPattern(request.Search)
+		q = q.Where(field.Or(
+			j.Name.Lower().Like(pattern),
+			j.JobName.Lower().Like(pattern),
+			j.Queue.Lower().Like(pattern),
+			u.Name.Lower().Like(pattern),
+			u.Nickname.Lower().Like(pattern),
+			a.Name.Lower().Like(pattern),
+			a.Nickname.Lower().Like(pattern),
+		))
+	}
+	return q
+}
+
+func jobSortFields() map[string]field.OrderExpr {
+	j := query.Job
+	return map[string]field.OrderExpr{
+		"id":                j.ID,
+		"name":              j.Name,
+		"jobName":           j.JobName,
+		"owner":             query.User.Nickname,
+		"queue":             query.Account.Nickname,
+		"jobType":           j.JobType,
+		"scheduleType":      j.ScheduleType,
+		"status":            j.Status,
+		"billedPointsTotal": j.BilledPointsTotal,
+		"createdAt":         j.CreationTimestamp,
+		"startedAt":         j.RunningTimestamp,
+		"completedAt":       j.CompletedTimestamp,
+	}
+}
+
+func findJobFacets(
+	ctx context.Context,
+	scope jobListScope,
+	request *jobListQuery,
+	defaultDays int,
+	includeOverview bool,
+) (map[string][]resputil.FacetItem, error) {
+	typeRequest := jobFacetQuery(request, "job_type")
+	types, err := scanJobStringFacet(ctx, scope, &typeRequest, defaultDays, &query.Job.JobType)
+	if err != nil {
+		return nil, err
+	}
+	scheduleRequest := jobFacetQuery(request, "schedule_type")
+	schedules, err := scanJobIntFacet(ctx, scope, &scheduleRequest, defaultDays, &query.Job.ScheduleType)
+	if err != nil {
+		return nil, err
+	}
+	statusRequest := jobFacetQuery(request, "status")
+	statuses, err := scanJobStringFacet(ctx, scope, &statusRequest, defaultDays, &query.Job.Status)
+	if err != nil {
+		return nil, err
+	}
+	result := map[string][]resputil.FacetItem{
+		"job_type":      types,
+		"schedule_type": schedules,
+		"status":        statuses,
+	}
+	if !includeOverview {
+		return result, nil
+	}
+	runningRequest := *request
+	runningRequest.Statuses = []string{"Running"}
+	result["owner"], err = scanJobStringFacet(
+		ctx, scope, &runningRequest, defaultDays, &query.User.Nickname,
+	)
+	if err != nil {
+		return nil, err
+	}
+	result["gpu_resource"], err = scanJobGPUResourceFacet(ctx, scope, &runningRequest, defaultDays)
+	return result, err
+}
+
+func jobFacetQuery(source *jobListQuery, facet string) jobListQuery {
+	request := *source
+	switch facet {
+	case "job_type":
+		request.JobTypes = nil
+	case "schedule_type":
+		request.ScheduleTypes = nil
+	case "status":
+		request.Statuses = nil
+	}
+	return request
+}
+
+func scanJobStringFacet(
+	ctx context.Context,
+	scope jobListScope,
+	request *jobListQuery,
+	defaultDays int,
+	group *field.String,
+) ([]resputil.FacetItem, error) {
+	rows := make([]struct {
+		Value string
+		Count int64
+	}, 0)
+	err := applyJobFilters(ctx, scope, request, defaultDays).
+		Select(group.As("value"), query.Job.ID.Count().As("count")).
+		Group(group).
+		Order(query.Job.ID.Count().Desc(), group.Asc()).
+		Scan(&rows)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]resputil.FacetItem, len(rows))
+	for index, row := range rows {
+		items[index] = resputil.FacetItem{Value: row.Value, Count: row.Count}
+	}
+	return items, nil
+}
+
+func scanJobIntFacet(
+	ctx context.Context,
+	scope jobListScope,
+	request *jobListQuery,
+	defaultDays int,
+	group *field.Int,
+) ([]resputil.FacetItem, error) {
+	rows := make([]struct {
+		Value int
+		Count int64
+	}, 0)
+	err := applyJobFilters(ctx, scope, request, defaultDays).
+		Select(group.As("value"), query.Job.ID.Count().As("count")).
+		Group(group).
+		Order(query.Job.ID.Count().Desc(), group.Asc()).
+		Scan(&rows)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]resputil.FacetItem, len(rows))
+	for index, row := range rows {
+		items[index] = resputil.FacetItem{Value: strconv.Itoa(row.Value), Count: row.Count}
+	}
+	return items, nil
+}
+
+func scanJobGPUResourceFacet(
+	ctx context.Context,
+	scope jobListScope,
+	request *jobListQuery,
+	defaultDays int,
+) ([]resputil.FacetItem, error) {
+	items := make([]resputil.FacetItem, 0)
+	err := applyJobFilters(ctx, scope, request, defaultDays).
+		UnderlyingDB().
+		Joins("CROSS JOIN LATERAL jsonb_each_text(jobs.resources) AS resource(key, value)").
+		Where("resource.key LIKE ?", "nvidia.com/%").
+		Select("regexp_replace(resource.key, '^nvidia.com/', '') AS value, " +
+			"SUM(CASE WHEN resource.value ~ '^[0-9]+$' THEN resource.value::bigint ELSE 0 END) AS count").
+		Group("resource.key").
+		Order("count DESC, resource.key ASC").
+		Scan(&items).Error
+	return items, err
+}

--- a/backend/internal/handler/vcjob/vcjob.go
+++ b/backend/internal/handler/vcjob/vcjob.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -81,8 +80,11 @@ func (mgr *VolcanojobMgr) RegisterPublic(_ *gin.RouterGroup) {}
 
 func (mgr *VolcanojobMgr) RegisterProtected(g *gin.RouterGroup) {
 	g.GET("", mgr.GetSelfJobs)
+	g.GET("facets", mgr.GetSelfJobFacets)
 	g.GET("all", mgr.GetAllJobsInDays)
+	g.GET("all/facets", mgr.GetAllJobFacets)
 	g.GET("user/:username", mgr.GetUserJobsInDays)
+	g.GET("user/:username/facets", mgr.GetUserJobFacets)
 	g.GET("billing", mgr.GetSelfJobBilling)
 	g.GET("billing/all", mgr.GetAllJobBillingInDays)
 	g.GET("billing/user/:username", mgr.GetUserJobBillingInDays)
@@ -122,7 +124,9 @@ func (mgr *VolcanojobMgr) RegisterProtected(g *gin.RouterGroup) {
 
 func (mgr *VolcanojobMgr) RegisterAdmin(g *gin.RouterGroup) {
 	g.GET("", mgr.GetAllJobsInDays)
+	g.GET("facets", mgr.GetAllJobFacets)
 	g.GET("user/:username", mgr.GetUserJobsInDays)
+	g.GET("user/:username/facets", mgr.GetUserJobFacets)
 	g.GET("billing", mgr.GetAllJobBillingInDays)
 	g.GET("billing/user/:username", mgr.GetUserJobBillingInDays)
 	g.GET(":name/billing", mgr.GetJobBillingDetail)
@@ -582,6 +586,7 @@ type (
 		Locked                  bool               `json:"locked"`
 		PermanentLocked         bool               `json:"permanentLocked"`
 		LockedTimestamp         metav1.Time        `json:"lockedTimestamp"`
+		BilledPointsTotal       float64            `json:"billedPointsTotal"`
 	}
 
 	JobBillingResp struct {
@@ -599,25 +604,25 @@ type (
 //	@Accept			json
 //	@Produce		json
 //	@Security		Bearer
-//	@Success		200	{object}	resputil.Response[any]	"Volcano Job List"
+//	@Param			page		query	int	false	"Page number"
+//	@Param			page_size	query	int	false	"Page size, 1-200"
+//	@Param			sort		query	string	false	"Sort fields"
+//	@Param			search		query	string	false	"Search jobs"
+//	@Param			days		query	int	false	"Number of days to look back, -1 for all"
+//	@Param			job_type	query	[]string	false	"Job types" collectionFormat(multi)
+//	@Param			schedule_type	query	[]int	false	"Schedule types" collectionFormat(multi)
+//	@Param			status		query	[]string	false	"Job statuses" collectionFormat(multi)
+//	@Param			node		query	string	false	"Node name"
+//	@Success		200	{object}	resputil.Response[resputil.Page[JobResp]]	"Volcano Job List"
 //	@Failure		400	{object}	resputil.Response[any]	"Request parameter error"
 //	@Failure		500	{object}	resputil.Response[any]	"Other errors"
 //	@Router			/v1/vcjobs [get]
 func (mgr *VolcanojobMgr) GetSelfJobs(c *gin.Context) {
 	token := util.GetToken(c)
-
-	// TODO: add indexer to list jobs by user
-	j := query.Job
-	jobs, err := j.WithContext(c).Preload(j.Account).Preload(j.User).
-		Where(j.UserID.Eq(token.UserID), j.AccountID.Eq(token.AccountID)).Find()
-	if err != nil {
-		resputil.Error(c, err.Error(), resputil.NotSpecified)
-		return
-	}
-
-	jobList := convertJobResp(jobs)
-
-	resputil.Success(c, jobList)
+	mgr.listJobs(c, -1, jobListScope{
+		UserID:    &token.UserID,
+		AccountID: &token.AccountID,
+	})
 }
 
 // GetAllJobsInDays godoc
@@ -629,47 +634,136 @@ func (mgr *VolcanojobMgr) GetSelfJobs(c *gin.Context) {
 //	@Produce		json
 //	@Security		Bearer
 //	@Param			days	query		int						false	"Number of days to look back, default is 14"	default(14)
-//	@Success		200		{object}	resputil.Response[any]	"admin get Volcano Job List"
+//	@Param			page		query	int	false	"Page number"
+//	@Param			page_size	query	int	false	"Page size, 1-200"
+//	@Param			sort		query	string	false	"Sort fields"
+//	@Param			search		query	string	false	"Search jobs"
+//	@Param			job_type	query	[]string	false	"Job types" collectionFormat(multi)
+//	@Param			schedule_type	query	[]int	false	"Schedule types" collectionFormat(multi)
+//	@Param			status		query	[]string	false	"Job statuses" collectionFormat(multi)
+//	@Param			node		query	string	false	"Node name"
+//	@Success		200		{object}	resputil.Response[resputil.Page[JobResp]]	"admin get Volcano Job List"
 //	@Failure		400		{object}	resputil.Response[any]	"admin Request parameter error"
 //	@Failure		500		{object}	resputil.Response[any]	"Other errors"
 //	@Router			/v1/vcjobs/all [get]
 func (mgr *VolcanojobMgr) GetAllJobsInDays(c *gin.Context) {
-	type QueryParams struct {
-		Days int `form:"days"`
-	}
+	mgr.listJobs(c, allJobsDefaultDays, jobListScope{})
+}
 
-	var req QueryParams
-	if err := c.ShouldBindQuery(&req); err != nil {
-		resputil.BadRequestError(c, err.Error())
-		return
-	}
-
-	// Use default value of 7 if days parameter is not provided or is zero
-	days := 7
-	if req.Days > 0 {
-		days = req.Days
-	}
-
-	j := query.Job
-	q := j.WithContext(c).Preload(j.Account).Preload(query.Job.User)
-
-	// If days is -1, don't apply time filter (return all jobs)
-	// Otherwise apply the time filter for the specified days
-	if req.Days != -1 {
-		now := time.Now()
-		lookbackPeriod := now.AddDate(0, 0, -days)
-		q = q.Where(j.CreatedAt.Gte(lookbackPeriod))
-	}
-
-	jobs, err := q.Find()
+func (mgr *VolcanojobMgr) listJobs(c *gin.Context, defaultDays int, scope jobListScope) {
+	request, err := bindJobListQuery(c, true)
 	if err != nil {
-		resputil.Error(c, err.Error(), resputil.NotSpecified)
+		resputil.HandleError(c, err)
 		return
 	}
+	jobs, total, err := findJobs(c, scope, &request, defaultDays)
+	if err != nil {
+		resputil.HandleError(c, bizerr.Internal.DatabaseError.Wrap(err, "list jobs failed"))
+		return
+	}
+	resputil.Success(c, resputil.NewPage(
+		convertJobResp(jobs),
+		total,
+		request.Page,
+		request.PageSize,
+	))
+}
 
-	jobList := convertJobResp(jobs)
+// GetSelfJobFacets godoc
+//
+//	@Summary	Get job facets for the current user
+//	@Tags		VolcanoJob
+//	@Produce	json
+//	@Security	Bearer
+//	@Param		days	query	int	false	"Number of days to look back, -1 for all"
+//	@Param		search	query	string	false	"Search jobs"
+//	@Param		job_type	query	[]string	false	"Job types" collectionFormat(multi)
+//	@Param		schedule_type	query	[]int	false	"Schedule types" collectionFormat(multi)
+//	@Param		status	query	[]string	false	"Job statuses" collectionFormat(multi)
+//	@Param		node	query	string	false	"Node name"
+//	@Success	200	{object}	resputil.Response[resputil.FacetResponse]
+//	@Router		/v1/vcjobs/facets [get]
+func (mgr *VolcanojobMgr) GetSelfJobFacets(c *gin.Context) {
+	token := util.GetToken(c)
+	mgr.listJobFacets(c, -1, jobListScope{
+		UserID:    &token.UserID,
+		AccountID: &token.AccountID,
+	}, false)
+}
 
-	resputil.Success(c, jobList)
+// GetAllJobFacets godoc
+//
+//	@Summary	Get all visible job facets
+//	@Tags		VolcanoJob
+//	@Produce	json
+//	@Security	Bearer
+//	@Param		days	query	int	false	"Number of days to look back, -1 for all"
+//	@Param		search	query	string	false	"Search jobs"
+//	@Param		job_type	query	[]string	false	"Job types" collectionFormat(multi)
+//	@Param		schedule_type	query	[]int	false	"Schedule types" collectionFormat(multi)
+//	@Param		status	query	[]string	false	"Job statuses" collectionFormat(multi)
+//	@Param		node	query	string	false	"Node name"
+//	@Success	200	{object}	resputil.Response[resputil.FacetResponse]
+//	@Router		/v1/vcjobs/all/facets [get]
+func (mgr *VolcanojobMgr) GetAllJobFacets(c *gin.Context) {
+	mgr.listJobFacets(c, allJobsDefaultDays, jobListScope{}, true)
+}
+
+// GetUserJobFacets godoc
+//
+//	@Summary	Get job facets for a user
+//	@Tags		VolcanoJob
+//	@Produce	json
+//	@Security	Bearer
+//	@Param		username	path	string	true	"Username"
+//	@Param		days	query	int	false	"Number of days to look back, -1 for all"
+//	@Param		search	query	string	false	"Search jobs"
+//	@Param		job_type	query	[]string	false	"Job types" collectionFormat(multi)
+//	@Param		schedule_type	query	[]int	false	"Schedule types" collectionFormat(multi)
+//	@Param		status	query	[]string	false	"Job statuses" collectionFormat(multi)
+//	@Param		node	query	string	false	"Node name"
+//	@Success	200	{object}	resputil.Response[resputil.FacetResponse]
+//	@Router		/v1/vcjobs/user/{username}/facets [get]
+func (mgr *VolcanojobMgr) GetUserJobFacets(c *gin.Context) {
+	scope, ok := resolveJobUserScope(c)
+	if !ok {
+		return
+	}
+	mgr.listJobFacets(c, userJobsDefaultDays, scope, false)
+}
+
+func (mgr *VolcanojobMgr) listJobFacets(
+	c *gin.Context,
+	defaultDays int,
+	scope jobListScope,
+	includeOverview bool,
+) {
+	request, err := bindJobListQuery(c, false)
+	if err != nil {
+		resputil.HandleError(c, err)
+		return
+	}
+	facets, err := findJobFacets(c, scope, &request, defaultDays, includeOverview)
+	if err != nil {
+		resputil.HandleError(c, bizerr.Internal.DatabaseError.Wrap(err, "list job facets failed"))
+		return
+	}
+	resputil.Success(c, resputil.FacetResponse{Facets: facets})
+}
+
+func resolveJobUserScope(c *gin.Context) (jobListScope, bool) {
+	username := c.Param("username")
+	if username == "" {
+		resputil.HandleError(c, bizerr.BadRequest.MissingParameter.New("username is required"))
+		return jobListScope{}, false
+	}
+	u := query.User
+	targetUser, err := u.WithContext(c).Where(u.Name.Eq(username)).First()
+	if err != nil {
+		resputil.HandleError(c, bizerr.NotFound.DataBaseNotFound.Wrap(err, "user not found"))
+		return jobListScope{}, false
+	}
+	return jobListScope{UserID: &targetUser.ID}, true
 }
 
 func convertJobBillingResp(jobs []*model.Job) []JobBillingResp {
@@ -786,68 +880,26 @@ func (mgr *VolcanojobMgr) GetUserJobBillingInDays(c *gin.Context) {
 //	@Security		Bearer
 //	@Param			username	path		string					true	"Username"
 //	@Param			days		query		int						false	"Number of days to look back, default is 30, -1 for all"	default(30)
-//	@Success		200			{object}	resputil.Response[any]	"User's Job List"
+//	@Param			page		query		int					false	"Page number"
+//	@Param			page_size	query		int					false	"Page size, 1-200"
+//	@Param			sort		query		string				false	"Sort fields"
+//	@Param			search		query		string				false	"Search jobs"
+//	@Param			job_type	query		[]string			false	"Job types" collectionFormat(multi)
+//	@Param			schedule_type	query		[]int				false	"Schedule types" collectionFormat(multi)
+//	@Param			status		query		[]string			false	"Job statuses" collectionFormat(multi)
+//	@Param			node		query		string				false	"Node name"
+//	@Success		200			{object}	resputil.Response[resputil.Page[JobResp]]	"User's Job List"
 //	@Failure		400			{object}	resputil.Response[any]	"Request parameter error"
 //	@Failure		403			{object}	resputil.Response[any]	"Forbidden - insufficient permissions"
 //	@Failure		404			{object}	resputil.Response[any]	"User not found"
 //	@Failure		500			{object}	resputil.Response[any]	"Other errors"
 //	@Router			/v1/vcjobs/user/{username} [get]
 func (mgr *VolcanojobMgr) GetUserJobsInDays(c *gin.Context) {
-	// Get username from path parameter
-	username := c.Param("username")
-	if username == "" {
-		resputil.BadRequestError(c, "username is required")
+	scope, ok := resolveJobUserScope(c)
+	if !ok {
 		return
 	}
-
-	// Get days from query parameter
-	type QueryParams struct {
-		Days int `form:"days"`
-	}
-
-	var req QueryParams
-	if err := c.ShouldBindQuery(&req); err != nil {
-		resputil.BadRequestError(c, err.Error())
-		return
-	}
-
-	// Use default value of 30 days
-	days := 30
-	if req.Days > 0 {
-		days = req.Days
-	}
-
-	// Get target user information
-	u := query.User
-	targetUser, err := u.WithContext(c).Where(u.Name.Eq(username)).First()
-	if err != nil {
-		resputil.Error(c, "User not found", resputil.NotSpecified)
-		return
-	}
-
-	// Permission check:
-	// Both users and administrators can view jobs of any user
-	// No additional permission check needed beyond authentication
-
-	// Query jobs
-	j := query.Job
-	q := j.WithContext(c).Preload(j.Account).Preload(j.User).Where(j.UserID.Eq(targetUser.ID))
-
-	// Apply time filter if days is not -1
-	if req.Days != -1 {
-		now := time.Now()
-		lookbackPeriod := now.AddDate(0, 0, -days)
-		q = q.Where(j.CreatedAt.Gte(lookbackPeriod))
-	}
-
-	jobs, err := q.Find()
-	if err != nil {
-		resputil.Error(c, err.Error(), resputil.NotSpecified)
-		return
-	}
-
-	jobList := convertJobResp(jobs)
-	resputil.Success(c, jobList)
+	mgr.listJobs(c, userJobsDefaultDays, scope)
 }
 
 func convertJobResp(jobs []*model.Job) []JobResp {
@@ -879,11 +931,9 @@ func convertJobResp(jobs []*model.Job) []JobResp {
 			Locked:                  job.LockedTimestamp.After(utils.GetLocalTime()),
 			PermanentLocked:         utils.IsPermanentTime(job.LockedTimestamp),
 			LockedTimestamp:         metav1.NewTime(job.LockedTimestamp),
+			BilledPointsTotal:       service.ToDisplayPoints(job.BilledPointsTotal),
 		}
 	}
-	sort.Slice(jobList, func(i, j int) bool {
-		return jobList[i].CreationTimestamp.After(jobList[j].CreationTimestamp.Time)
-	})
 	return jobList
 }
 

--- a/backend/internal/resputil/response.go
+++ b/backend/internal/resputil/response.go
@@ -20,6 +20,29 @@ type List[T any] struct {
 	Items []T   `json:"items"`
 }
 
+type Page[T any] struct {
+	Items    []T   `json:"items"`
+	Total    int64 `json:"total"`
+	Page     int   `json:"page"`
+	PageSize int   `json:"page_size"`
+}
+
+func NewPage[T any](items []T, total int64, page, pageSize int) Page[T] {
+	if items == nil {
+		items = []T{}
+	}
+	return Page[T]{Items: items, Total: total, Page: page, PageSize: pageSize}
+}
+
+type FacetItem struct {
+	Value string `json:"value"`
+	Count int64  `json:"count"`
+}
+
+type FacetResponse struct {
+	Facets map[string][]FacetItem `json:"facets"`
+}
+
 // emit 内部统一发送方法，接收基础 ErrorCode
 func emit(c *gin.Context, httpCode int, bizCode bizerr.BizCode, msg string, data any) {
 	c.JSON(httpCode, Response[any]{

--- a/backend/internal/util/sql.go
+++ b/backend/internal/util/sql.go
@@ -1,0 +1,8 @@
+package util
+
+import "strings"
+
+func ContainsPattern(search string) string {
+	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(strings.ToLower(search))
+	return "%" + escaped + "%"
+}

--- a/backend/pkg/cleaner/clean_waiting.go
+++ b/backend/pkg/cleaner/clean_waiting.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"gorm.io/gen/field"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
@@ -14,6 +15,7 @@ import (
 	"github.com/raids-lab/crater/dao/model"
 	"github.com/raids-lab/crater/dao/query"
 	"github.com/raids-lab/crater/pkg/config"
+	"github.com/raids-lab/crater/pkg/utils"
 )
 
 type CancelWaitingJobsRequest struct {
@@ -44,11 +46,16 @@ func deleteUnscheduledJobs(c context.Context, clients *Clients, waitMinitues int
 	jobTypeStrs := lo.Map(jobTypes, func(jobType model.JobType, _ int) string {
 		return string(jobType)
 	})
+	now := utils.GetLocalTime()
 	jobDB := query.Job
 	jobs, err := jobDB.WithContext(c).Where(
+		field.Or(
+			jobDB.LockedTimestamp.IsNull(),
+			jobDB.LockedTimestamp.Lte(now),
+		),
 		jobDB.Status.Eq(string(batch.Pending)),
 		jobDB.JobType.In(jobTypeStrs...),
-		jobDB.CreationTimestamp.Lt(time.Now().Add(-time.Duration(waitMinitues)*time.Minute)),
+		jobDB.CreationTimestamp.Lt(now.Add(-time.Duration(waitMinitues)*time.Minute)),
 	).Find()
 
 	if err != nil {
@@ -70,6 +77,14 @@ func deleteUnscheduledJobs(c context.Context, clients *Clients, waitMinitues int
 			continue
 		}
 
+		latestJob, err := jobDB.WithContext(c).Where(jobDB.ID.Eq(job.ID)).First()
+		if err != nil {
+			klog.Errorf("Failed to get job %s from database: %v", job.JobName, err)
+			continue
+		}
+		if latestJob.LockedTimestamp.After(utils.GetLocalTime()) {
+			continue
+		}
 		if err := clients.Client.Delete(c, vcjob); err != nil {
 			klog.Errorf("Failed to delete job %s: %v", job.JobName, err)
 			continue

--- a/cli/cmd/job.go
+++ b/cli/cmd/job.go
@@ -100,18 +100,33 @@ func runAdminJobLs(cmd *cobra.Command, _ []string) error {
 }
 
 func readJobListOptions(cmd *cobra.Command, admin bool) (api.JobListOptions, error) {
+	listOptions, err := readJobPaginationOptions(cmd)
+	if err != nil {
+		return api.JobListOptions{}, err
+	}
 	all, _ := cmd.Flags().GetBool("all")
 	username, _ := cmd.Flags().GetString("user")
 	username = strings.TrimSpace(username)
 	days, _ := cmd.Flags().GetInt("days")
+	status, _ := cmd.Flags().GetString("status")
+	jobType, _ := cmd.Flags().GetString("type")
+	node, _ := cmd.Flags().GetString("node")
+	interactive, _ := cmd.Flags().GetBool("interactive")
+	batch, _ := cmd.Flags().GetBool("batch")
 	if err := validateJobListFilters(cmd); err != nil {
 		return api.JobListOptions{}, err
 	}
 	return api.JobListOptions{
-		All:      all,
-		Admin:    admin,
-		Username: username,
-		Days:     days,
+		ListOptions: listOptions,
+		All:         all,
+		Admin:       admin,
+		Username:    username,
+		Days:        days,
+		Status:      strings.TrimSpace(status),
+		JobType:     strings.TrimSpace(jobType),
+		Node:        strings.TrimSpace(node),
+		Interactive: interactive,
+		Batch:       batch,
 	}, nil
 }
 
@@ -120,19 +135,56 @@ func listJobs(cmd *cobra.Command, opts api.JobListOptions) error {
 	if err != nil {
 		return err
 	}
-	jobs, err := client.ListJobs(opts)
-	if err != nil {
-		return cliErrFromAPI(err)
+	fetchAll := opts.AllPages || hasLocalJobFilters(cmd)
+	var jobs api.Page[api.JobInfo]
+	var items []api.JobInfo
+	if fetchAll {
+		items, err = api.FetchAllPages(opts.ListOptions, func(listOptions api.ListOptions) (api.Page[api.JobInfo], error) {
+			next := opts
+			next.ListOptions = listOptions
+			return client.ListJobs(next)
+		})
+		if err != nil {
+			return cliErrFromAPI(err)
+		}
+	} else {
+		jobs, err = client.ListJobs(opts)
+		if err != nil {
+			return cliErrFromAPI(err)
+		}
+		items = jobs.Items
 	}
-	filtered, err := filterJobs(cmd, jobs)
+	items, err = filterJobs(cmd, items)
 	if err != nil {
 		return err
 	}
 	if outputJSON {
-		return output.WriteSuccessJSON(os.Stdout, output.SuccessEnvelope(map[string]interface{}{"jobs": filtered}))
+		if fetchAll {
+			return output.WriteSuccessJSON(os.Stdout, output.SuccessEnvelope(map[string]interface{}{
+				"jobs": items,
+			}))
+		}
+		return output.WriteSuccessJSON(os.Stdout, output.SuccessEnvelope(map[string]interface{}{
+			"jobs": items,
+			"pagination": map[string]interface{}{
+				"page":      jobs.Page,
+				"page_size": jobs.PageSize,
+				"total":     jobs.Total,
+			},
+		}))
 	}
-	printJobTable(filtered)
+	printJobTable(items)
+	if !fetchAll {
+		fmt.Printf("Page %d, %d items total\n", jobs.Page, jobs.Total)
+	}
 	return nil
+}
+
+func hasLocalJobFilters(cmd *cobra.Command) bool {
+	owner, _ := cmd.Flags().GetString("owner")
+	from, _ := cmd.Flags().GetString("from")
+	to, _ := cmd.Flags().GetString("to")
+	return strings.TrimSpace(owner) != "" || strings.TrimSpace(from) != "" || strings.TrimSpace(to) != ""
 }
 
 func runJobGet(_ *cobra.Command, args []string) error {
@@ -1344,6 +1396,7 @@ func init() {
 	jobLsCmd.Flags().String("to", "", "Filter createdAt until time, RFC3339 or YYYY-MM-DD")
 	jobLsCmd.Flags().Bool("interactive", false, "Only show interactive jobs")
 	jobLsCmd.Flags().Bool("batch", false, "Only show batch jobs")
+	addJobListFlags(jobLsCmd)
 
 	adminJobLsCmd.Flags().String("user", "", "List jobs for a username")
 	adminJobLsCmd.Flags().Int("days", 0, "Look back days; -1 means all")
@@ -1355,6 +1408,7 @@ func init() {
 	adminJobLsCmd.Flags().String("to", "", "Filter createdAt until time, RFC3339 or YYYY-MM-DD")
 	adminJobLsCmd.Flags().Bool("interactive", false, "Only show interactive jobs")
 	adminJobLsCmd.Flags().Bool("batch", false, "Only show batch jobs")
+	addJobListFlags(adminJobLsCmd)
 
 	addCreateCommonFlags(jobCreateJupyterCmd)
 	addCreateCommonFlags(jobCreateWebIDECmd)
@@ -1386,7 +1440,6 @@ func init() {
 	} {
 		cleanCmd.Flags().BoolP("yes", "y", false, "Run cleanup without confirmation")
 	}
-
 	completion.RegisterFlagValue([]string{"job", "ls"}, "status", staticValueCompleter(jobStatuses, nil))
 	completion.RegisterFlagValue([]string{"job", "ls"}, "type", staticValueCompleter(jobTypes, nil))
 	completion.RegisterFlagValue([]string{"admin", "job", "ls"}, "status", staticValueCompleter(jobStatuses, nil))

--- a/cli/cmd/job_list_options.go
+++ b/cli/cmd/job_list_options.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/raids-lab/crater/cli/internal/api"
+	"github.com/raids-lab/crater/cli/pkg/errorcodes"
+	"github.com/spf13/cobra"
+)
+
+const maxJobListPageSize = 200
+
+func addJobListFlags(cmd *cobra.Command) {
+	cmd.Flags().Int("page", 1, "Page number")
+	cmd.Flags().Int("page-size", 50, "Page size")
+	cmd.Flags().String("sort", "", "Sort fields")
+	cmd.Flags().Bool("all-pages", false, "Fetch all pages")
+}
+
+func readJobPaginationOptions(cmd *cobra.Command) (api.ListOptions, error) {
+	page, _ := cmd.Flags().GetInt("page")
+	pageSize, _ := cmd.Flags().GetInt("page-size")
+	sortFields, _ := cmd.Flags().GetString("sort")
+	allPages, _ := cmd.Flags().GetBool("all-pages")
+	issues := make([]usageIssue, 0, 2)
+	if page < 1 {
+		issues = append(issues, usageIssue{
+			Code:    errorcodes.ErrInvalidFlagValue,
+			Message: "page must be at least 1",
+			Field:   "page",
+		})
+	}
+	if pageSize < 1 || pageSize > maxJobListPageSize {
+		issues = append(issues, usageIssue{
+			Code:    errorcodes.ErrInvalidFlagValue,
+			Message: fmt.Sprintf("page-size must be between 1 and %d", maxJobListPageSize),
+			Field:   "page-size",
+		})
+	}
+	if len(issues) > 0 {
+		return api.ListOptions{}, errUsageFromIssues(issues)
+	}
+	return api.ListOptions{
+		Page:     page,
+		PageSize: pageSize,
+		Sort:     strings.TrimSpace(sortFields),
+		AllPages: allPages,
+	}, nil
+}

--- a/cli/internal/api/job.go
+++ b/cli/internal/api/job.go
@@ -1,13 +1,13 @@
 package api
 
 import (
-	"fmt"
 	"net/url"
+	"strconv"
 	"time"
 )
 
 type JobClient interface {
-	ListJobs(opts JobListOptions) ([]JobInfo, error)
+	ListJobs(opts JobListOptions) (Page[JobInfo], error)
 	GetJob(name string) (*JobDetail, error)
 	GetJobPods(name string) ([]PodDetail, error)
 	GetJobEvents(name string) ([]map[string]interface{}, error)
@@ -35,10 +35,16 @@ type JobClient interface {
 }
 
 type JobListOptions struct {
-	All      bool
-	Admin    bool
-	Username string
-	Days     int
+	ListOptions
+	All         bool
+	Admin       bool
+	Username    string
+	Days        int
+	Status      string
+	JobType     string
+	Node        string
+	Interactive bool
+	Batch       bool
 }
 
 type UserInfo struct {
@@ -92,6 +98,7 @@ type JobInfo struct {
 	Locked                  bool         `json:"locked"`
 	PermanentLocked         bool         `json:"permanentLocked"`
 	LockedTimestamp         time.Time    `json:"lockedTimestamp"`
+	BilledPointsTotal       float64      `json:"billedPointsTotal"`
 }
 
 type JobDetail struct {
@@ -209,41 +216,63 @@ type CleanLowGPUUsageRequest struct {
 	Util      int `json:"util"`
 }
 
-func (c *Client) ListJobs(opts JobListOptions) ([]JobInfo, error) {
+func (c *Client) ListJobs(opts JobListOptions) (Page[JobInfo], error) {
 	prefix := VCJobsPrefix
 	if opts.Admin {
 		prefix = AdminVCJobsPrefix
 	}
 	path := prefix
-	query := url.Values{}
+	values := jobListValues(opts)
 	switch {
 	case opts.Username != "":
 		path += "/user/" + url.PathEscape(opts.Username)
-		if opts.Days != 0 {
-			query.Set("days", fmt.Sprintf("%d", opts.Days))
-		}
 	case opts.All && !opts.Admin:
 		path += "/all"
-		if opts.Days != 0 {
-			query.Set("days", fmt.Sprintf("%d", opts.Days))
-		}
-	case opts.Admin:
-		if opts.Days != 0 {
-			query.Set("days", fmt.Sprintf("%d", opts.Days))
-		}
 	}
-	if encoded := query.Encode(); encoded != "" {
-		path += "?" + encoded
-	}
-	var result Response[[]JobInfo]
-	resp, err := c.httpClient.R().SetSuccessResult(&result).SetErrorResult(&result).Get(path)
+	var result Response[Page[JobInfo]]
+	resp, err := c.httpClient.R().
+		SetSuccessResult(&result).
+		SetErrorResult(&result).
+		SetQueryParamsFromValues(values).
+		Get(path)
 	if err != nil {
-		return nil, &NetworkError{Cause: err}
+		return Page[JobInfo]{}, &NetworkError{Cause: err}
 	}
 	if err := errorFromResponse(resp, result.Code, result.Message); err != nil {
-		return nil, err
+		return Page[JobInfo]{}, err
 	}
 	return result.Data, nil
+}
+
+func jobListValues(options JobListOptions) url.Values {
+	values := options.ListOptions.Values()
+	if options.Days != 0 {
+		values.Set("days", strconv.Itoa(options.Days))
+	}
+	if options.Status != "" {
+		values.Set("status", options.Status)
+	}
+	if options.Node != "" {
+		values.Set("node", options.Node)
+	}
+	types := selectedJobTypes(options)
+	for _, jobType := range types {
+		values.Add("job_type", jobType)
+	}
+	return values
+}
+
+func selectedJobTypes(options JobListOptions) []string {
+	if options.JobType != "" {
+		return []string{options.JobType}
+	}
+	if options.Interactive {
+		return []string{"jupyter", "webide"}
+	}
+	if options.Batch {
+		return []string{"custom", "pytorch", "tensorflow", "kuberay", "deepspeed", "openmpi"}
+	}
+	return nil
 }
 
 func (c *Client) GetJob(name string) (*JobDetail, error) {

--- a/cli/internal/api/job_test.go
+++ b/cli/internal/api/job_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/imroc/req/v3"
@@ -54,15 +55,15 @@ func TestJobClientAdminListRoute(t *testing.T) {
 		if got := r.URL.Query().Get("days"); got != "-1" {
 			t.Errorf("days = %q, want -1", got)
 		}
-		writeJobTestResponse(t, w, []interface{}{})
+		writeJobTestResponse(t, w, Page[JobInfo]{})
 	})
 
-	jobs, err := client.ListJobs(JobListOptions{Admin: true, Days: -1})
+	page, err := client.ListJobs(JobListOptions{Admin: true, Days: -1})
 	if err != nil {
 		t.Fatalf("ListJobs: %v", err)
 	}
-	if len(jobs) != 0 {
-		t.Fatalf("jobs = %#v, want empty", jobs)
+	if len(page.Items) != 0 {
+		t.Fatalf("jobs = %#v, want empty", page.Items)
 	}
 }
 
@@ -192,5 +193,74 @@ func TestJobClientDeleteAcceptsNullSuccessData(t *testing.T) {
 	}
 	if message != "" {
 		t.Fatalf("message = %q, want empty backend message", message)
+	}
+}
+
+func TestListJobsSendsPagingAndServerFilters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != VCJobListPath+"/all" {
+			t.Fatalf("unexpected path: %s", request.URL.Path)
+		}
+		query := request.URL.Query()
+		if query.Get("page") != "2" || query.Get("page_size") != "25" || query.Get("sort") != "-createdAt" {
+			t.Fatalf("unexpected paging query: %v", query)
+		}
+		if query.Get("days") != "14" || query.Get("status") != "Running" || query.Get("node") != "gpu-01" {
+			t.Fatalf("unexpected filters: %v", query)
+		}
+		if !reflect.DeepEqual(query["job_type"], []string{"jupyter", "webide"}) {
+			t.Fatalf("unexpected job types: %v", query["job_type"])
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(Response[Page[JobInfo]]{
+			Data: Page[JobInfo]{Items: []JobInfo{{Name: "job"}}, Total: 1, Page: 2, PageSize: 25},
+		})
+	}))
+	defer server.Close()
+
+	page, err := NewClient(server.URL).ListJobs(JobListOptions{
+		ListOptions: ListOptions{Page: 2, PageSize: 25, Sort: "-createdAt"},
+		All:         true,
+		Days:        14,
+		Status:      "Running",
+		Node:        "gpu-01",
+		Interactive: true,
+	})
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if page.Total != 1 || len(page.Items) != 1 {
+		t.Fatalf("unexpected page: %#v", page)
+	}
+}
+
+func TestFetchAllJobPagesSequentially(t *testing.T) {
+	requested := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		page := request.URL.Query().Get("page")
+		requested = append(requested, page)
+		items := map[string][]JobInfo{
+			"1": {{Name: "job-1"}, {Name: "job-2"}},
+			"2": {{Name: "job-3"}},
+		}[page]
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(Response[Page[JobInfo]]{
+			Data: Page[JobInfo]{Items: items, Total: 3, PageSize: 2},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	items, err := FetchAllPages(ListOptions{PageSize: 2}, func(options ListOptions) (Page[JobInfo], error) {
+		return client.ListJobs(JobListOptions{ListOptions: options})
+	})
+	if err != nil {
+		t.Fatalf("FetchAllPages returned error: %v", err)
+	}
+	if !reflect.DeepEqual(requested, []string{"1", "2"}) {
+		t.Fatalf("unexpected request order: %v", requested)
+	}
+	if len(items) != 3 {
+		t.Fatalf("unexpected items: %#v", items)
 	}
 }

--- a/cli/internal/api/pagination.go
+++ b/cli/internal/api/pagination.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"net/url"
+	"strconv"
+)
+
+const defaultCLIPageSize = 50
+
+type Page[T any] struct {
+	Items    []T   `json:"items"`
+	Total    int64 `json:"total"`
+	Page     int   `json:"page"`
+	PageSize int   `json:"page_size"`
+}
+
+type ListOptions struct {
+	Page     int
+	PageSize int
+	Sort     string
+	AllPages bool
+}
+
+func (options ListOptions) Normalize() ListOptions {
+	if options.Page < 1 {
+		options.Page = 1
+	}
+	if options.PageSize < 1 {
+		options.PageSize = defaultCLIPageSize
+	}
+	return options
+}
+
+func (options ListOptions) Values() url.Values {
+	options = options.Normalize()
+	values := url.Values{
+		"page":      {strconv.Itoa(options.Page)},
+		"page_size": {strconv.Itoa(options.PageSize)},
+	}
+	if options.Sort != "" {
+		values.Set("sort", options.Sort)
+	}
+	return values
+}
+
+func FetchAllPages[T any](
+	options ListOptions,
+	fetch func(ListOptions) (Page[T], error),
+) ([]T, error) {
+	options = options.Normalize()
+	options.Page = 1
+	items := make([]T, 0)
+	for {
+		page, err := fetch(options)
+		if err != nil {
+			return nil, err
+		}
+		if len(page.Items) == 0 {
+			return items, nil
+		}
+		items = append(items, page.Items...)
+		if int64(len(items)) >= page.Total {
+			return items, nil
+		}
+		options.Page++
+	}
+}

--- a/cli/internal/api/pagination_test.go
+++ b/cli/internal/api/pagination_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestListOptionsNormalize(t *testing.T) {
+	options := (ListOptions{}).Normalize()
+	if options.Page != 1 || options.PageSize != 50 {
+		t.Fatalf("unexpected defaults: %#v", options)
+	}
+}
+
+func TestListOptionsValues(t *testing.T) {
+	values := (ListOptions{Page: 2, PageSize: 100, Sort: "-createdAt"}).Values()
+	if values.Get("page") != "2" || values.Get("page_size") != "100" || values.Get("sort") != "-createdAt" {
+		t.Fatalf("unexpected query values: %v", values)
+	}
+}
+
+func TestFetchAllPagesSequentially(t *testing.T) {
+	requested := make([]int, 0, 3)
+	fetch := func(options ListOptions) (Page[int], error) {
+		requested = append(requested, options.Page)
+		items := map[int][]int{1: {1, 2}, 2: {3, 4}, 3: {5}}[options.Page]
+		return Page[int]{Items: items, Total: 5, Page: options.Page, PageSize: 2}, nil
+	}
+
+	items, err := FetchAllPages(ListOptions{PageSize: 2, AllPages: true}, fetch)
+	if err != nil {
+		t.Fatalf("FetchAllPages returned error: %v", err)
+	}
+	if !reflect.DeepEqual(requested, []int{1, 2, 3}) {
+		t.Fatalf("unexpected request order: %v", requested)
+	}
+	if !reflect.DeepEqual(items, []int{1, 2, 3, 4, 5}) {
+		t.Fatalf("unexpected items: %v", items)
+	}
+}
+
+func TestFetchAllPagesStopsOnEmptyPage(t *testing.T) {
+	requests := 0
+	fetch := func(options ListOptions) (Page[int], error) {
+		requests++
+		return Page[int]{Items: []int{}, Total: 10, Page: options.Page, PageSize: 2}, nil
+	}
+
+	items, err := FetchAllPages(ListOptions{AllPages: true}, fetch)
+	if err != nil {
+		t.Fatalf("FetchAllPages returned error: %v", err)
+	}
+	if requests != 1 || len(items) != 0 {
+		t.Fatalf("unexpected empty page handling: requests=%d items=%v", requests, items)
+	}
+}

--- a/frontend/src/components/badge/job-type-badge.tsx
+++ b/frontend/src/components/badge/job-type-badge.tsx
@@ -38,6 +38,18 @@ export const jobTypes = [
     value: 'pytorch',
     label: 'Pytorch',
   },
+  {
+    value: 'kuberay',
+    label: 'KubeRay',
+  },
+  {
+    value: 'deepspeed',
+    label: 'DeepSpeed',
+  },
+  {
+    value: 'openmpi',
+    label: 'OpenMPI',
+  },
 ]
 
 const getJobTypeLabel = (
@@ -77,6 +89,24 @@ const getJobTypeLabel = (
         label: 'Pytorch',
         color: 'text-highlight-rose bg-highlight-rose/10',
         description: 'Pytorch DDP 作业',
+      }
+    case JobType.KubeRay:
+      return {
+        label: 'KubeRay',
+        color: 'text-highlight-blue bg-highlight-blue/10',
+        description: 'KubeRay 作业',
+      }
+    case JobType.DeepSpeed:
+      return {
+        label: 'DeepSpeed',
+        color: 'text-highlight-orange bg-highlight-orange/10',
+        description: 'DeepSpeed 作业',
+      }
+    case JobType.OpenMPI:
+      return {
+        label: 'OpenMPI',
+        color: 'text-highlight-green bg-highlight-green/10',
+        description: 'OpenMPI 作业',
       }
     default:
       return {

--- a/frontend/src/components/job/overview/admin-jobs.tsx
+++ b/frontend/src/components/job/overview/admin-jobs.tsx
@@ -15,7 +15,7 @@
  */
 // i18n-processed-v1.1.0
 // Modified code
-import { UseQueryResult, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ColumnDef } from '@tanstack/react-table'
 import { t } from 'i18next'
 import { CalendarIcon, LockIcon, Trash2Icon } from 'lucide-react'
@@ -31,32 +31,34 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 
-import JobPhaseLabel, { jobPhases } from '@/components/badge/job-phase-badge'
-import JobTypeLabel, { jobTypes } from '@/components/badge/job-type-badge'
+import JobPhaseLabel from '@/components/badge/job-phase-badge'
+import JobTypeLabel from '@/components/badge/job-type-badge'
 import NodeBadges from '@/components/badge/node-badges'
 import ResourceBadges from '@/components/badge/resource-badges'
 import ScheduleTypeLabel from '@/components/badge/schedule-type-badge'
 import { BillingPointsBadge } from '@/components/custom/billing-points-badge'
 import { TimeDistance } from '@/components/custom/time-distance'
 import { JobActionsMenu } from '@/components/job/overview/job-actions-menu'
-import { scheduleTypes } from '@/components/job/statuses'
+import { getRemoteJobToolbarConfig } from '@/components/job/statuses'
 import { JobNameCell } from '@/components/label/job-name-label'
 import UserLabel from '@/components/label/user-label'
-import { DataTable } from '@/components/query-table'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
-import { DataTableToolbarConfig } from '@/components/query-table/toolbar'
+import { RemoteDataTable } from '@/components/query-table/remote'
+import { buildFacetQueryKey, buildRemoteQueryKey } from '@/components/query-table/remote-state'
 
-import { apiAdminGetJobBillingList } from '@/services/api/billing'
 import { apiAdminGetBillingStatus } from '@/services/api/system-config'
 import {
   IJobInfo,
   JobPhase,
   JobType,
   ScheduleType,
+  apiAdminGetJobFacets,
   apiAdminGetJobList,
   apiJobDeleteForAdmin,
   getDisplayJobPhase,
 } from '@/services/api/vcjob'
+
+import useRemoteTableState from '@/hooks/use-remote-table-state'
 
 import { isBillingVisibleForAdmin } from '@/utils/billing-visibility'
 import { logger } from '@/utils/loglevel'
@@ -74,7 +76,7 @@ export type StatusValue =
   | 'Preempted'
   | 'Deleted'
 
-type JobTableRow = IJobInfo & { billedPointsTotal?: number }
+type JobTableRow = IJobInfo
 
 export const getHeader = (key: string): string => {
   switch (key) {
@@ -108,7 +110,6 @@ export const getHeader = (key: string): string => {
 const AdminJobOverview = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
-  const [days, setDays] = useState(7)
   const [selectedJobs, setSelectedJobs] = useState<IJobInfo[]>([])
   const [isLockDialogOpen, setIsLockDialogOpen] = useState(false)
   const [isExtendDialogOpen, setIsExtendDialogOpen] = useState(false)
@@ -117,96 +118,42 @@ const AdminJobOverview = () => {
     queryFn: () => apiAdminGetBillingStatus().then((res) => res.data),
   })
   const billingVisible = isBillingVisibleForAdmin(billingStatus)
-
-  const toolbarConfig: DataTableToolbarConfig = {
-    globalSearch: {
-      enabled: true,
-    },
-    filterOptions: [
-      {
-        key: 'jobType',
-        title: t('jobs.filters.jobType'),
-        option: jobTypes,
-      },
-      {
-        key: 'scheduleType',
-        title: t('jobs.filters.scheduleType'),
-        option: scheduleTypes,
-      },
-      {
-        key: 'status',
-        title: t('jobs.filters.status'),
-        option: jobPhases,
-      },
-    ],
-    getHeader: getHeader,
-  }
+  const tableState = useRemoteTableState('admin_job_overview', {
+    sorting: [{ id: 'createdAt', desc: true }],
+    columnFilters: [{ id: 'days', value: ['7'] }],
+  })
+  const days = Number(
+    (
+      tableState.columnFilters.find(({ id }) => id === 'days')?.value as string[] | undefined
+    )?.[0] ?? 7
+  )
 
   const vcjobQuery = useQuery({
-    queryKey: ['admin', 'tasklist', 'job', days],
-    queryFn: () => apiAdminGetJobList(days),
-    select: (res) => res.data,
+    queryKey: buildRemoteQueryKey('admin-jobs', tableState.params),
+    queryFn: async ({ signal }) => (await apiAdminGetJobList(tableState.params, signal)).data,
+    placeholderData: keepPreviousData,
   })
-  const billingQuery = useQuery({
-    queryKey: ['admin', 'tasklist', 'job', 'billing', days],
-    queryFn: () => apiAdminGetJobBillingList(days),
-    select: (res) =>
-      res.data.reduce<Record<string, number>>((acc, item) => {
-        acc[item.jobName] = item.billedPointsTotal
-        return acc
-      }, {}),
-    enabled: billingVisible,
+  const facetsQuery = useQuery({
+    queryKey: buildFacetQueryKey('admin-jobs', tableState.params),
+    queryFn: async ({ signal }) => (await apiAdminGetJobFacets(tableState.params, signal)).data,
   })
-  const refetchVcjobQuery = vcjobQuery.refetch
-  const refetchBillingQuery = billingQuery.refetch
-  const refetchMergedQuery = useCallback(async () => {
-    const [vcjobResult] = await Promise.all([refetchVcjobQuery(), refetchBillingQuery()])
-    return vcjobResult
-  }, [refetchBillingQuery, refetchVcjobQuery])
-  const mergedVcjobQuery = useMemo(
-    () =>
-      ({
-        data: (vcjobQuery.data ?? []).map((job) => ({
-          ...job,
-          billedPointsTotal: billingQuery.data?.[job.jobName] ?? 0,
-        })),
-        isLoading: vcjobQuery.isLoading || (billingVisible && billingQuery.isLoading),
-        dataUpdatedAt: Math.max(
-          vcjobQuery.dataUpdatedAt,
-          billingVisible ? billingQuery.dataUpdatedAt : 0
-        ),
-        refetch: refetchMergedQuery,
-      }) as unknown as UseQueryResult<JobTableRow[], Error>,
-    [
-      billingVisible,
-      billingQuery.data,
-      billingQuery.dataUpdatedAt,
-      billingQuery.isLoading,
-      refetchMergedQuery,
-      vcjobQuery.data,
-      vcjobQuery.dataUpdatedAt,
-      vcjobQuery.isLoading,
-    ]
+  const toolbarConfig = useMemo(
+    () => ({ ...getRemoteJobToolbarConfig(facetsQuery.data), getHeader }),
+    [facetsQuery.data]
   )
 
   const refetchTaskList = useCallback(async () => {
     try {
       await Promise.all([
         new Promise((resolve) => setTimeout(resolve, 200)).then(() =>
-          queryClient.invalidateQueries({
-            queryKey: ['admin', 'tasklist', 'job', days],
-          })
+          queryClient.invalidateQueries({ queryKey: ['remote-list', 'admin-jobs'] })
         ),
-        new Promise((resolve) => setTimeout(resolve, 200)).then(() =>
-          queryClient.invalidateQueries({
-            queryKey: ['admin', 'tasklist', 'job', 'billing', days],
-          })
-        ),
+        queryClient.invalidateQueries({ queryKey: ['remote-list-facets', 'admin-jobs'] }),
       ])
     } catch (error) {
       logger.error('更新查询失败', error)
     }
-  }, [queryClient, days])
+  }, [queryClient])
 
   const { mutate: deleteTask } = useMutation({
     mutationFn: apiJobDeleteForAdmin,
@@ -287,6 +234,7 @@ const AdminJobOverview = () => {
       },
       {
         accessorKey: 'nodes',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getHeader('nodes')} />
         ),
@@ -297,6 +245,7 @@ const AdminJobOverview = () => {
       },
       {
         accessorKey: 'resources',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getHeader('resources')} />
         ),
@@ -377,14 +326,15 @@ const AdminJobOverview = () => {
 
   return (
     <>
-      <DataTable
+      <RemoteDataTable
         info={{
           title: t('adminJobOverview.title'),
           description: t('adminJobOverview.description'),
         }}
-        storageKey="admin_job_overview"
-        query={mergedVcjobQuery}
+        query={vcjobQuery}
+        state={tableState}
         columns={vcjobColumns}
+        getRowId={(row) => row.jobName}
         toolbarConfig={toolbarConfig}
         multipleHandlers={[
           {
@@ -432,7 +382,10 @@ const AdminJobOverview = () => {
         <Select
           value={days.toString()}
           onValueChange={(value) => {
-            setDays(parseInt(value))
+            tableState.setColumnFilters((current) => [
+              ...current.filter(({ id }) => id !== 'days'),
+              { id: 'days', value: [value] },
+            ])
           }}
         >
           <SelectTrigger className="bg-background h-9 pr-2 pl-3">
@@ -449,7 +402,7 @@ const AdminJobOverview = () => {
             ))}
           </SelectContent>
         </Select>
-      </DataTable>
+      </RemoteDataTable>
 
       {/* Duration Dialog for locking/unlocking jobs (batch operation) */}
       <DurationDialog

--- a/frontend/src/components/job/overview/custom-jobs.tsx
+++ b/frontend/src/components/job/overview/custom-jobs.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { UseQueryResult, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ColumnDef } from '@tanstack/react-table'
 import { Trash2Icon } from 'lucide-react'
 import { useMemo } from 'react'
@@ -30,23 +30,26 @@ import { BillingPointsBadge } from '@/components/custom/billing-points-badge'
 import { TimeDistance } from '@/components/custom/time-distance'
 import JobResourceSummary from '@/components/job/job-resource-summary'
 import { JobActionsMenu } from '@/components/job/overview/job-actions-menu'
-import { getHeader, jobToolbarConfig } from '@/components/job/statuses'
+import { getHeader, getRemoteJobToolbarConfig } from '@/components/job/statuses'
 import { JobNameCell } from '@/components/label/job-name-label'
-import { DataTable } from '@/components/query-table'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
+import { RemoteDataTable } from '@/components/query-table/remote'
+import { buildFacetQueryKey, buildRemoteQueryKey } from '@/components/query-table/remote-state'
 
-import { apiJobBillingList } from '@/services/api/billing'
 import { apiGetBillingStatus } from '@/services/api/system-config'
 import {
   IJobInfo,
   JobPhase,
   JobType,
   ScheduleType,
+  apiJobBatchFacets,
   apiJobBatchList,
   apiJobDelete,
+  batchJobTypes,
   getDisplayJobPhase,
-  isInteracitveJob,
 } from '@/services/api/vcjob'
+
+import useRemoteTableState from '@/hooks/use-remote-table-state'
 
 import { isBillingVisibleForUser } from '@/utils/billing-visibility'
 import { logger } from '@/utils/loglevel'
@@ -55,7 +58,7 @@ import { REFETCH_INTERVAL } from '@/lib/constants'
 
 import ListedNewJobButton from '../new-job-button'
 
-type JobTableRow = IJobInfo & { billedPointsTotal?: number }
+type JobTableRow = IJobInfo
 
 const VolcanoOverview = () => {
   const { t } = useTranslation()
@@ -65,54 +68,31 @@ const VolcanoOverview = () => {
     queryFn: () => apiGetBillingStatus().then((res) => res.data),
   })
   const billingVisible = isBillingVisibleForUser(billingStatus)
+  const tableState = useRemoteTableState('portal_batch_job_overview', {
+    sorting: [{ id: 'createdAt', desc: true }],
+  })
 
   const batchQuery = useQuery({
-    queryKey: ['job', 'batch'],
-    queryFn: apiJobBatchList,
-    select: (res) => res.data.filter((task) => !isInteracitveJob(task.jobType)),
+    queryKey: buildRemoteQueryKey('jobs-batch', tableState.params),
+    queryFn: async ({ signal }) => (await apiJobBatchList(tableState.params, signal)).data,
+    placeholderData: keepPreviousData,
     refetchInterval: REFETCH_INTERVAL,
   })
-  const billingQuery = useQuery({
-    queryKey: ['job', 'billing'],
-    queryFn: apiJobBillingList,
-    select: (res) =>
-      res.data.reduce<Record<string, number>>((acc, item) => {
-        acc[item.jobName] = item.billedPointsTotal
-        return acc
-      }, {}),
-    refetchInterval: REFETCH_INTERVAL,
-    enabled: billingVisible,
+  const facetsQuery = useQuery({
+    queryKey: buildFacetQueryKey('jobs-batch', tableState.params),
+    queryFn: async ({ signal }) => (await apiJobBatchFacets(tableState.params, signal)).data,
   })
-  const mergedBatchQuery = useMemo(
-    () =>
-      ({
-        data: (batchQuery.data ?? []).map((job) => ({
-          ...job,
-          billedPointsTotal: billingQuery.data?.[job.jobName] ?? 0,
-        })),
-        isLoading: batchQuery.isLoading || (billingVisible && billingQuery.isLoading),
-        dataUpdatedAt: Math.max(
-          batchQuery.dataUpdatedAt,
-          billingVisible ? billingQuery.dataUpdatedAt : 0
-        ),
-        refetch: batchQuery.refetch,
-      }) as unknown as UseQueryResult<JobTableRow[], Error>,
-    [
-      batchQuery.data,
-      batchQuery.dataUpdatedAt,
-      batchQuery.isLoading,
-      batchQuery.refetch,
-      billingVisible,
-      billingQuery.data,
-      billingQuery.dataUpdatedAt,
-      billingQuery.isLoading,
-    ]
+  const toolbarConfig = useMemo(
+    () => getRemoteJobToolbarConfig(facetsQuery.data, batchJobTypes),
+    [facetsQuery.data]
   )
 
   const refetchTaskList = async () => {
     try {
       // 并行发送所有异步请求
       await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['remote-list', 'jobs-batch'] }),
+        queryClient.invalidateQueries({ queryKey: ['remote-list-facets', 'jobs-batch'] }),
         queryClient.invalidateQueries({ queryKey: ['job'] }),
         queryClient.invalidateQueries({ queryKey: ['job', 'billing'] }),
         queryClient.invalidateQueries({ queryKey: ['aitask', 'quota'] }),
@@ -172,6 +152,7 @@ const VolcanoOverview = () => {
       },
       {
         accessorKey: 'nodes',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getHeader('nodes')} />
         ),
@@ -182,6 +163,7 @@ const VolcanoOverview = () => {
       },
       {
         accessorKey: 'resources',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getHeader('resources')} />
         ),
@@ -242,15 +224,16 @@ const VolcanoOverview = () => {
   )
 
   return (
-    <DataTable
+    <RemoteDataTable
       info={{
         title: '自定义作业',
         description: '使用自定义作业进行训练、推理等任务',
       }}
-      storageKey="portal_batch_job_overview"
-      query={mergedBatchQuery}
+      query={batchQuery}
+      state={tableState}
       columns={batchColumns}
-      toolbarConfig={jobToolbarConfig}
+      getRowId={(row) => row.jobName}
+      toolbarConfig={toolbarConfig}
       briefChildren={<JobResourceSummary />}
       multipleHandlers={[
         {
@@ -276,7 +259,7 @@ const VolcanoOverview = () => {
         <DocsButton title="查看文档" url="quick-start/batchprocess" />
         <ListedNewJobButton mode="custom" />
       </div>
-    </DataTable>
+    </RemoteDataTable>
   )
 }
 

--- a/frontend/src/components/job/overview/emias-jobs.tsx
+++ b/frontend/src/components/job/overview/emias-jobs.tsx
@@ -154,7 +154,6 @@ interface ColocateJobInfo extends IJobInfo {
   id: number
   profileStatus: string
   priority: string
-  billedPointsTotal?: number
 }
 
 const ColocateOverview = () => {
@@ -168,9 +167,9 @@ const ColocateOverview = () => {
 
   const batchQuery = useQuery({
     queryKey: ['job', 'batch'],
-    queryFn: apiJobBatchList,
+    queryFn: () => apiJobBatchList({ page: 1, page_size: 200, filters: {} }),
     select: (res) =>
-      res.data
+      res.data.items
         .filter((task) => task.jobType !== JobType.Jupyter)
         .sort((a, b) => b.createdAt.localeCompare(a.createdAt)) as unknown as ColocateJobInfo[],
     refetchInterval: REFETCH_INTERVAL,

--- a/frontend/src/components/job/statuses.ts
+++ b/frontend/src/components/job/statuses.ts
@@ -20,6 +20,7 @@ import { jobTypes } from '@/components/badge/job-type-badge'
 import { DataTableToolbarConfig } from '@/components/query-table/toolbar'
 
 import { ScheduleType } from '@/services/api/vcjob'
+import type { IFacetResponse } from '@/services/types'
 
 export const scheduleTypes = [
   {
@@ -90,4 +91,39 @@ export const jobToolbarConfig: DataTableToolbarConfig = {
     },
   ],
   getHeader: getHeader,
+}
+
+export function getRemoteJobToolbarConfig(
+  facets?: IFacetResponse,
+  allowedJobTypes?: ReadonlyArray<string>
+): DataTableToolbarConfig {
+  const facetKeys: Record<string, string> = {
+    jobType: 'job_type',
+    scheduleType: 'schedule_type',
+    status: 'status',
+  }
+  return {
+    globalSearch: { enabled: true, placeholder: t('jobs.toolbar.searchPlaceholder') },
+    filterOptions: jobToolbarConfig.filterOptions.map((filter) => ({
+      ...filter,
+      remoteFacets: true,
+      option: filter.option
+        ?.filter(
+          (option) =>
+            filter.key !== 'jobType' ||
+            !allowedJobTypes ||
+            allowedJobTypes.includes(String(option.value))
+        )
+        .map((option) => {
+          const count = facets?.facets[facetKeys[filter.key]]?.find(
+            (item) => item.value === String(option.value)
+          )?.count
+          return {
+            ...option,
+            count: facets ? (count ?? 0) : undefined,
+          }
+        }),
+    })),
+    getHeader,
+  }
 }

--- a/frontend/src/components/query-table/faceted-filter.tsx
+++ b/frontend/src/components/query-table/faceted-filter.tsx
@@ -39,6 +39,7 @@ export interface DataTableFacetedFilterOption {
   label: string
   value: string
   icon?: React.ComponentType<{ className?: string }>
+  count?: number
 }
 
 interface DataTableFacetedFilterProps<TData, TValue> {
@@ -46,6 +47,7 @@ interface DataTableFacetedFilterProps<TData, TValue> {
   title?: string
   options?: DataTableFacetedFilterOption[]
   defaultValues?: string[]
+  remoteFacets?: boolean
 }
 
 export function DataTableFacetedFilter<TData, TValue>({
@@ -53,6 +55,7 @@ export function DataTableFacetedFilter<TData, TValue>({
   title,
   options: rawOptions,
   defaultValues,
+  remoteFacets = false,
 }: DataTableFacetedFilterProps<TData, TValue>) {
   const { t } = useTranslation()
   const facets = column?.getFacetedUniqueValues()
@@ -94,7 +97,7 @@ export function DataTableFacetedFilter<TData, TValue>({
           variant="outline"
           size="sm"
           className="h-9 border-dashed"
-          disabled={facets?.size === 0}
+          disabled={!remoteFacets && facets?.size === 0}
         >
           <ListFilter className="size-4" />
           <span className="text-xs">{title}</span>
@@ -135,9 +138,16 @@ export function DataTableFacetedFilter<TData, TValue>({
             <CommandEmpty>{t('dataTableFacetedFilter.noResults')}</CommandEmpty>
             <CommandGroup>
               {options
-                .filter((option) => 0 < (facets?.get(option.value) || 0))
+                .filter((option) =>
+                  remoteFacets
+                    ? option.count === undefined ||
+                      option.count > 0 ||
+                      selectedValues.has(option.value)
+                    : 0 < (facets?.get(option.value) || 0)
+                )
                 .map((option) => {
                   const isSelected = selectedValues.has(option.value)
+                  const count = remoteFacets ? option.count : facets?.get(option.value)
                   return (
                     <CommandItem
                       key={option.value}
@@ -163,9 +173,9 @@ export function DataTableFacetedFilter<TData, TValue>({
                       </div>
                       {option.icon && <option.icon className="text-muted-foreground mr-2 size-4" />}
                       <span>{option.label}</span>
-                      {facets?.get(option.value) && (
+                      {count !== undefined && (
                         <span className="ml-auto flex size-4 items-center justify-center font-mono text-xs">
-                          {facets.get(option.value)}
+                          {count}
                         </span>
                       )}
                     </CommandItem>

--- a/frontend/src/components/query-table/index.tsx
+++ b/frontend/src/components/query-table/index.tsx
@@ -23,7 +23,6 @@ import {
   SortingState,
   Updater,
   VisibilityState,
-  flexRender,
   getCoreRowModel,
   getFacetedRowModel,
   getFacetedUniqueValues,
@@ -32,31 +31,16 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { GridIcon } from 'lucide-react'
 import React, { useMemo, useState } from 'react'
-import { useTranslation } from 'react-i18next'
 import { useLocalStorage } from 'usehooks-ts'
 
-import { Card, CardContent } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
-
-import LoadingCircleIcon from '@/components/icon/loading-circle-icon'
-import PageTitle from '@/components/layout/page-title'
 
 import usePaginationWithStorage from '@/hooks/use-pagination-with-storage'
 
-import { cn } from '@/lib/utils'
-
-import { DataTablePagination, MultipleHandler } from './pagination'
-import { DataTableToolbar, DataTableToolbarConfig } from './toolbar'
+import { type MultipleHandler } from './pagination'
+import { DataTableShell } from './shell'
+import { type DataTableToolbarConfig } from './toolbar'
 
 const resolveUpdater = <TState,>(updater: Updater<TState>, state: TState) => {
   return typeof updater === 'function' ? (updater as (state: TState) => TState)(state) : updater
@@ -78,7 +62,7 @@ interface DataTableProps<TData, TValue> extends React.HTMLAttributes<HTMLDivElem
   initialColumnVisibility?: VisibilityState
 }
 
-export function DataTable<TData, TValue>({
+export function LocalDataTable<TData, TValue>({
   info,
   storageKey,
   query,
@@ -91,7 +75,6 @@ export function DataTable<TData, TValue>({
   className,
   initialColumnVisibility = {},
 }: DataTableProps<TData, TValue>) {
-  const { t } = useTranslation()
   const [rowSelection, setRowSelection] = useState({})
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(initialColumnVisibility)
   const [columnFilters, setColumnFilters] = useLocalStorage<ColumnFiltersState>(
@@ -100,12 +83,7 @@ export function DataTable<TData, TValue>({
   )
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
-  const { data: queryData, isLoading, dataUpdatedAt, refetch } = query
-  const updatedAt = new Date(dataUpdatedAt).toLocaleString([], {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  })
+  const { data: queryData, error, isError, isLoading, dataUpdatedAt, refetch } = query
   const [pagination, setPagination] = usePaginationWithStorage(storageKey)
 
   const data = useMemo(() => {
@@ -204,88 +182,23 @@ export function DataTable<TData, TValue>({
   }, [pageCount, pagination.pageIndex, setPagination])
 
   return (
-    <div className={cn('flex flex-col gap-4', className)}>
-      {info && (
-        <PageTitle title={info.title} description={info.description}>
-          {children}
-        </PageTitle>
-      )}
-      {briefChildren && <>{briefChildren}</>}
-      {toolbarConfig && (
-        <DataTableToolbar table={table} config={toolbarConfig} isLoading={query.isLoading}>
-          {!info && <>{children}</>}
-        </DataTableToolbar>
-      )}
-      <Card className="overflow-hidden rounded-md p-0 shadow-xs">
-        <CardContent className="p-0">
-          <Table>
-            <TableHeader>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <TableRow key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    return (
-                      <TableHead
-                        key={header.id}
-                        colSpan={header.colSpan}
-                        className="text-muted-foreground px-4"
-                      >
-                        {header.isPlaceholder
-                          ? null
-                          : flexRender(header.column.columnDef.header, header.getContext())}
-                      </TableHead>
-                    )
-                  })}
-                </TableRow>
-              ))}
-            </TableHeader>
-            <TableBody>
-              {table.getRowModel().rows?.length ? (
-                table.getRowModel().rows.map((row) => (
-                  <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id} className="pl-4">
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))
-              ) : (
-                <>
-                  {isLoading ? (
-                    <TableRow>
-                      <TableCell colSpan={table.getAllColumns().length} className="h-60">
-                        <LoadingCircleIcon />
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    <TableRow>
-                      <TableCell
-                        colSpan={table.getAllColumns().length}
-                        className="text-muted-foreground/85 h-60 text-center hover:bg-transparent"
-                      >
-                        <div className="flex flex-col items-center justify-center py-16">
-                          <div className="bg-muted mb-4 rounded-full p-3">
-                            <GridIcon className="h-6 w-6" />
-                          </div>
-                          <p className="select-none">
-                            {withI18n ? t('dataTable.noData') : '暂无数据'}
-                          </p>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </>
-              )}
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
-      <DataTablePagination
-        table={table}
-        refetch={() => void refetch()}
-        updatedAt={updatedAt}
-        multipleHandlers={multipleHandlers}
-      />
-    </div>
+    <DataTableShell
+      table={table}
+      info={info}
+      toolbarConfig={toolbarConfig}
+      multipleHandlers={multipleHandlers}
+      briefChildren={briefChildren}
+      withI18n={withI18n}
+      className={className}
+      isLoading={isLoading}
+      isError={isError}
+      errorMessage={error?.message}
+      refetch={() => void refetch()}
+      dataUpdatedAt={dataUpdatedAt}
+    >
+      {children}
+    </DataTableShell>
   )
 }
+
+export const DataTable = LocalDataTable

--- a/frontend/src/components/query-table/pagination.tsx
+++ b/frontend/src/components/query-table/pagination.tsx
@@ -124,6 +124,7 @@ interface DataTablePaginationProps<TData> {
   table: Table<TData>
   multipleHandlers?: MultipleHandler<TData>[]
   pageSizeOptions?: number[]
+  totalItems?: number
 }
 
 export function DataTablePagination<TData>({
@@ -132,6 +133,7 @@ export function DataTablePagination<TData>({
   table,
   multipleHandlers,
   pageSizeOptions = [10, 20, 50, 100, 200],
+  totalItems,
 }: DataTablePaginationProps<TData>) {
   const { t } = useTranslation()
 
@@ -205,7 +207,7 @@ export function DataTablePagination<TData>({
         <Select
           value={`${table.getState().pagination.pageSize}`}
           onValueChange={(value) => {
-            table.setPageSize(Number(value))
+            table.setPagination({ pageIndex: 0, pageSize: Number(value) })
           }}
         >
           <SelectTrigger className="bg-background h-9 w-[100px] pr-2 pl-3 text-xs">
@@ -225,14 +227,14 @@ export function DataTablePagination<TData>({
           {table.getFilteredSelectedRowModel().rows.length === 0 ? (
             <>
               {t('dataTablePagination.totalItems', {
-                count: table.getFilteredRowModel().rows.length,
+                count: totalItems ?? table.getFilteredRowModel().rows.length,
               })}
             </>
           ) : (
             <>
               {t('dataTablePagination.selectedItems', {
                 selected: table.getFilteredSelectedRowModel().rows.length,
-                total: table.getFilteredRowModel().rows.length,
+                total: totalItems ?? table.getFilteredRowModel().rows.length,
               })}
             </>
           )}

--- a/frontend/src/components/query-table/remote-state.ts
+++ b/frontend/src/components/query-table/remote-state.ts
@@ -1,0 +1,91 @@
+import type { ColumnFiltersState, PaginationState, SortingState } from '@tanstack/react-table'
+
+export interface RemoteTableParams {
+  page: number
+  page_size: number
+  sort?: string
+  search?: string
+  filters: Record<string, string[]>
+}
+
+interface RemoteTableState {
+  pagination: PaginationState
+  sorting: SortingState
+  search: string
+  filters: ColumnFiltersState
+}
+
+export function normalizeRemoteTableParams(state: RemoteTableState): RemoteTableParams {
+  const sort = state.sorting
+    .slice(0, 3)
+    .map(({ id, desc }) => `${desc ? '-' : ''}${id}`)
+    .join(',')
+  const filters = Object.fromEntries(
+    state.filters
+      .map(({ id, value }) => [id, normalizeFilterValue(value)] as const)
+      .filter(([, values]) => values.length > 0)
+      .sort(([left], [right]) => left.localeCompare(right))
+  )
+  const search = state.search.trim()
+
+  return {
+    page: state.pagination.pageIndex + 1,
+    page_size: state.pagination.pageSize,
+    ...(sort ? { sort } : {}),
+    ...(search ? { search } : {}),
+    filters,
+  }
+}
+
+export function buildRemoteSearchParams(params: RemoteTableParams): URLSearchParams {
+  const searchParams = new URLSearchParams()
+  searchParams.set('page', String(params.page))
+  searchParams.set('page_size', String(params.page_size))
+  if (params.sort) searchParams.set('sort', params.sort)
+  if (params.search) searchParams.set('search', params.search)
+  appendFilters(searchParams, params.filters)
+  return searchParams
+}
+
+export function buildFacetSearchParams(params: RemoteTableParams): URLSearchParams {
+  const searchParams = new URLSearchParams()
+  if (params.search) searchParams.set('search', params.search)
+  appendFilters(searchParams, params.filters)
+  return searchParams
+}
+
+export function buildRemoteQueryKey(resource: string, params: RemoteTableParams) {
+  return ['remote-list', resource, params] as const
+}
+
+export function buildFacetQueryKey(resource: string, params: RemoteTableParams) {
+  return [
+    'remote-list-facets',
+    resource,
+    { search: params.search ?? '', filters: params.filters },
+  ] as const
+}
+
+export function getLastPageIndex(total: number, pageSize: number): number {
+  return Math.max(Math.ceil(total / pageSize) - 1, 0)
+}
+
+export function shouldClearRemoteSelection(
+  previous: RemoteTableParams,
+  next: RemoteTableParams
+): boolean {
+  return JSON.stringify(previous) !== JSON.stringify(next)
+}
+
+function normalizeFilterValue(value: unknown): string[] {
+  const values = Array.isArray(value) ? value : value === undefined || value === '' ? [] : [value]
+  return values.map(String).filter(Boolean).sort()
+}
+
+function appendFilters(searchParams: URLSearchParams, filters: Record<string, string[]>) {
+  for (const key of Object.keys(filters).sort()) {
+    for (const value of filters[key]) {
+      searchParams.append(key, value)
+    }
+  }
+}

--- a/frontend/src/components/query-table/remote.tsx
+++ b/frontend/src/components/query-table/remote.tsx
@@ -1,0 +1,158 @@
+import type { UseQueryResult } from '@tanstack/react-query'
+import type { ColumnDef, OnChangeFn, VisibilityState } from '@tanstack/react-table'
+import { getCoreRowModel, useReactTable } from '@tanstack/react-table'
+import type { HTMLAttributes } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import { Checkbox } from '@/components/ui/checkbox'
+
+import type { IPage } from '@/services/types'
+
+import type { RemoteTableState } from '@/hooks/use-remote-table-state'
+
+import { type MultipleHandler } from './pagination'
+import { getLastPageIndex, shouldClearRemoteSelection } from './remote-state'
+import { DataTableShell } from './shell'
+import { type DataTableToolbarConfig } from './toolbar'
+
+interface RemoteDataTableProps<TData, TValue> extends HTMLAttributes<HTMLDivElement> {
+  info?: {
+    title?: string
+    description: string
+  }
+  query: UseQueryResult<IPage<TData>, Error>
+  state: RemoteTableState
+  columns: ColumnDef<TData, TValue>[]
+  getRowId: (row: TData) => string
+  toolbarConfig?: DataTableToolbarConfig
+  multipleHandlers?: MultipleHandler<TData>[]
+  briefChildren?: React.ReactNode
+  withI18n?: boolean
+  initialColumnVisibility?: VisibilityState
+}
+
+export function RemoteDataTable<TData, TValue>({
+  info,
+  query,
+  state,
+  columns,
+  getRowId,
+  toolbarConfig,
+  multipleHandlers,
+  children,
+  briefChildren,
+  withI18n = false,
+  className,
+  initialColumnVisibility = {},
+}: RemoteDataTableProps<TData, TValue>) {
+  const [rowSelection, setRowSelection] = useState({})
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(initialColumnVisibility)
+  const data = query.data?.items ?? []
+  const total = query.data?.total ?? 0
+  const pageIndex = state.pagination.pageIndex
+  const pageSize = state.pagination.pageSize
+  const setPagination = state.setPagination
+  const previousParams = useRef(state.params)
+
+  const columnsWithSelection = useMemo(() => {
+    if (!multipleHandlers?.length) return columns
+    return [
+      {
+        id: 'select',
+        header: ({ table }) => (
+          <Checkbox
+            checked={table.getIsAllPageRowsSelected()}
+            onCheckedChange={(value) => table.toggleAllPageRowsSelected(Boolean(value))}
+            hidden={table.getRowModel().rows.length === 0}
+          />
+        ),
+        cell: ({ row }) => (
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(value) => row.toggleSelected(Boolean(value))}
+          />
+        ),
+        enableSorting: false,
+        enableHiding: false,
+      } satisfies ColumnDef<TData>,
+      ...columns,
+    ]
+  }, [columns, multipleHandlers])
+
+  const handleGlobalFilterChange: OnChangeFn<string> = (updater) => {
+    const next = typeof updater === 'function' ? updater(state.search) : updater
+    state.setSearch(next)
+  }
+
+  const table = useReactTable({
+    data,
+    columns: columnsWithSelection,
+    getRowId,
+    pageCount: Math.ceil(total / state.pagination.pageSize),
+    state: {
+      pagination: state.pagination,
+      sorting: state.sorting,
+      columnFilters: state.columnFilters,
+      globalFilter: state.search,
+      columnVisibility,
+      rowSelection,
+    },
+    enableRowSelection: Boolean(multipleHandlers?.length),
+    enableMultiSort: true,
+    maxMultiSortColCount: 3,
+    autoResetPageIndex: false,
+    manualPagination: true,
+    manualSorting: true,
+    manualFiltering: true,
+    onPaginationChange: state.setPagination,
+    onSortingChange: state.setSorting,
+    onColumnFiltersChange: state.setColumnFilters,
+    onGlobalFilterChange: handleGlobalFilterChange,
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  useEffect(() => {
+    if (shouldClearRemoteSelection(previousParams.current, state.params)) {
+      setRowSelection({})
+    }
+    previousParams.current = state.params
+  }, [state.params])
+
+  useEffect(() => {
+    if (!query.data || query.isError || query.isFetching || query.isPlaceholderData) return
+    const lastPageIndex = getLastPageIndex(query.data.total, pageSize)
+    if (pageIndex > lastPageIndex) {
+      setPagination((current) => ({ ...current, pageIndex: lastPageIndex }))
+    }
+  }, [
+    pageIndex,
+    pageSize,
+    query.data,
+    query.isError,
+    query.isFetching,
+    query.isPlaceholderData,
+    setPagination,
+  ])
+
+  return (
+    <DataTableShell
+      table={table}
+      info={info}
+      toolbarConfig={toolbarConfig}
+      multipleHandlers={multipleHandlers}
+      briefChildren={briefChildren}
+      withI18n={withI18n}
+      className={className}
+      isLoading={query.isLoading}
+      isError={query.isError}
+      errorMessage={query.error?.message}
+      refetch={() => void query.refetch()}
+      dataUpdatedAt={query.dataUpdatedAt}
+      totalItems={total}
+    >
+      {children}
+    </DataTableShell>
+  )
+}

--- a/frontend/src/components/query-table/shell.tsx
+++ b/frontend/src/components/query-table/shell.tsx
@@ -1,0 +1,157 @@
+import type { Table as TableInstance } from '@tanstack/react-table'
+import { flexRender } from '@tanstack/react-table'
+import { GridIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import LoadingCircleIcon from '@/components/icon/loading-circle-icon'
+import PageTitle from '@/components/layout/page-title'
+
+import { cn } from '@/lib/utils'
+
+import { DataTablePagination, type MultipleHandler } from './pagination'
+import { DataTableToolbar, type DataTableToolbarConfig } from './toolbar'
+
+interface DataTableShellProps<TData> {
+  table: TableInstance<TData>
+  info?: {
+    title?: string
+    description: string
+  }
+  toolbarConfig?: DataTableToolbarConfig
+  multipleHandlers?: MultipleHandler<TData>[]
+  children?: ReactNode
+  briefChildren?: ReactNode
+  withI18n: boolean
+  className?: string
+  isLoading: boolean
+  isError: boolean
+  errorMessage?: string
+  refetch: () => void
+  dataUpdatedAt: number
+  totalItems?: number
+}
+
+export function DataTableShell<TData>({
+  table,
+  info,
+  toolbarConfig,
+  multipleHandlers,
+  children,
+  briefChildren,
+  withI18n,
+  className,
+  isLoading,
+  isError,
+  errorMessage,
+  refetch,
+  dataUpdatedAt,
+  totalItems,
+}: DataTableShellProps<TData>) {
+  const { t } = useTranslation()
+  const updatedAt = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      })
+    : '--'
+
+  return (
+    <div className={cn('flex flex-col gap-4', className)}>
+      {info && (
+        <PageTitle title={info.title} description={info.description}>
+          {children}
+        </PageTitle>
+      )}
+      {briefChildren && <>{briefChildren}</>}
+      {toolbarConfig && (
+        <DataTableToolbar table={table} config={toolbarConfig} isLoading={isLoading}>
+          {!info && <>{children}</>}
+        </DataTableToolbar>
+      )}
+      <Card className="overflow-hidden rounded-md p-0 shadow-xs">
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <TableHead
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      className="text-muted-foreground px-4"
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows.length > 0 ? (
+                table.getRowModel().rows.map((row) => (
+                  <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id} className="pl-4">
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={table.getAllColumns().length} className="h-60">
+                    <LoadingCircleIcon />
+                  </TableCell>
+                </TableRow>
+              ) : isError ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={table.getAllColumns().length}
+                    className="text-destructive h-60 text-center hover:bg-transparent"
+                  >
+                    {errorMessage || t('common.error')}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                <TableRow>
+                  <TableCell
+                    colSpan={table.getAllColumns().length}
+                    className="text-muted-foreground/85 h-60 text-center hover:bg-transparent"
+                  >
+                    <div className="flex flex-col items-center justify-center py-16">
+                      <div className="bg-muted mb-4 rounded-full p-3">
+                        <GridIcon className="h-6 w-6" />
+                      </div>
+                      <p className="select-none">{withI18n ? t('dataTable.noData') : '暂无数据'}</p>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+      <DataTablePagination
+        table={table}
+        refetch={refetch}
+        updatedAt={updatedAt}
+        multipleHandlers={multipleHandlers}
+        totalItems={totalItems}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/query-table/toolbar.tsx
+++ b/frontend/src/components/query-table/toolbar.tsx
@@ -30,6 +30,7 @@ export type DataTableToolbarConfig = {
     title: string
     option?: DataTableFacetedFilterOption[]
     defaultValues?: string[]
+    remoteFacets?: boolean
   }[]
   getHeader: (key: string) => string
 } & (
@@ -98,6 +99,7 @@ export function DataTableToolbar<TData>({
                 title={filterOption.title}
                 options={filterOption.option}
                 defaultValues={filterOption.defaultValues}
+                remoteFacets={filterOption.remoteFacets}
               />
             )
         )}

--- a/frontend/src/components/user/user-jobs.tsx
+++ b/frontend/src/components/user/user-jobs.tsx
@@ -6,7 +6,7 @@
  * to show the user column (since we're already viewing a specific user's jobs)
  * and in the user view, we don't show the name column.
  */
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ColumnDef } from '@tanstack/react-table'
 import { Trash2Icon } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
@@ -20,22 +20,25 @@ import ResourceBadges from '@/components/badge/resource-badges'
 import ScheduleTypeLabel from '@/components/badge/schedule-type-badge'
 import { TimeDistance } from '@/components/custom/time-distance'
 import { JobActionsMenu } from '@/components/job/overview/job-actions-menu'
-import { getHeader, jobToolbarConfig } from '@/components/job/statuses'
+import { getHeader, getRemoteJobToolbarConfig } from '@/components/job/statuses'
 import { JobNameCell } from '@/components/label/job-name-label'
-import { DataTable } from '@/components/query-table'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
-import { DataTableToolbarConfig } from '@/components/query-table/toolbar'
+import { RemoteDataTable } from '@/components/query-table/remote'
+import { buildFacetQueryKey, buildRemoteQueryKey } from '@/components/query-table/remote-state'
 
 import {
   IJobInfo,
   ScheduleType,
+  apiAdminGetUserJobFacets,
   apiAdminGetUserJobList,
+  apiGetUserJobFacets,
   apiGetUserJobs,
   apiJobDeleteForAdmin,
   getDisplayJobPhase,
 } from '@/services/api/vcjob'
 
 import useIsAdmin from '@/hooks/use-admin'
+import useRemoteTableState from '@/hooks/use-remote-table-state'
 
 // Define the props for the component
 interface UserJobsOverviewProps {
@@ -49,19 +52,39 @@ export function UserJobsOverview({ username }: UserJobsOverviewProps) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const isAdmin = useIsAdmin()
+  const resourceKey = `user-jobs-${username}-${isAdmin}`
+  const tableState = useRemoteTableState(`user_jobs_overview_${username}_${isAdmin}`, {
+    sorting: [{ id: 'createdAt', desc: true }],
+    columnFilters: [{ id: 'days', value: ['30'] }],
+  })
 
   // Fetch user jobs data
   const userJobsQuery = useQuery({
-    queryKey: ['user-jobs', username, isAdmin],
-    queryFn: () => (isAdmin ? apiAdminGetUserJobList(username, 30) : apiGetUserJobs(username, 30)), // Query 30 days of data
-    select: (res) => res.data,
+    queryKey: [...buildRemoteQueryKey(resourceKey, tableState.params), username, isAdmin],
+    queryFn: async ({ signal }) =>
+      (
+        await (isAdmin
+          ? apiAdminGetUserJobList(username, tableState.params, signal)
+          : apiGetUserJobs(username, tableState.params, signal))
+      ).data,
+    placeholderData: keepPreviousData,
+  })
+  const facetsQuery = useQuery({
+    queryKey: [...buildFacetQueryKey(resourceKey, tableState.params), username, isAdmin],
+    queryFn: async ({ signal }) =>
+      (
+        await (isAdmin
+          ? apiAdminGetUserJobFacets(username, tableState.params, signal)
+          : apiGetUserJobFacets(username, tableState.params, signal))
+      ).data,
   })
 
   const refetchJobs = useCallback(async () => {
-    await queryClient.invalidateQueries({
-      queryKey: ['user-jobs', username, isAdmin],
-    })
-  }, [queryClient, username, isAdmin])
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['remote-list', resourceKey] }),
+      queryClient.invalidateQueries({ queryKey: ['remote-list-facets', resourceKey] }),
+    ])
+  }, [queryClient, resourceKey])
 
   // Only admin view can delete jobs, so always use admin delete API
   const { mutate: deleteJob } = useMutation({
@@ -72,22 +95,10 @@ export function UserJobsOverview({ username }: UserJobsOverviewProps) {
     },
   })
 
-  // Define toolbar config based on admin status
-  const toolbarConfig = useMemo<DataTableToolbarConfig>(() => {
-    if (isAdmin) {
-      // Admin view: use default config with search
-      return jobToolbarConfig
-    } else {
-      // User view: no search box, but keep filters and view options
-      return {
-        globalSearch: {
-          enabled: false,
-        },
-        filterOptions: jobToolbarConfig.filterOptions,
-        getHeader: getHeader,
-      }
-    }
-  }, [isAdmin])
+  const toolbarConfig = useMemo(
+    () => getRemoteJobToolbarConfig(facetsQuery.data),
+    [facetsQuery.data]
+  )
 
   // Define table columns
   const userJobsColumns = useMemo<ColumnDef<IJobInfo>[]>(() => {
@@ -130,6 +141,7 @@ export function UserJobsOverview({ username }: UserJobsOverviewProps) {
       },
       {
         accessorKey: 'nodes',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={t('jobs.headers.nodes')} />
         ),
@@ -140,6 +152,7 @@ export function UserJobsOverview({ username }: UserJobsOverviewProps) {
       },
       {
         accessorKey: 'resources',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={t('jobs.headers.resources')} />
         ),
@@ -208,15 +221,16 @@ export function UserJobsOverview({ username }: UserJobsOverviewProps) {
   }, [t, deleteJob, isAdmin, refetchJobs])
 
   return (
-    <DataTable
+    <RemoteDataTable
       info={{
         description: t(
           isAdmin ? 'jobs.userJobsDescription.admin' : 'jobs.userJobsDescription.user'
         ),
       }}
-      storageKey="user_jobs_overview"
       query={userJobsQuery}
+      state={tableState}
       columns={userJobsColumns}
+      getRowId={(row) => row.jobName}
       toolbarConfig={toolbarConfig}
       initialColumnVisibility={{ nodes: false }}
       multipleHandlers={

--- a/frontend/src/hooks/use-approval-order-lock.ts
+++ b/frontend/src/hooks/use-approval-order-lock.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useAtomValue } from 'jotai'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'

--- a/frontend/src/hooks/use-approval-order-lock.ts
+++ b/frontend/src/hooks/use-approval-order-lock.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAtomValue } from 'jotai'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -34,14 +35,6 @@ export function useApprovalOrderLock() {
 
   // 近 7 天窗口，避免 -1 带来的重负载
   const JOB_DAYS_WINDOW = 7
-
-  // 获取作业列表用于查找对应作业
-  const { data: jobList } = useQuery({
-    queryKey: ['admin', 'tasklist', 'job', JOB_DAYS_WINDOW],
-    queryFn: () => apiAdminGetJobList(JOB_DAYS_WINDOW),
-    select: (res) => res.data,
-    retry: 1,
-  })
 
   // 选中工单的锁定小时（只用 content.approvalorderExtensionHours，空按 0 处理）
   const selectedExtHours = useMemo(() => {
@@ -69,7 +62,6 @@ export function useApprovalOrderLock() {
     },
     onSuccess: () => {
       toast.success(t('ApprovalOrderTable.toast.approveSuccess'))
-      // 刷新所有工单相关的查询缓存
       queryClient.invalidateQueries({
         queryKey: ['admin', 'approvalorders'],
       })
@@ -79,7 +71,6 @@ export function useApprovalOrderLock() {
       queryClient.invalidateQueries({
         queryKey: ['portal', 'approvalorders'],
       })
-      // 清空状态
       setIsDelayDialogOpen(false)
       setSelectedOrder(null)
       setSelectedJob(null)
@@ -94,17 +85,6 @@ export function useApprovalOrderLock() {
     const findTarget = (list?: IJobInfo[]) =>
       list?.find((j) => j.jobName === order.name || j.name === order.name)
 
-    // 先查缓存
-    const cached = findTarget(jobList)
-    if (cached) {
-      if (!isRunningPhase(cached.status)) {
-        toast.error(`该作业当前状态为 ${phaseLabel(cached.status)}，无法锁定（仅运行中可锁定）`)
-        return null
-      }
-      return cached
-    }
-
-    // 未命中缓存：优先扩大时间窗口（7 -> 14 -> 30 天）
     setIsFetchingJob(true)
     try {
       const tryDays = [JOB_DAYS_WINDOW, 14, 30]
@@ -113,11 +93,13 @@ export function useApprovalOrderLock() {
 
       for (const d of tryDays) {
         try {
-          const res = await apiAdminGetJobList(d)
-          const list = res.data ?? []
-
-          // 更新缓存，保持与 useQuery 相同的 queryKey
-          queryClient.setQueryData(['admin', 'tasklist', 'job', d], res)
+          const res = await apiAdminGetJobList({
+            page: 1,
+            page_size: 10,
+            search: order.name,
+            filters: { days: [String(d)] },
+          })
+          const list = res.data.items
 
           const job = findTarget(list)
           if (job) {

--- a/frontend/src/hooks/use-remote-table-state.ts
+++ b/frontend/src/hooks/use-remote-table-state.ts
@@ -1,0 +1,107 @@
+import type {
+  ColumnFiltersState,
+  OnChangeFn,
+  PaginationState,
+  SortingState,
+  Updater,
+} from '@tanstack/react-table'
+import { useCallback, useMemo } from 'react'
+import { useDebounceValue, useLocalStorage } from 'usehooks-ts'
+
+import { normalizeRemoteTableParams } from '@/components/query-table/remote-state'
+
+const SEARCH_DEBOUNCE_MS = 300
+
+interface RemoteTableInitialState {
+  pageSize?: number
+  sorting?: SortingState
+  columnFilters?: ColumnFiltersState
+  search?: string
+}
+
+function resolveUpdater<T>(updater: Updater<T>, current: T): T {
+  return typeof updater === 'function' ? (updater as (value: T) => T)(current) : updater
+}
+
+export default function useRemoteTableState(
+  storageKey: string,
+  initialState: RemoteTableInitialState = {}
+) {
+  const [pageIndex, setPageIndex] = useLocalStorage(`${storageKey}-page-index`, 0)
+  const [pageSize, setPageSize] = useLocalStorage(
+    `${storageKey}-page-size`,
+    initialState.pageSize ?? 10
+  )
+  const [sorting, persistSorting] = useLocalStorage<SortingState>(
+    `${storageKey}-sorting`,
+    initialState.sorting ?? []
+  )
+  const [columnFilters, persistColumnFilters] = useLocalStorage<ColumnFiltersState>(
+    `${storageKey}-column-filters`,
+    initialState.columnFilters ?? []
+  )
+  const [search, persistSearch] = useLocalStorage(`${storageKey}-search`, initialState.search ?? '')
+  const [debouncedSearch, setDebouncedSearch] = useDebounceValue(search, SEARCH_DEBOUNCE_MS)
+
+  const pagination = useMemo(() => ({ pageIndex, pageSize }), [pageIndex, pageSize])
+  const resetPage = useCallback(() => setPageIndex(0), [setPageIndex])
+
+  const setPagination = useCallback<OnChangeFn<PaginationState>>(
+    (updater) => {
+      const next = resolveUpdater(updater, pagination)
+      setPageIndex(next.pageIndex)
+      setPageSize(next.pageSize)
+    },
+    [pagination, setPageIndex, setPageSize]
+  )
+
+  const setSorting = useCallback<OnChangeFn<SortingState>>(
+    (updater) => {
+      persistSorting((current) => resolveUpdater(updater, current))
+      resetPage()
+    },
+    [persistSorting, resetPage]
+  )
+
+  const setColumnFilters = useCallback<OnChangeFn<ColumnFiltersState>>(
+    (updater) => {
+      persistColumnFilters((current) => resolveUpdater(updater, current))
+      resetPage()
+    },
+    [persistColumnFilters, resetPage]
+  )
+
+  const setSearch = useCallback(
+    (value: string) => {
+      persistSearch(value)
+      setDebouncedSearch(value)
+      resetPage()
+    },
+    [persistSearch, resetPage, setDebouncedSearch]
+  )
+
+  const params = useMemo(
+    () =>
+      normalizeRemoteTableParams({
+        pagination,
+        sorting,
+        search: debouncedSearch,
+        filters: columnFilters,
+      }),
+    [columnFilters, debouncedSearch, pagination, sorting]
+  )
+
+  return {
+    pagination,
+    sorting,
+    columnFilters,
+    search,
+    params,
+    setPagination,
+    setSorting,
+    setColumnFilters,
+    setSearch,
+  }
+}
+
+export type RemoteTableState = ReturnType<typeof useRemoteTableState>

--- a/frontend/src/routes/portal/jobs/inter/index.tsx
+++ b/frontend/src/routes/portal/jobs/inter/index.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { UseQueryResult, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, createFileRoute } from '@tanstack/react-router'
 import { ColumnDef } from '@tanstack/react-table'
 import { t } from 'i18next'
@@ -37,13 +37,13 @@ import JupyterIcon from '@/components/icon/jupyter-icon'
 import JobResourceSummary from '@/components/job/job-resource-summary'
 import ListedNewJobButton from '@/components/job/new-job-button'
 import { JobActionsMenu } from '@/components/job/overview/job-actions-menu'
-import { getHeader, jobToolbarConfig } from '@/components/job/statuses'
+import { getHeader, getRemoteJobToolbarConfig } from '@/components/job/statuses'
 import { JobNameCell } from '@/components/label/job-name-label'
 import SimpleTooltip from '@/components/label/simple-tooltip'
-import { DataTable } from '@/components/query-table'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
+import { RemoteDataTable } from '@/components/query-table/remote'
+import { buildFacetQueryKey, buildRemoteQueryKey } from '@/components/query-table/remote-state'
 
-import { apiJobBillingList } from '@/services/api/billing'
 import { apiGetBillingStatus } from '@/services/api/system-config'
 import {
   IJobInfo,
@@ -51,10 +51,13 @@ import {
   JobType,
   ScheduleType,
   apiJobDelete,
+  apiJobInteractiveFacets,
   apiJobInteractiveList,
   getDisplayJobPhase,
-  isInteracitveJob,
+  interactiveJobTypes,
 } from '@/services/api/vcjob'
+
+import useRemoteTableState from '@/hooks/use-remote-table-state'
 
 import { isBillingVisibleForUser } from '@/utils/billing-visibility'
 import { logger } from '@/utils/loglevel'
@@ -70,7 +73,7 @@ export const Route = createFileRoute('/portal/jobs/inter/')({
   component: RouteComponent,
 })
 
-type JobTableRow = IJobInfo & { billedPointsTotal?: number }
+type JobTableRow = IJobInfo
 
 function RouteComponent() {
   const { t: translate } = useTranslation()
@@ -80,54 +83,31 @@ function RouteComponent() {
     queryFn: () => apiGetBillingStatus().then((res) => res.data),
   })
   const billingVisible = isBillingVisibleForUser(billingStatus)
+  const tableState = useRemoteTableState('portal_job_interactive', {
+    sorting: [{ id: 'createdAt', desc: true }],
+  })
 
   const interactiveQuery = useQuery({
-    queryKey: ['job', 'interactive'],
-    queryFn: apiJobInteractiveList,
-    select: (res) => res.data.filter((task) => isInteracitveJob(task.jobType)),
+    queryKey: buildRemoteQueryKey('jobs-interactive', tableState.params),
+    queryFn: async ({ signal }) => (await apiJobInteractiveList(tableState.params, signal)).data,
+    placeholderData: keepPreviousData,
     refetchInterval: REFETCH_INTERVAL,
   })
-  const billingQuery = useQuery({
-    queryKey: ['job', 'billing'],
-    queryFn: apiJobBillingList,
-    select: (res) =>
-      res.data.reduce<Record<string, number>>((acc, item) => {
-        acc[item.jobName] = item.billedPointsTotal
-        return acc
-      }, {}),
-    refetchInterval: REFETCH_INTERVAL,
-    enabled: billingVisible,
+  const facetsQuery = useQuery({
+    queryKey: buildFacetQueryKey('jobs-interactive', tableState.params),
+    queryFn: async ({ signal }) => (await apiJobInteractiveFacets(tableState.params, signal)).data,
   })
-  const mergedInteractiveQuery = useMemo(
-    () =>
-      ({
-        data: (interactiveQuery.data ?? []).map((job) => ({
-          ...job,
-          billedPointsTotal: billingQuery.data?.[job.jobName] ?? 0,
-        })),
-        isLoading: interactiveQuery.isLoading || (billingVisible && billingQuery.isLoading),
-        dataUpdatedAt: Math.max(
-          interactiveQuery.dataUpdatedAt,
-          billingVisible ? billingQuery.dataUpdatedAt : 0
-        ),
-        refetch: interactiveQuery.refetch,
-      }) as unknown as UseQueryResult<JobTableRow[], Error>,
-    [
-      billingVisible,
-      billingQuery.data,
-      billingQuery.dataUpdatedAt,
-      billingQuery.isLoading,
-      interactiveQuery.data,
-      interactiveQuery.dataUpdatedAt,
-      interactiveQuery.isLoading,
-      interactiveQuery.refetch,
-    ]
+  const toolbarConfig = useMemo(
+    () => getRemoteJobToolbarConfig(facetsQuery.data, interactiveJobTypes),
+    [facetsQuery.data]
   )
 
   const refetchTaskList = async () => {
     try {
       // 隔 200ms 并行发送所有异步请求
       await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['remote-list', 'jobs-interactive'] }),
+        queryClient.invalidateQueries({ queryKey: ['remote-list-facets', 'jobs-interactive'] }),
         new Promise((resolve) => setTimeout(resolve, 200)).then(() =>
           queryClient.invalidateQueries({ queryKey: ['job'] })
         ),
@@ -191,6 +171,7 @@ function RouteComponent() {
       },
       {
         accessorKey: 'nodes',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getHeader('nodes')} />
         ),
@@ -201,6 +182,7 @@ function RouteComponent() {
       },
       {
         accessorKey: 'resources',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getHeader('resources')} />
         ),
@@ -305,15 +287,16 @@ function RouteComponent() {
   )
 
   return (
-    <DataTable
+    <RemoteDataTable
       info={{
         title: t('navigation.interacitveJobs'),
         description: '提供开箱即用的 Jupyter Lab， 可用于测试、调试等',
       }}
-      storageKey="portal_job_interactive"
-      query={mergedInteractiveQuery}
+      query={interactiveQuery}
+      state={tableState}
       columns={interColumns}
-      toolbarConfig={jobToolbarConfig}
+      getRowId={(row) => row.jobName}
+      toolbarConfig={toolbarConfig}
       briefChildren={<JobResourceSummary />}
       multipleHandlers={[
         {
@@ -339,6 +322,6 @@ function RouteComponent() {
         <DocsButton title="查看文档" url="quick-start/interactive" />
         <ListedNewJobButton mode="inter" />
       </div>
-    </DataTable>
+    </RemoteDataTable>
   )
 }

--- a/frontend/src/routes/portal/overview/index.tsx
+++ b/frontend/src/routes/portal/overview/index.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { UseQueryResult, useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { ColumnDef } from '@tanstack/react-table'
 import { type Locale, enUS, ja, ko, zhCN } from 'date-fns/locale'
@@ -23,7 +23,7 @@ import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import JobPhaseLabel, { getJobPhaseLabel, jobPhases } from '@/components/badge/job-phase-badge'
-import JobTypeLabel, { jobTypes } from '@/components/badge/job-type-badge'
+import JobTypeLabel from '@/components/badge/job-type-badge'
 import NodeBadges from '@/components/badge/node-badges'
 import ResourceBadges from '@/components/badge/resource-badges'
 import ScheduleTypeLabel from '@/components/badge/schedule-type-badge'
@@ -35,7 +35,7 @@ import { BillingSummaryCards } from '@/components/custom/billing-summary-cards'
 import { TimeDistance } from '@/components/custom/time-distance'
 import ListedNewJobButton from '@/components/job/new-job-button'
 import { getHeader } from '@/components/job/overview/admin-jobs'
-import { scheduleTypes } from '@/components/job/statuses'
+import { getRemoteJobToolbarConfig } from '@/components/job/statuses'
 import UserLabel from '@/components/label/user-label'
 import PageTitle from '@/components/layout/page-title'
 import { SectionCards } from '@/components/metrics/section-cards'
@@ -43,9 +43,13 @@ import { useAccountNameLookup } from '@/components/node/getaccountnickname'
 import { getNodeColumns, nodesToolbarConfig } from '@/components/node/node-list'
 import { DataTable } from '@/components/query-table'
 import { DataTableColumnHeader } from '@/components/query-table/column-header'
-import { DataTableToolbarConfig } from '@/components/query-table/toolbar'
+import { RemoteDataTable } from '@/components/query-table/remote'
+import {
+  type RemoteTableParams,
+  buildFacetQueryKey,
+  buildRemoteQueryKey,
+} from '@/components/query-table/remote-state'
 
-import { apiJobAllBillingList } from '@/services/api/billing'
 import { apiContextBillingSummary } from '@/services/api/context'
 import { apiGetBillingStatus } from '@/services/api/system-config'
 import {
@@ -53,11 +57,14 @@ import {
   JobPhase,
   JobType,
   ScheduleType,
+  apiJobAllFacets,
   apiJobAllList,
   getDisplayJobPhase,
 } from '@/services/api/vcjob'
 import { queryNodes } from '@/services/query/node'
 import { queryResources } from '@/services/query/resource'
+
+import useRemoteTableState from '@/hooks/use-remote-table-state'
 
 import { isBillingVisibleForUser } from '@/utils/billing-visibility'
 import { getUserPseudonym } from '@/utils/pseudonym'
@@ -69,33 +76,13 @@ export const Route = createFileRoute('/portal/overview/')({
   component: Overview,
 })
 
-const toolbarConfig: DataTableToolbarConfig = {
-  filterInput: {
-    placeholder: '搜索用户名称',
-    key: 'owner',
-  },
-  filterOptions: [
-    {
-      key: 'jobType',
-      title: '类型',
-      option: jobTypes,
-    },
-    {
-      key: 'scheduleType',
-      title: getHeader('scheduleType'),
-      option: scheduleTypes,
-    },
-    {
-      key: 'status',
-      title: '状态',
-      option: jobPhases,
-      defaultValues: ['Running', 'Pending', 'Prequeue'],
-    },
-  ],
-  getHeader: getHeader,
-}
+type JobTableRow = IJobInfo
 
-type JobTableRow = IJobInfo & { billedPointsTotal?: number }
+const overviewSummaryParams: RemoteTableParams = {
+  page: 1,
+  page_size: 1,
+  filters: { days: ['7'] },
+}
 
 function Overview() {
   const { i18n, t } = useTranslation()
@@ -107,6 +94,13 @@ function Overview() {
     queryFn: () => apiGetBillingStatus().then((res) => res.data),
   })
   const billingVisible = isBillingVisibleForUser(billingStatus)
+  const tableState = useRemoteTableState('overview_joblist', {
+    sorting: [{ id: 'createdAt', desc: true }],
+    columnFilters: [
+      { id: 'days', value: ['7'] },
+      { id: 'status', value: ['Running', 'Pending', 'Prequeue'] },
+    ],
+  })
 
   // 获取当前语言对应的 date-fns locale
   const getDateLocale = useCallback((): Locale => {
@@ -158,6 +152,7 @@ function Overview() {
       },
       {
         accessorKey: 'nodes',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getHeader('nodes')} />
         ),
@@ -168,6 +163,7 @@ function Overview() {
       },
       {
         accessorKey: 'resources',
+        enableSorting: false,
         header: ({ column }) => (
           <DataTableColumnHeader column={column} title={getHeader('resources')} />
         ),
@@ -248,47 +244,33 @@ function Overview() {
   )
 
   const jobQuery = useQuery({
-    queryKey: ['overview', 'joblist'],
-    queryFn: apiJobAllList,
-    select: (res) => res.data,
+    queryKey: buildRemoteQueryKey('overview-jobs', tableState.params),
+    queryFn: async ({ signal }) => (await apiJobAllList(tableState.params, signal)).data,
+    placeholderData: keepPreviousData,
     refetchInterval: REFETCH_INTERVAL,
   })
-  const jobBillingQuery = useQuery({
-    queryKey: ['overview', 'joblist', 'billing'],
-    queryFn: () => apiJobAllBillingList(),
-    select: (res) =>
-      res.data.reduce<Record<string, number>>((acc, item) => {
-        acc[item.jobName] = item.billedPointsTotal
-        return acc
-      }, {}),
+  const jobFacetsQuery = useQuery({
+    queryKey: buildFacetQueryKey('overview-jobs', tableState.params),
+    queryFn: async ({ signal }) => (await apiJobAllFacets(tableState.params, signal)).data,
     refetchInterval: REFETCH_INTERVAL,
-    enabled: billingVisible,
   })
-  const mergedJobQuery = useMemo(
-    () =>
-      ({
-        data: (jobQuery.data ?? []).map((job) => ({
-          ...job,
-          billedPointsTotal: jobBillingQuery.data?.[job.jobName] ?? 0,
-        })),
-        isLoading: jobQuery.isLoading || (billingVisible && jobBillingQuery.isLoading),
-        dataUpdatedAt: Math.max(
-          jobQuery.dataUpdatedAt,
-          billingVisible ? jobBillingQuery.dataUpdatedAt : 0
-        ),
-        refetch: jobQuery.refetch,
-      }) as unknown as UseQueryResult<JobTableRow[], Error>,
-    [
-      billingVisible,
-      jobBillingQuery.data,
-      jobBillingQuery.dataUpdatedAt,
-      jobBillingQuery.isLoading,
-      jobQuery.data,
-      jobQuery.dataUpdatedAt,
-      jobQuery.isLoading,
-      jobQuery.refetch,
-    ]
-  )
+  const jobSummaryFacetsQuery = useQuery({
+    queryKey: buildFacetQueryKey('overview-job-summary', overviewSummaryParams),
+    queryFn: async ({ signal }) => (await apiJobAllFacets(overviewSummaryParams, signal)).data,
+    refetchInterval: REFETCH_INTERVAL,
+  })
+  const toolbarConfig = useMemo(() => {
+    const config = getRemoteJobToolbarConfig(jobFacetsQuery.data)
+    return {
+      ...config,
+      getHeader,
+      filterOptions: config.filterOptions.map((filter) =>
+        filter.key === 'status'
+          ? { ...filter, defaultValues: ['Running', 'Pending', 'Prequeue'] }
+          : filter
+      ),
+    }
+  }, [jobFacetsQuery.data])
 
   const resourcesQuery = useQuery(
     queryResources(true, (resource) => {
@@ -302,88 +284,31 @@ function Overview() {
   })
 
   const jobStatus = useMemo(() => {
-    if (!jobQuery.data) {
-      return []
-    }
-    const data = jobQuery.data
-    const counts = data
-      .filter((d) => d.status !== JobPhase.Deleted && d.status !== JobPhase.Freed)
-      .reduce(
-        (acc, item) => {
-          const phase = item.status
-          if (!acc[phase]) {
-            acc[phase] = 0
-          }
-          acc[phase] += 1
-          return acc
-        },
-        {} as Record<JobPhase, number>
-      )
-    return Object.entries(counts).map(([phase, count]) => ({
-      id: phase,
-      label: getJobPhaseLabel(phase as JobPhase).label,
-      value: count,
-    }))
-  }, [jobQuery.data])
+    return (jobSummaryFacetsQuery.data?.facets.status ?? [])
+      .filter(({ value }) => value !== JobPhase.Deleted && value !== JobPhase.Freed)
+      .map(({ value, count }) => ({
+        id: value,
+        label: getJobPhaseLabel(value as JobPhase).label,
+        value: count,
+      }))
+  }, [jobSummaryFacetsQuery.data])
 
   const hideUsername = useAtomValue(globalHideUsername)
   const userStatus = useMemo(() => {
-    if (!jobQuery.data) {
-      return []
-    }
-    const data = jobQuery.data
-    const counts = data
-      .filter((job) => job.status == 'Running')
-      .reduce(
-        (acc, item) => {
-          const owner = hideUsername ? getUserPseudonym(item.owner) : item.owner
-          if (!acc[owner]) {
-            acc[owner] = {
-              nickname: item.userInfo.nickname ?? item.owner,
-              count: 0,
-            }
-          }
-          acc[owner].count += 1
-          return acc
-        },
-        {} as Record<string, { nickname: string; count: number }>
-      )
-    return Object.entries(counts).map(([owner, pair]) => ({
-      id: owner,
-      label: hideUsername ? getUserPseudonym(owner) : pair.nickname,
-      value: pair.count,
-    }))
-  }, [hideUsername, jobQuery.data])
-
-  const gpuStatus = useMemo(() => {
-    if (!jobQuery.data) {
-      return []
-    }
-    const data = jobQuery.data
-    const counts = data
-      .filter((job) => job.status == 'Running')
-      .reduce(
-        (acc, item) => {
-          const resources = item.resources
-          for (const [k, value] of Object.entries(resources ?? {})) {
-            if (k.startsWith('nvidia.com')) {
-              const key = k.replace('nvidia.com/', '')
-              if (!acc[key]) {
-                acc[key] = 0
-              }
-              acc[key] += parseInt(value)
-            }
-          }
-          return acc
-        },
-        {} as Record<string, number>
-      )
-    return Object.entries(counts).map(([phase, count]) => ({
-      id: phase,
-      label: phase,
+    return (jobSummaryFacetsQuery.data?.facets.owner ?? []).map(({ value, count }) => ({
+      id: value,
+      label: hideUsername ? getUserPseudonym(value) : value,
       value: count,
     }))
-  }, [jobQuery.data])
+  }, [hideUsername, jobSummaryFacetsQuery.data])
+
+  const gpuStatus = useMemo(() => {
+    return (jobSummaryFacetsQuery.data?.facets.gpu_resource ?? []).map(({ value, count }) => ({
+      id: value,
+      label: value,
+      value: count,
+    }))
+  }, [jobSummaryFacetsQuery.data])
 
   const gpuAllocation = useMemo(() => {
     if (resourcesQuery.data === undefined) {
@@ -426,21 +351,21 @@ function Overview() {
           items={[
             {
               title: '运行中作业',
-              value: jobQuery.data?.filter((job) => job.status === JobPhase.Running).length,
+              value: jobStatus.find(({ id }) => id === JobPhase.Running)?.value ?? 0,
               className: 'text-highlight-blue',
               description: '正在运行的作业数量',
               icon: FlaskConicalIcon,
             },
             {
               title: t('statuses.awaitingAdmission'),
-              value: jobQuery.data?.filter((job) => job.status === JobPhase.Prequeue).length ?? 0,
+              value: jobStatus.find(({ id }) => id === JobPhase.Prequeue)?.value ?? 0,
               className: 'text-highlight-violet',
               description: t('jobs.statuses.prequeue.description'),
               icon: ClockIcon,
             },
             {
               title: t('statuses.pendingScheduling'),
-              value: jobQuery.data?.filter((job) => job.status === JobPhase.Pending).length ?? 0,
+              value: jobStatus.find(({ id }) => id === JobPhase.Pending)?.value ?? 0,
               className: 'text-highlight-purple',
               description: t('jobs.statuses.pending.description'),
               icon: ClockIcon,
@@ -466,7 +391,7 @@ function Overview() {
           icon={FlaskConicalIcon}
           cardTitle="作业状态"
           cardDescription="查看集群近 7 天作业的状态统计"
-          isLoading={jobQuery.isLoading}
+          isLoading={jobSummaryFacetsQuery.isLoading}
         >
           <NivoPie
             data={jobStatus}
@@ -481,19 +406,20 @@ function Overview() {
           icon={UsersRoundIcon}
           cardTitle="用户统计"
           cardDescription="当前正在运行作业所属的用户"
-          isLoading={jobQuery.isLoading}
+          isLoading={jobSummaryFacetsQuery.isLoading}
         >
           <NivoPie data={userStatus} margin={{ top: 20, bottom: 30 }} />
         </PieCard>
       </div>
-      <DataTable
+      <RemoteDataTable
         info={{
           title: '作业信息',
           description: '查看近 7 天集群作业的运行情况',
         }}
-        storageKey="overview_joblist"
-        query={mergedJobQuery}
+        query={jobQuery}
+        state={tableState}
         columns={jobColumns}
+        getRowId={(row) => row.jobName}
         toolbarConfig={toolbarConfig}
       />
       <DataTable

--- a/frontend/src/services/api/vcjob.ts
+++ b/frontend/src/services/api/vcjob.ts
@@ -16,12 +16,18 @@
 import { getDefaultStore } from 'jotai'
 import { Event as KubernetesEvent } from 'kubernetes-types/core/v1'
 
+import {
+  type RemoteTableParams,
+  buildFacetSearchParams,
+  buildRemoteSearchParams,
+} from '@/components/query-table/remote-state'
+
 import { apiV1Delete, apiV1Get, apiV1Post, apiV1Put } from '@/services/client'
 
 import { V1ResourceList } from '@/utils/resource'
 import { globalJobUrl } from '@/utils/store'
 
-import { IResponse } from '../types'
+import type { IFacetResponse, IPage, IResponse } from '../types'
 import { ImageInfoResponse } from './imagepack'
 import { TerminatedState } from './tool'
 
@@ -69,27 +75,71 @@ export interface IJobInfo {
   locked: boolean
   permanentLocked: boolean
   lockedTimestamp?: string
+  billedPointsTotal: number
 }
 
-export const apiAdminGetJobList = (days: number) =>
-  apiV1Get<IResponse<IJobInfo[]>>(`admin/${JOB_URL}`, {
-    searchParams: { days },
+export const apiAdminGetJobList = (params: RemoteTableParams, signal?: AbortSignal) =>
+  apiV1Get<IResponse<IPage<IJobInfo>>>(`admin/${JOB_URL}`, {
+    searchParams: buildRemoteSearchParams(toJobProtocol(params)),
+    signal,
+  })
+
+export const apiAdminGetJobFacets = (params: RemoteTableParams, signal?: AbortSignal) =>
+  apiV1Get<IResponse<IFacetResponse>>(`admin/${JOB_URL}/facets`, {
+    searchParams: buildFacetSearchParams(toJobProtocol(params)),
+    signal,
   })
 
 export const apiAdminGetJobDetail = (jobName: string) =>
   apiV1Get<IResponse<IJupyterDetail>>(`admin/${JOB_URL}/${jobName}/detail`)
 
-export const apiAdminGetUserJobList = (username: string, days: number = 30) =>
-  apiV1Get<IResponse<IJobInfo[]>>(`admin/${JOB_URL}/user/${username}`, {
-    searchParams: { days },
+export const apiAdminGetUserJobList = (
+  username: string,
+  params: RemoteTableParams,
+  signal?: AbortSignal
+) =>
+  apiV1Get<IResponse<IPage<IJobInfo>>>(`admin/${JOB_URL}/user/${username}`, {
+    searchParams: buildRemoteSearchParams(toJobProtocol(params)),
+    signal,
   })
 
-export const apiGetUserJobs = (username: string, days: number = 30) =>
-  apiV1Get<IResponse<IJobInfo[]>>(`${JOB_URL}/user/${username}`, {
-    searchParams: { days },
+export const apiAdminGetUserJobFacets = (
+  username: string,
+  params: RemoteTableParams,
+  signal?: AbortSignal
+) =>
+  apiV1Get<IResponse<IFacetResponse>>(`admin/${JOB_URL}/user/${username}/facets`, {
+    searchParams: buildFacetSearchParams(toJobProtocol(params)),
+    signal,
   })
 
-export const apiJobAllList = () => apiV1Get<IResponse<IJobInfo[]>>(`${JOB_URL}/all`)
+export const apiGetUserJobs = (username: string, params: RemoteTableParams, signal?: AbortSignal) =>
+  apiV1Get<IResponse<IPage<IJobInfo>>>(`${JOB_URL}/user/${username}`, {
+    searchParams: buildRemoteSearchParams(toJobProtocol(params)),
+    signal,
+  })
+
+export const apiGetUserJobFacets = (
+  username: string,
+  params: RemoteTableParams,
+  signal?: AbortSignal
+) =>
+  apiV1Get<IResponse<IFacetResponse>>(`${JOB_URL}/user/${username}/facets`, {
+    searchParams: buildFacetSearchParams(toJobProtocol(params)),
+    signal,
+  })
+
+export const apiJobAllList = (params: RemoteTableParams, signal?: AbortSignal) =>
+  apiV1Get<IResponse<IPage<IJobInfo>>>(`${JOB_URL}/all`, {
+    searchParams: buildRemoteSearchParams(toJobProtocol(params)),
+    signal,
+  })
+
+export const apiJobAllFacets = (params: RemoteTableParams, signal?: AbortSignal) =>
+  apiV1Get<IResponse<IFacetResponse>>(`${JOB_URL}/all/facets`, {
+    searchParams: buildFacetSearchParams(toJobProtocol(params)),
+    signal,
+  })
 
 export enum JobPhase {
   Prequeue = 'Prequeue',
@@ -162,9 +212,57 @@ export const getJobStateType = (phase: JobPhase): JobStatus => {
   return JobStatus.Unknown
 }
 
-export const apiJobBatchList = () => apiV1Get<IResponse<IJobInfo[]>>(JOB_URL)
+export const apiJobBatchList = (params: RemoteTableParams, signal?: AbortSignal) =>
+  apiV1Get<IResponse<IPage<IJobInfo>>>(JOB_URL, {
+    searchParams: buildRemoteSearchParams(toJobProtocol(withJobTypes(params, batchJobTypes))),
+    signal,
+  })
 
-export const apiJobInteractiveList = () => apiV1Get<IResponse<IJobInfo[]>>(JOB_URL)
+export const apiJobBatchFacets = (params: RemoteTableParams, signal?: AbortSignal) =>
+  apiV1Get<IResponse<IFacetResponse>>(`${JOB_URL}/facets`, {
+    searchParams: buildFacetSearchParams(toJobProtocol(withJobTypes(params, batchJobTypes))),
+    signal,
+  })
+
+export const apiJobInteractiveList = (params: RemoteTableParams, signal?: AbortSignal) =>
+  apiV1Get<IResponse<IPage<IJobInfo>>>(JOB_URL, {
+    searchParams: buildRemoteSearchParams(toJobProtocol(withJobTypes(params, interactiveJobTypes))),
+    signal,
+  })
+
+export const apiJobInteractiveFacets = (params: RemoteTableParams, signal?: AbortSignal) =>
+  apiV1Get<IResponse<IFacetResponse>>(`${JOB_URL}/facets`, {
+    searchParams: buildFacetSearchParams(toJobProtocol(withJobTypes(params, interactiveJobTypes))),
+    signal,
+  })
+
+export const interactiveJobTypes = [JobType.Jupyter, JobType.WebIDE]
+export const batchJobTypes = Object.values(JobType).filter(
+  (type) => !interactiveJobTypes.includes(type)
+)
+
+function withJobTypes(params: RemoteTableParams, allowed: JobType[]): RemoteTableParams {
+  const { jobType, job_type, ...filters } = params.filters
+  const selected = jobType ?? job_type
+  const selectedTypes = selected?.filter((type) => allowed.includes(type as JobType)) ?? []
+  const jobTypes = selectedTypes.length > 0 ? selectedTypes : allowed
+  return {
+    ...params,
+    filters: { ...filters, job_type: jobTypes },
+  }
+}
+
+export function toJobProtocol(params: RemoteTableParams): RemoteTableParams {
+  const { jobType, scheduleType, ...filters } = params.filters
+  return {
+    ...params,
+    filters: {
+      ...filters,
+      ...(jobType ? { job_type: jobType } : {}),
+      ...(scheduleType ? { schedule_type: scheduleType } : {}),
+    },
+  }
+}
 
 export interface PodDetail {
   name: string

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -41,3 +41,19 @@ export interface IWithPagination<T> {
   items: T[]
   total: number
 }
+
+export interface IPage<T> {
+  items: T[]
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface IFacetItem {
+  value: string
+  count: number
+}
+
+export interface IFacetResponse {
+  facets: Record<string, IFacetItem[]>
+}


### PR DESCRIPTION
- Add paginated Volcano job list APIs with server-side filtering, sorting, facets, and supporting database indexes.
- Migrate job overview pages to reusable remote table components with persisted table state.
- Extend `crater-cli job list` with pagination, sorting, and `--all-pages`.
- Update Swagger documentation and add pagination API coverage.