### PR TITLE
build: publish model downloader image

### DIFF
--- a/.github/workflows/depend-build.yml
+++ b/.github/workflows/depend-build.yml
@@ -20,6 +20,10 @@ on:
     paths:
       - ".github/workflows/depend-build.yml"
       - "hack/depend-image-dockerfile/**"
+  pull_request:
+    paths:
+      - ".github/workflows/depend-build.yml"
+      - "hack/depend-image-dockerfile/model-downloader/**"
 
 env:
   REGISTRY: ghcr.io
@@ -30,6 +34,8 @@ env:
   ENVD_VERSION: v1.2.1
   NERDCTL_CLIENT: nerdctl-client
   NERDCTL_VERSION: v2.1.2
+  MODEL_DOWNLOADER: crater-model-downloader
+  MODEL_DOWNLOADER_VERSION: v1.0.0
 
 jobs:
   detect-changes:
@@ -38,6 +44,7 @@ jobs:
       buildx-client: ${{ steps.changes.outputs.buildx-client }}
       envd-client: ${{ steps.changes.outputs.envd-client }}
       nerdctl-client: ${{ steps.changes.outputs.nerdctl-client }}
+      model-downloader: ${{ steps.changes.outputs.model-downloader }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -55,6 +62,8 @@ jobs:
               - 'hack/depend-image-dockerfile/envd-client/**'
             nerdctl-client:
               - 'hack/depend-image-dockerfile/nerdctl-client/**'
+            model-downloader:
+              - 'hack/depend-image-dockerfile/model-downloader/**'
 
   build-buildx-client:
     runs-on: ubuntu-latest
@@ -191,10 +200,55 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  build-model-downloader:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.model-downloader == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta for model-downloader
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.MODEL_DOWNLOADER }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ env.MODEL_DOWNLOADER_VERSION }}
+
+      - name: Build and push model-downloader image
+        uses: docker/build-push-action@v6
+        with:
+          context: hack/depend-image-dockerfile/model-downloader
+          file: hack/depend-image-dockerfile/model-downloader/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   cleanup:
     runs-on: ubuntu-latest
-    needs: [build-buildx-client, build-envd-client, build-nerdctl-client]
-    if: always() && (needs.build-buildx-client.result == 'success' || needs.build-envd-client.result == 'success' || needs.build-nerdctl-client.result == 'success')
+    needs: [build-buildx-client, build-envd-client, build-nerdctl-client, build-model-downloader]
+    if: github.event_name != 'pull_request' && always() && (needs.build-buildx-client.result == 'success' || needs.build-envd-client.result == 'success' || needs.build-nerdctl-client.result == 'success' || needs.build-model-downloader.result == 'success')
     permissions:
       contents: read
       packages: write
@@ -230,6 +284,18 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repository-owner: ${{ github.repository_owner }}
           package-name: ${{ env.NERDCTL_CLIENT }}
+          delete-untagged: true
+          keep-at-most: 5
+          skip-tags: latest
+        continue-on-error: true
+
+      - name: Clean up old model-downloader images
+        uses: quartx-analytics/ghcr-cleaner@v1
+        with:
+          owner-type: org
+          token: ${{ secrets.PAT_TOKEN }}
+          repository-owner: ${{ github.repository_owner }}
+          package-name: ${{ env.MODEL_DOWNLOADER }}
           delete-untagged: true
           keep-at-most: 5
           skip-tags: latest

--- a/hack/depend-image-dockerfile/model-downloader/Dockerfile
+++ b/hack/depend-image-dockerfile/model-downloader/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2026 The Crater Project Team, RAIDS-Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.11-slim
+
+ARG HUGGINGFACE_HUB_VERSION=1.23.0
+ARG MODELSCOPE_VERSION=1.38.1
+ARG MODELSCOPE_HUB_VERSION=0.1.7
+
+LABEL org.opencontainers.image.source="https://github.com/raids-lab/crater"
+LABEL org.opencontainers.image.description="Reproducible model and dataset downloader for Crater"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+RUN pip install --no-cache-dir \
+      "huggingface_hub==${HUGGINGFACE_HUB_VERSION}" \
+      "modelscope==${MODELSCOPE_VERSION}" \
+      "modelscope-hub==${MODELSCOPE_HUB_VERSION}" \
+    && python -c "import huggingface_hub, modelscope, modelscope_hub; print(huggingface_hub.__version__, modelscope.__version__, modelscope_hub.__version__)"
+
+WORKDIR /data
+
+ENTRYPOINT ["/bin/bash", "-c"]


### PR DESCRIPTION
## What changed

- add a dedicated `crater-model-downloader` image with pinned Hugging Face and ModelScope client versions
- extend the dependency-image workflow to build the image on pull requests
- publish `latest`, `v1.0.0`, branch, and commit tags to GHCR after the change reaches `main`
- include the new package in dependency-image cleanup

## Why

PR #447 configures model and dataset download Jobs to use `ghcr.io/raids-lab/crater-model-downloader:v1.0.0`, but that package does not exist yet. Publishing the image independently allows the download workflow to be tested end to end before PR #447 is merged.

## Impact

This PR only adds the image and its publishing workflow. It does not change Crater runtime configuration or switch any running download Job to the new image.

After this PR is merged, the push workflow will publish the image to GHCR. We will verify anonymous pull access and test PR #447 locally against the published image before merging the feature PR.

## Validation

- workflow YAML parses successfully
- `git diff --check`
- the same multi-platform Dockerfile build passed in PR #447's `build-model-downloader` check
