### PR TITLE
fix(order): use admin review endpoint

### DIFF
--- a/frontend/src/components/job/detail/job-order-list.tsx
+++ b/frontend/src/components/job/detail/job-order-list.tsx
@@ -16,9 +16,20 @@
 import { DurationDialog } from '@/routes/admin/jobs/-components/duration-dialog'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { useAtomValue } from 'jotai'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 
 import { ApprovalOrderDataTable } from '@/components/approval-order/approval-order-data-table'
 import {
@@ -30,13 +41,11 @@ import {
 import {
   type ApprovalOrder,
   listApprovalOrdersbyName,
-  updateApprovalOrder,
+  reviewApprovalOrder,
 } from '@/services/api/approvalorder'
 
 import useAdmin from '@/hooks/use-admin'
 import { useApprovalOrderLock } from '@/hooks/use-approval-order-lock'
-
-import { atomUserInfo } from '@/utils/store'
 
 interface JobOrderListProps {
   jobName: string
@@ -45,9 +54,11 @@ interface JobOrderListProps {
 export default function JobOrderList({ jobName }: JobOrderListProps) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
-  const user = useAtomValue(atomUserInfo)
   const isAdmin = useAdmin()
   const navigate = useNavigate()
+  const [rejectDialogOpen, setRejectDialogOpen] = useState(false)
+  const [rejectReason, setRejectReason] = useState('')
+  const [rejectTarget, setRejectTarget] = useState<ApprovalOrder | null>(null)
 
   // 使用锁定管理器 hook
   const {
@@ -86,15 +97,7 @@ export default function JobOrderList({ jobName }: JobOrderListProps) {
   // 批准操作（仅用于无需锁定的场景）
   const { mutate: approveOrder, isPending: isApproving } = useMutation({
     mutationFn: async (order: ApprovalOrder) => {
-      await updateApprovalOrder(order.id, {
-        name: order.name,
-        type: order.type,
-        status: 'Approved',
-        approvalorderTypeID: Number(order.content.approvalorderTypeID) || 0,
-        approvalorderReason: String(order.content.approvalorderReason || ''),
-        approvalorderExtensionHours: Number(order.content.approvalorderExtensionHours) || 0,
-        reviewerID: user?.id || 0,
-      })
+      await reviewApprovalOrder(order.id, { status: 'Approved' })
       return order
     },
     onSuccess: () => {
@@ -108,25 +111,30 @@ export default function JobOrderList({ jobName }: JobOrderListProps) {
 
   // 拒绝操作 mutation
   const { mutate: rejectOrder, isPending: isRejecting } = useMutation({
-    mutationFn: async (order: ApprovalOrder) => {
-      return updateApprovalOrder(order.id, {
-        name: order.name,
-        type: order.type,
-        status: 'Rejected',
-        approvalorderTypeID: Number(order.content.approvalorderTypeID) || 0,
-        approvalorderReason: String(order.content.approvalorderReason || ''),
-        approvalorderExtensionHours: Number(order.content.approvalorderExtensionHours) || 0,
-        reviewerID: user?.id || 0,
-      })
+    mutationFn: async ({ order, reason }: { order: ApprovalOrder; reason: string }) => {
+      return reviewApprovalOrder(order.id, { status: 'Rejected', reviewNotes: reason })
     },
     onSuccess: () => {
       toast.success(t('ApprovalOrderTable.toast.rejectSuccess'))
       refetchOrders()
+      setRejectDialogOpen(false)
+      setRejectReason('')
+      setRejectTarget(null)
     },
     onError: () => {
       toast.error(t('ApprovalOrderTable.toast.rejectError'))
     },
   })
+
+  const handleRejectConfirm = () => {
+    if (!rejectTarget) return
+    const reason = rejectReason.trim()
+    if (!reason) {
+      toast.error('请输入拒绝理由')
+      return
+    }
+    rejectOrder({ order: rejectTarget, reason })
+  }
 
   const handleViewOrder = (order: ApprovalOrder) => {
     // 首先显示一个提示，确认点击被触发
@@ -182,7 +190,11 @@ export default function JobOrderList({ jobName }: JobOrderListProps) {
       },
       reject: {
         show: isPending,
-        onClick: rejectOrder,
+        onClick: (order) => {
+          setRejectTarget(order)
+          setRejectReason('')
+          setRejectDialogOpen(true)
+        },
         disabled: () => isApproving || isRejecting,
       },
     }
@@ -230,6 +242,37 @@ export default function JobOrderList({ jobName }: JobOrderListProps) {
           defaultHours={(selectedExtHours || 8) % 24}
         />
       )}
+
+      <Dialog open={rejectDialogOpen} onOpenChange={setRejectDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>拒绝工单</DialogTitle>
+            <DialogDescription>
+              提供拒绝理由后提交，系统会将该工单标记为拒绝状态。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <Input
+              value={rejectReason}
+              onChange={(event) => setRejectReason(event.target.value)}
+              placeholder="请输入拒绝原因"
+              disabled={isRejecting}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setRejectDialogOpen(false)}
+              disabled={isRejecting}
+            >
+              取消
+            </Button>
+            <Button onClick={handleRejectConfirm} disabled={isRejecting}>
+              {isRejecting ? '提交中...' : '确认拒绝'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }

--- a/frontend/src/hooks/use-approval-order-lock.ts
+++ b/frontend/src/hooks/use-approval-order-lock.ts
@@ -14,23 +14,19 @@
  * limitations under the License.
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useAtomValue } from 'jotai'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 import { getJobPhaseLabel } from '@/components/badge/job-phase-badge'
 
-import { type ApprovalOrder, updateApprovalOrder } from '@/services/api/approvalorder'
+import { type ApprovalOrder, reviewApprovalOrder } from '@/services/api/approvalorder'
 import { type IJobInfo, JobPhase, apiAdminGetJobList } from '@/services/api/vcjob'
-
-import { atomUserInfo } from '@/utils/store'
 
 // Hook 用于管理工单锁定逻辑
 export function useApprovalOrderLock() {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
-  const user = useAtomValue(atomUserInfo)
   const [selectedOrder, setSelectedOrder] = useState<ApprovalOrder | null>(null)
   const [selectedJob, setSelectedJob] = useState<IJobInfo | null>(null)
   const [isDelayDialogOpen, setIsDelayDialogOpen] = useState(false)
@@ -68,15 +64,7 @@ export function useApprovalOrderLock() {
   // 批准操作 mutation
   const { mutate: approveOrder } = useMutation({
     mutationFn: async (order: ApprovalOrder) => {
-      await updateApprovalOrder(order.id, {
-        name: order.name,
-        type: order.type,
-        status: 'Approved',
-        approvalorderTypeID: Number(order.content.approvalorderTypeID) || 0,
-        approvalorderReason: String(order.content.approvalorderReason || ''),
-        approvalorderExtensionHours: Number(order.content.approvalorderExtensionHours) || 0,
-        reviewerID: user?.id || 0,
-      })
+      await reviewApprovalOrder(order.id, { status: 'Approved' })
       return order
     },
     onSuccess: () => {

--- a/frontend/src/routes/admin/more/orders/$id.tsx
+++ b/frontend/src/routes/admin/more/orders/$id.tsx
@@ -51,9 +51,8 @@ import GrafanaIframe from '@/components/layout/embed/grafana-iframe'
 
 import {
   type ApprovalOrder,
-  type ApprovalOrderReq,
   adminGetApprovalOrder,
-  updateApprovalOrder,
+  reviewApprovalOrder,
 } from '@/services/api/approvalorder'
 import { listApprovalOrdersbyName } from '@/services/api/approvalorder'
 import { JobStatus, apiJobGetDetail, apiJobGetPods, getJobStateType } from '@/services/api/vcjob'
@@ -62,7 +61,6 @@ import { queryNodes } from '@/services/query/node'
 import { useApprovalOrderLock } from '@/hooks/use-approval-order-lock'
 
 import { hasNvidiaGPU } from '@/utils/resource'
-import { atomUserInfo } from '@/utils/store'
 import { configGrafanaJobAtom } from '@/utils/store/config'
 
 import { DurationDialog } from '../../jobs/-components/duration-dialog'
@@ -79,7 +77,6 @@ export const Route = createFileRoute('/admin/more/orders/$id')({
 
 function RouteComponent() {
   const queryClient = useQueryClient()
-  const user = useAtomValue(atomUserInfo)
   const grafanaJob = useAtomValue(configGrafanaJobAtom)
   const { id } = Route.useParams()
   const { tab: currentTab } = Route.useSearch()
@@ -168,22 +165,6 @@ function RouteComponent() {
     selectedOrderRef.current = selectedOrder ?? null
   }, [selectedOrder])
 
-  const buildPayload = (target: ApprovalOrder, overrides: Partial<ApprovalOrderReq> = {}) => ({
-    name: target.name,
-    type: target.type,
-    status: overrides.status ?? target.status,
-    approvalorderTypeID: Number(target.content?.approvalorderTypeID) || 0,
-    approvalorderReason: target.content?.approvalorderReason ?? '',
-    approvalorderExtensionHours: Number(target.content?.approvalorderExtensionHours) || 0,
-    reviewerID: user?.id || 0,
-    reviewNotes:
-      overrides.reviewNotes ?? (typeof target.reviewNotes === 'string' ? target.reviewNotes : ''),
-  })
-
-  const updateDetailCache = (next: ApprovalOrder) => {
-    queryClient.setQueryData([...DETAIL_QUERY_KEY, orderId], next)
-  }
-
   const invalidateOrderLists = () => {
     queryClient.invalidateQueries({ queryKey: ['admin', 'approvalorders'] })
     queryClient.invalidateQueries({ queryKey: ['approvalorders'] })
@@ -192,13 +173,10 @@ function RouteComponent() {
 
   const approveMutation = useMutation({
     mutationFn: async (target: ApprovalOrder) => {
-      const payload = buildPayload(target, { status: 'Approved' })
-      const res = await updateApprovalOrder(target.id, payload)
-      return res.data
+      await reviewApprovalOrder(target.id, { status: 'Approved' })
     },
-    onSuccess: async (updated) => {
+    onSuccess: async () => {
       toast.success('工单已批准')
-      updateDetailCache(updated)
       invalidateOrderLists()
       await refetch()
     },
@@ -210,15 +188,12 @@ function RouteComponent() {
 
   const rejectMutation = useMutation({
     mutationFn: async ({ target, reason }: { target: ApprovalOrder; reason: string }) => {
-      const payload = buildPayload(target, { status: 'Rejected', reviewNotes: reason })
-      const res = await updateApprovalOrder(target.id, payload)
-      return res.data
+      await reviewApprovalOrder(target.id, { status: 'Rejected', reviewNotes: reason })
     },
-    onSuccess: async (updated) => {
+    onSuccess: async () => {
       toast.success('工单已拒绝')
       setIsRejectDialogOpen(false)
       setRejectionReason('')
-      updateDetailCache(updated)
       invalidateOrderLists()
       await refetch()
     },

--- a/frontend/src/routes/admin/more/orders/index.tsx
+++ b/frontend/src/routes/admin/more/orders/index.tsx
@@ -17,7 +17,6 @@
 // Modified code
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useAtomValue } from 'jotai'
 import { Database, Hourglass, ListChecks } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -45,12 +44,10 @@ import { SectionCards } from '@/components/metrics/section-cards'
 import {
   type ApprovalOrder,
   listApprovalOrders,
-  updateApprovalOrder,
+  reviewApprovalOrder,
 } from '@/services/api/approvalorder'
 
 import { useApprovalOrderLock } from '@/hooks/use-approval-order-lock'
-
-import { atomUserInfo } from '@/utils/store'
 
 import { DurationDialog } from '../../jobs/-components/duration-dialog'
 
@@ -76,7 +73,6 @@ function RouteComponent() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const user = useAtomValue(atomUserInfo)
   const [rejectDialogOpen, setRejectDialogOpen] = useState(false)
 
   const [rejectReason, setRejectReason] = useState('')
@@ -122,15 +118,7 @@ function RouteComponent() {
   // 批准操作（仅用于无需锁定的场景）
   const { mutate: approveOrder, isPending: isApproving } = useMutation({
     mutationFn: async (order: ApprovalOrder) => {
-      await updateApprovalOrder(order.id, {
-        name: order.name,
-        type: order.type,
-        status: 'Approved',
-        approvalorderTypeID: Number(order.content.approvalorderTypeID) || 0,
-        approvalorderReason: String(order.content.approvalorderReason || ''),
-        approvalorderExtensionHours: Number(order.content.approvalorderExtensionHours) || 0,
-        reviewerID: user?.id || 0,
-      })
+      await reviewApprovalOrder(order.id, { status: 'Approved' })
       return order
     },
     onSuccess: () => {
@@ -145,16 +133,7 @@ function RouteComponent() {
   // 拒绝操作 mutation
   const { mutate: rejectOrder, isPending: isRejecting } = useMutation({
     mutationFn: async ({ order, reason }: { order: ApprovalOrder; reason: string }) => {
-      return updateApprovalOrder(order.id, {
-        name: order.name,
-        type: order.type,
-        status: 'Rejected',
-        approvalorderTypeID: Number(order.content.approvalorderTypeID) || 0,
-        approvalorderReason: String(order.content.approvalorderReason || ''),
-        approvalorderExtensionHours: Number(order.content.approvalorderExtensionHours) || 0,
-        reviewerID: user?.id || 0,
-        reviewNotes: reason,
-      })
+      return reviewApprovalOrder(order.id, { status: 'Rejected', reviewNotes: reason })
     },
     onSuccess: () => {
       toast.success(t('ApprovalOrderTable.toast.rejectSuccess'))

--- a/frontend/src/services/api/approvalorder.ts
+++ b/frontend/src/services/api/approvalorder.ts
@@ -45,6 +45,12 @@ export interface ApprovalOrderReq {
   reviewerID?: number
   reviewNotes?: string
 }
+
+export interface ApprovalOrderReviewReq {
+  status: 'Approved' | 'Rejected' | 'Canceled'
+  reviewNotes?: string
+}
+
 export const listApprovalOrders = () => {
   return apiV1Get<IResponse<ApprovalOrder[]>>('admin/approvalorder')
 }
@@ -59,6 +65,9 @@ export const createApprovalOrder = (data: ApprovalOrderReq) => {
 }
 export const updateApprovalOrder = (id: number, data: ApprovalOrderReq) => {
   return apiV1Put<IResponse<ApprovalOrder>>(`approvalorder/${id}`, data)
+}
+export const reviewApprovalOrder = (id: number, data: ApprovalOrderReviewReq) => {
+  return apiV1Put<IResponse<string>>(`admin/approvalorder/${id}/review`, data)
 }
 export const listApprovalOrdersbyName = (name: string) => {
   return apiV1Get<IResponse<ApprovalOrder[]>>(`approvalorder/name/${name}`)


### PR DESCRIPTION
## Summary
- route admin approval and rejection through `/admin/approvalorder/:id/review`
- fix the approve-and-lock flow that was rejected by creator-only authorization
- collect rejection notes in the job detail order list

## Validation
- `make pre-commit-check`
- `pnpm build`

This keeps the protected creator update endpoint unchanged.