### PR TITLE
fix(model): persist downloaded README metadata immediately

### DIFF
--- a/backend/cmd/model-metadata-refresh/main.go
+++ b/backend/cmd/model-metadata-refresh/main.go
@@ -25,12 +25,10 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
 
-	xhtml "golang.org/x/net/html"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 
@@ -46,7 +44,7 @@ const (
 	defaultRequestDelay       = 100 * time.Millisecond
 	maxSourceDescriptionBytes = 500
 	maxMetadataTags           = 4
-	maxStoredReadmeBytes      = 64 * 1024
+	maxStoredReadmeBytes      = modeldataset.MaxStoredReadmeBytes
 	maxModelScopePageBytes    = 2 * 1024 * 1024
 	maxLogoRedirects          = 5
 )
@@ -551,128 +549,7 @@ func truncateText(text string, limit int) string {
 }
 
 func cleanReadme(text string) string {
-	text = strings.TrimSpace(text)
-	if strings.HasPrefix(text, "---\n") {
-		if end := strings.Index(text[4:], "\n---"); end >= 0 {
-			text = text[end+8:]
-		}
-	}
-	text = sourceUnsafeHTMLBlockPattern.ReplaceAllString(text, "")
-	text = sourceHTMLTablePattern.ReplaceAllStringFunc(text, htmlTableToMarkdown)
-	text = sourceHTMLTagPattern.ReplaceAllString(text, " ")
-	text = stdhtml.UnescapeString(text)
-	return truncateText(strings.TrimSpace(text), maxStoredReadmeBytes)
-}
-
-func htmlTableToMarkdown(tableHTML string) string {
-	document, err := xhtml.Parse(strings.NewReader(tableHTML))
-	if err != nil {
-		return tableHTML
-	}
-	table := findHTMLNode(document, "table")
-	if table == nil {
-		return tableHTML
-	}
-
-	rows := make([][]string, 0)
-	collectHTMLTableRows(table, &rows)
-	columnCount := 0
-	for _, row := range rows {
-		if len(row) > columnCount {
-			columnCount = len(row)
-		}
-	}
-	if len(rows) == 0 || columnCount == 0 {
-		return tableHTML
-	}
-
-	var result strings.Builder
-	result.WriteString("\n\n")
-	writeMarkdownTableRow(&result, rows[0], columnCount)
-	separator := make([]string, columnCount)
-	for i := range separator {
-		separator[i] = "---"
-	}
-	writeMarkdownTableRow(&result, separator, columnCount)
-	for _, row := range rows[1:] {
-		writeMarkdownTableRow(&result, row, columnCount)
-	}
-	result.WriteString("\n")
-	return result.String()
-}
-
-func findHTMLNode(node *xhtml.Node, tag string) *xhtml.Node {
-	if node.Type == xhtml.ElementNode && node.Data == tag {
-		return node
-	}
-	for child := node.FirstChild; child != nil; child = child.NextSibling {
-		if found := findHTMLNode(child, tag); found != nil {
-			return found
-		}
-	}
-	return nil
-}
-
-func collectHTMLTableRows(node *xhtml.Node, rows *[][]string) {
-	if node.Type == xhtml.ElementNode && node.Data == "tr" {
-		row := make([]string, 0)
-		for child := node.FirstChild; child != nil; child = child.NextSibling {
-			if child.Type != xhtml.ElementNode || child.Data != "th" && child.Data != "td" {
-				continue
-			}
-			cell := strings.Join(strings.Fields(htmlNodeText(child)), " ")
-			cell = strings.ReplaceAll(cell, "|", `\|`)
-			row = append(row, cell)
-			for i := 1; i < htmlColSpan(child); i++ {
-				row = append(row, "")
-			}
-		}
-		if len(row) > 0 {
-			*rows = append(*rows, row)
-		}
-		return
-	}
-	for child := node.FirstChild; child != nil; child = child.NextSibling {
-		collectHTMLTableRows(child, rows)
-	}
-}
-
-func htmlNodeText(node *xhtml.Node) string {
-	if node.Type == xhtml.TextNode {
-		return node.Data
-	}
-	var result strings.Builder
-	for child := node.FirstChild; child != nil; child = child.NextSibling {
-		result.WriteString(htmlNodeText(child))
-		result.WriteByte(' ')
-	}
-	return result.String()
-}
-
-func htmlColSpan(node *xhtml.Node) int {
-	for _, attribute := range node.Attr {
-		if attribute.Key == "colspan" {
-			span, err := strconv.Atoi(attribute.Val)
-			if err == nil && span > 1 {
-				return span
-			}
-		}
-	}
-	return 1
-}
-
-func writeMarkdownTableRow(result *strings.Builder, row []string, columnCount int) {
-	result.WriteString("| ")
-	for column := 0; column < columnCount; column++ {
-		if column < len(row) {
-			result.WriteString(row[column])
-		}
-		result.WriteString(" |")
-		if column < columnCount-1 {
-			result.WriteByte(' ')
-		}
-	}
-	result.WriteByte('\n')
+	return modeldataset.CleanReadme(text, maxStoredReadmeBytes)
 }
 
 func sourceFlag(value any) bool {
@@ -720,10 +597,8 @@ func sourceDescription(description, readme string) string {
 }
 
 var (
-	sourceHTMLTagPattern         = regexp.MustCompile(`<[^>]+>`)
-	sourceHTMLTablePattern       = regexp.MustCompile(`(?is)<table\b[^>]*>.*?</table>`)
-	sourceMarkdownLinkPattern    = regexp.MustCompile(`!?\[([^]]+)]\([^)]+\)`)
-	sourceUnsafeHTMLBlockPattern = regexp.MustCompile(`(?is)<(script|style)[^>]*>.*?</(script|style)>`)
+	sourceHTMLTagPattern      = regexp.MustCompile(`<[^>]+>`)
+	sourceMarkdownLinkPattern = regexp.MustCompile(`!?\[([^]]+)]\([^)]+\)`)
 )
 
 func isGeneratedDescription(description string, download *model.ModelDownload) bool {

--- a/backend/cmd/model-metadata-refresh/main.go
+++ b/backend/cmd/model-metadata-refresh/main.go
@@ -225,7 +225,6 @@ func refreshDownload(
 		"source_url":            sourceURL,
 		"display_name":          metadata.DisplayName,
 		"source_description":    metadata.Description,
-		"source_readme":         metadata.Readme,
 		"license":               metadata.License,
 		"task":                  metadata.Task,
 		"library":               metadata.Library,
@@ -237,6 +236,9 @@ func refreshDownload(
 		"source_downloads":      metadata.Downloads,
 		"source_likes":          metadata.Likes,
 		"metadata_refreshed_at": time.Now(),
+	}
+	if strings.TrimSpace(metadata.Readme) != "" {
+		updates["source_readme"] = metadata.Readme
 	}
 	if logo.URL != "" {
 		updates["logo_url"] = logo.URL
@@ -501,10 +503,22 @@ func fetchMetadata(
 	}
 	library := tagValue(payload.Data.Tags, "library:")
 	modelType := tagValue(payload.Data.Tags, "model_type:")
+	readme := cleanReadme(payload.Data.Readme)
+	if strings.TrimSpace(download.Revision) != "" {
+		// The repository metadata endpoint is not revision-aware. Prefer the
+		// README from the exact downloaded revision, and fall back to the
+		// already captured README instead of replacing it with the default one.
+		revisionReadme, readmeErr := fetchModelScopeRevisionReadme(client, selectedEndpoint, download)
+		if readmeErr == nil && strings.TrimSpace(revisionReadme) != "" {
+			readme = cleanReadme(revisionReadme)
+		} else {
+			readme = download.SourceReadme
+		}
+	}
 	return sourceMetadata{
 		DisplayName:    payload.Data.DisplayName,
-		Description:    sourceDescription(payload.Data.Description, cleanReadme(payload.Data.Readme)),
-		Readme:         cleanReadme(payload.Data.Readme),
+		Description:    sourceDescription(payload.Data.Description, readme),
+		Readme:         readme,
 		License:        payload.Data.License,
 		Task:           task,
 		Library:        library,
@@ -520,6 +534,16 @@ func fetchMetadata(
 		UpdatedAt:      &payload.Data.LastModified,
 		Tags:           limitTags(append(payload.Data.Tasks, payload.Data.Tags...)),
 	}, selectedEndpoint, nil
+}
+
+func fetchModelScopeRevisionReadme(
+	client *http.Client, baseEndpoint string, download *model.ModelDownload,
+) (string, error) {
+	if download == nil || strings.TrimSpace(download.Revision) == "" {
+		return "", errors.New("model download revision is required")
+	}
+	endpoint := repositoryURL(download, baseEndpoint) + "/resolve/" + url.PathEscape(strings.TrimSpace(download.Revision)) + "/README.md"
+	return fetchOptionalText(client, endpoint, maxStoredReadmeBytes)
 }
 
 func fetchOptionalText(client *http.Client, endpoint string, limit int) (string, error) {

--- a/backend/cmd/model-metadata-refresh/main_test.go
+++ b/backend/cmd/model-metadata-refresh/main_test.go
@@ -144,6 +144,64 @@ func TestFetchModelScopeAvatarFromRepositoryPage(t *testing.T) {
 	}
 }
 
+func TestFetchModelScopeMetadataUsesExplicitRevisionReadme(t *testing.T) {
+	client := testHTTPClient(func(request *http.Request) (*http.Response, error) {
+		switch request.URL.Path {
+		case "/openapi/v1/models/owner/model":
+			return testResponse(http.StatusOK, "application/json", []byte(`{
+                "success": true,
+                "data": {"display_name":"model","description":"default description","readme":"default README"}
+            }`)), nil
+		case "/models/owner/model/resolve/v2/README.md":
+			return testResponse(http.StatusOK, "text/markdown", []byte("# v2 README")), nil
+		default:
+			t.Fatalf("unexpected ModelScope request path %q", request.URL.Path)
+			return nil, nil
+		}
+	})
+	download := &model.ModelDownload{
+		Name: "owner/model", Source: model.ModelSourceModelScope,
+		Category: model.DownloadCategoryModel, Revision: "v2",
+	}
+
+	metadata, endpoint, err := fetchMetadata(client, sourceEndpoints{ModelScope: []string{"https://modelscope.cn"}}, download)
+	if err != nil {
+		t.Fatalf("fetchMetadata() error = %v", err)
+	}
+	if endpoint != "https://modelscope.cn" || metadata.Readme != "# v2 README" {
+		t.Fatalf("endpoint = %q, metadata = %#v", endpoint, metadata)
+	}
+}
+
+func TestFetchModelScopeMetadataPreservesCapturedReadmeWhenRevisionUnavailable(t *testing.T) {
+	client := testHTTPClient(func(request *http.Request) (*http.Response, error) {
+		switch request.URL.Path {
+		case "/openapi/v1/models/owner/model":
+			return testResponse(http.StatusOK, "application/json", []byte(`{
+                "success": true,
+                "data": {"display_name":"model","readme":"default README"}
+            }`)), nil
+		case "/models/owner/model/resolve/v2/README.md":
+			return testResponse(http.StatusNotFound, "text/plain", []byte("missing")), nil
+		default:
+			t.Fatalf("unexpected ModelScope request path %q", request.URL.Path)
+			return nil, nil
+		}
+	})
+	download := &model.ModelDownload{
+		Name: "owner/model", Source: model.ModelSourceModelScope,
+		Category: model.DownloadCategoryModel, Revision: "v2", SourceReadme: "# captured v2 README",
+	}
+
+	metadata, _, err := fetchMetadata(client, sourceEndpoints{ModelScope: []string{"https://modelscope.cn"}}, download)
+	if err != nil {
+		t.Fatalf("fetchMetadata() error = %v", err)
+	}
+	if metadata.Readme != download.SourceReadme {
+		t.Fatalf("metadata.Readme = %q, want captured README %q", metadata.Readme, download.SourceReadme)
+	}
+}
+
 func TestFetchLogoFollowsOnlyAllowedRedirects(t *testing.T) {
 	var requestedHosts []string
 	client := testHTTPClient(func(request *http.Request) (*http.Response, error) {

--- a/backend/internal/governance/modeldataset/readme.go
+++ b/backend/internal/governance/modeldataset/readme.go
@@ -1,0 +1,174 @@
+// Copyright 2026 The Crater Project Team, RAIDS-Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modeldataset
+
+import (
+	"html"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	xhtml "golang.org/x/net/html"
+)
+
+const MaxStoredReadmeBytes = 64 * 1024
+
+var (
+	readmeHTMLTablePattern       = regexp.MustCompile(`(?is)<table\b[^>]*>.*?</table>`)
+	readmeHTMLTagPattern         = regexp.MustCompile(`<[^>]+>`)
+	readmeUnsafeHTMLBlockPattern = regexp.MustCompile(`(?is)<(script|style)[^>]*>.*?</(script|style)>`)
+)
+
+// CleanReadme removes source-controlled raw HTML that the Markdown renderer does
+// not support, converts simple HTML tables to Markdown, and applies a UTF-8-safe
+// byte limit before the content is persisted.
+func CleanReadme(text string, limit int) string {
+	if limit < 1 {
+		return ""
+	}
+	text = strings.TrimSpace(text)
+	if strings.HasPrefix(text, "---\n") {
+		if end := strings.Index(text[4:], "\n---"); end >= 0 {
+			text = text[end+8:]
+		}
+	}
+	text = readmeUnsafeHTMLBlockPattern.ReplaceAllString(text, "")
+	text = readmeHTMLTablePattern.ReplaceAllStringFunc(text, htmlTableToMarkdown)
+	text = readmeHTMLTagPattern.ReplaceAllString(text, " ")
+	text = html.UnescapeString(text)
+	return truncateReadme(strings.TrimSpace(text), limit)
+}
+
+func truncateReadme(text string, limit int) string {
+	if len(text) <= limit {
+		return text
+	}
+	for limit > 0 && !utf8.RuneStart(text[limit]) {
+		limit--
+	}
+	return text[:limit]
+}
+
+func htmlTableToMarkdown(tableHTML string) string {
+	document, err := xhtml.Parse(strings.NewReader(tableHTML))
+	if err != nil {
+		return tableHTML
+	}
+	table := findHTMLNode(document, "table")
+	if table == nil {
+		return tableHTML
+	}
+
+	rows := make([][]string, 0)
+	collectHTMLTableRows(table, &rows)
+	columnCount := 0
+	for _, row := range rows {
+		if len(row) > columnCount {
+			columnCount = len(row)
+		}
+	}
+	if len(rows) == 0 || columnCount == 0 {
+		return tableHTML
+	}
+
+	var result strings.Builder
+	result.WriteString("\n\n")
+	writeMarkdownTableRow(&result, rows[0], columnCount)
+	separator := make([]string, columnCount)
+	for i := range separator {
+		separator[i] = "---"
+	}
+	writeMarkdownTableRow(&result, separator, columnCount)
+	for _, row := range rows[1:] {
+		writeMarkdownTableRow(&result, row, columnCount)
+	}
+	result.WriteString("\n")
+	return result.String()
+}
+
+func findHTMLNode(node *xhtml.Node, tag string) *xhtml.Node {
+	if node.Type == xhtml.ElementNode && node.Data == tag {
+		return node
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		if found := findHTMLNode(child, tag); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func collectHTMLTableRows(node *xhtml.Node, rows *[][]string) {
+	if node.Type == xhtml.ElementNode && node.Data == "tr" {
+		row := make([]string, 0)
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			if child.Type != xhtml.ElementNode || child.Data != "th" && child.Data != "td" {
+				continue
+			}
+			cell := strings.Join(strings.Fields(htmlNodeText(child)), " ")
+			cell = strings.ReplaceAll(cell, "|", `\|`)
+			row = append(row, cell)
+			for i := 1; i < htmlColSpan(child); i++ {
+				row = append(row, "")
+			}
+		}
+		if len(row) > 0 {
+			*rows = append(*rows, row)
+		}
+		return
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		collectHTMLTableRows(child, rows)
+	}
+}
+
+func htmlNodeText(node *xhtml.Node) string {
+	if node.Type == xhtml.TextNode {
+		return node.Data
+	}
+	var result strings.Builder
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		result.WriteString(htmlNodeText(child))
+		result.WriteByte(' ')
+	}
+	return result.String()
+}
+
+func htmlColSpan(node *xhtml.Node) int {
+	for _, attribute := range node.Attr {
+		if attribute.Key == "colspan" {
+			span, err := strconv.Atoi(attribute.Val)
+			if err == nil && span > 1 {
+				return span
+			}
+		}
+	}
+	return 1
+}
+
+func writeMarkdownTableRow(result *strings.Builder, row []string, columnCount int) {
+	result.WriteString("| ")
+	for column := 0; column < columnCount; column++ {
+		if column < len(row) {
+			result.WriteString(row[column])
+		}
+		result.WriteString(" |")
+		if column < columnCount-1 {
+			result.WriteByte(' ')
+		}
+	}
+	result.WriteByte('\n')
+}

--- a/backend/internal/handler/modeldownload.go
+++ b/backend/internal/handler/modeldownload.go
@@ -30,6 +30,7 @@ import (
 	"github.com/raids-lab/crater/dao/model"
 	"github.com/raids-lab/crater/dao/query"
 	"github.com/raids-lab/crater/internal/bizerr"
+	"github.com/raids-lab/crater/internal/governance/modeldataset"
 	"github.com/raids-lab/crater/internal/resputil"
 	"github.com/raids-lab/crater/internal/service"
 	"github.com/raids-lab/crater/internal/util"
@@ -40,6 +41,8 @@ import (
 const (
 	defaultDownloadLogTailLines int64 = 1000
 	maxStoredDownloadLogBytes         = 64 * 1024
+	maxCapturedReadmeBytes            = modeldataset.MaxStoredReadmeBytes
+	readmeLogChunkCharacters          = 4096
 	maxDownloadRevisionLength         = 128
 	CategoryModel                     = "model"
 	CategoryDataset                   = "dataset"
@@ -1798,11 +1801,18 @@ PY
 `, resourcePath, download.Name)
 	}
 
-	// 下载完成后，从 README 提取一段简介，供平台展示与模型本身相关的描述。
-	descScript := `
+	// Capture the README from the exact downloaded revision. It is compressed and
+	// split across bounded log lines so the reconciler can persist it immediately
+	// without relying on the periodic source metadata refresh job.
+	descScript := fmt.Sprintf(`
 echo "Extracting summary from README..."
 python - << 'PY' || true
+import base64
 import os
+import zlib
+
+max_readme_bytes = %d
+chunk_characters = %d
 text = ""
 for name in ("README.md", "readme.md", "README.MD", "README"):
     p = os.path.join(os.environ["OUT_DIR"], name)
@@ -1813,6 +1823,14 @@ for name in ("README.md", "readme.md", "README.MD", "README"):
         except Exception:
             pass
         break
+raw_readme = text.encode("utf-8")[:max_readme_bytes]
+text = raw_readme.decode("utf-8", errors="ignore")
+if text:
+    payload = base64.b64encode(zlib.compress(text.encode("utf-8"), level=9)).decode("ascii")
+    print("[README] begin zlib+base64", flush=True)
+    for offset in range(0, len(payload), chunk_characters):
+        print("[README] chunk " + payload[offset:offset + chunk_characters], flush=True)
+    print("[README] end", flush=True)
 if text.startswith("---"):
     end = text.find("\n---", 3)
     if end != -1:
@@ -1830,7 +1848,7 @@ for block in text.split("\n\n"):
 if para:
     print("[DESC] " + para[:300], flush=True)
 PY
-`
+`, maxCapturedReadmeBytes, readmeLogChunkCharacters)
 
 	// 进度监控脚本（保持你原来的逻辑）
 	progressScript := `

--- a/backend/internal/handler/modeldownload.go
+++ b/backend/internal/handler/modeldownload.go
@@ -1813,17 +1813,16 @@ import zlib
 
 max_readme_bytes = %d
 chunk_characters = %d
-text = ""
+raw_readme = b""
 for name in ("README.md", "readme.md", "README.MD", "README"):
     p = os.path.join(os.environ["OUT_DIR"], name)
     if os.path.isfile(p):
         try:
-            with open(p, encoding="utf-8", errors="ignore") as f:
-                text = f.read()
+            with open(p, "rb") as f:
+                raw_readme = f.read(max_readme_bytes)
         except Exception:
             pass
         break
-raw_readme = text.encode("utf-8")[:max_readme_bytes]
 text = raw_readme.decode("utf-8", errors="ignore")
 if text:
     payload = base64.b64encode(zlib.compress(text.encode("utf-8"), level=9)).decode("ascii")

--- a/backend/internal/handler/modeldownload_test.go
+++ b/backend/internal/handler/modeldownload_test.go
@@ -232,6 +232,10 @@ func TestModelScopeDownloadCommandUsesArgumentArray(t *testing.T) {
 		"available revisions",
 		"modelscope==" + modelScopeVersion,
 		"modelscope-hub==" + modelScopeHubVersion,
+		"raw_readme = text.encode(\"utf-8\")[:max_readme_bytes]",
+		"[README] begin zlib+base64",
+		"[README] chunk ",
+		"[README] end",
 	} {
 		if !strings.Contains(command, expected) {
 			t.Fatalf("download command does not contain %q", expected)

--- a/backend/internal/handler/modeldownload_test.go
+++ b/backend/internal/handler/modeldownload_test.go
@@ -232,7 +232,10 @@ func TestModelScopeDownloadCommandUsesArgumentArray(t *testing.T) {
 		"available revisions",
 		"modelscope==" + modelScopeVersion,
 		"modelscope-hub==" + modelScopeHubVersion,
-		"raw_readme = text.encode(\"utf-8\")[:max_readme_bytes]",
+		`raw_readme = b""`,
+		`with open(p, "rb") as f:`,
+		"raw_readme = f.read(max_readme_bytes)",
+		`text = raw_readme.decode("utf-8", errors="ignore")`,
 		"[README] begin zlib+base64",
 		"[README] chunk ",
 		"[README] end",
@@ -246,6 +249,9 @@ func TestModelScopeDownloadCommandUsesArgumentArray(t *testing.T) {
 	}
 	if strings.Contains(command, "pip install -q modelscope") {
 		t.Fatal("download command performs an unpinned runtime installation")
+	}
+	if strings.Contains(command, "f.read()") {
+		t.Fatal("download command reads the complete README before truncating it")
 	}
 	if strings.Contains(command, "%!") {
 		t.Fatalf("download command contains an unresolved format directive: %s", command)

--- a/backend/pkg/reconciler/modeldownload-reconciler.go
+++ b/backend/pkg/reconciler/modeldownload-reconciler.go
@@ -1,7 +1,10 @@
 package reconciler
 
 import (
+	"bytes"
+	"compress/zlib"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -78,7 +81,13 @@ const (
 	progressRequeueInterval             = 5 * time.Second
 	// maxStoredLogBytes caps the log tail persisted on the download record when
 	// the job reaches a terminal state (the K8s Job itself is GC'd after 7 days).
-	maxStoredLogBytes = 64 * 1024
+	maxStoredLogBytes       = 64 * 1024
+	maxStoredReadmeBytes    = modeldataset.MaxStoredReadmeBytes
+	maxEncodedReadmeBytes   = (maxStoredReadmeBytes+1024)*4/3 + 4
+	readmeCaptureBegin      = "[README] begin zlib+base64"
+	readmeCaptureChunk      = "[README] chunk "
+	readmeCaptureEnd        = "[README] end"
+	readmeCapturedLogNotice = "[README] captured for the model details page"
 )
 
 // Markers printed by the download job script (see buildDownloadCommand).
@@ -175,20 +184,24 @@ func (r *ModelDownloadReconciler) syncDownloadWithJob(
 		}
 	}
 
-	if newStatus == model.ModelDownloadStatusReady && download.Status != model.ModelDownloadStatusReady {
+	if shouldSyncReadyArtifacts(download, newStatus) {
 		if err := r.extractFinalResult(ctx, job, download); err != nil {
 			logger.Error(err, "failed to extract final result")
 		}
 
 		// Persist the log tail before the Job/Pod is GC'd, and reuse it to pick
-		// up the [DESC] summary the job extracted from the repo's README.
+		// up the README and [DESC] summary extracted from the downloaded revision.
 		logs := r.persistFinalLogs(ctx, job, download)
-		if err := r.persistRepositoryMetadata(ctx, download, logs); err != nil {
+		metadata := parseRepositoryMetadata(logs)
+		readmeDescription := parseDescriptionFromLogs(logs)
+		if metadata.Description == "" {
+			metadata.Description = readmeDescription
+		}
+		if err := r.persistRepositoryMetadata(ctx, download, &metadata); err != nil {
 			logger.Error(err, "failed to persist repository metadata")
 		}
 
-		metadata := parseRepositoryMetadata(logs)
-		if err := r.createDatasetForModel(ctx, download, parseDescriptionFromLogs(logs), metadata.Tags); err != nil {
+		if err := r.createDatasetForModel(ctx, download, readmeDescription, metadata.Tags); err != nil {
 			logger.Error(err, "failed to create dataset for model")
 			return ctrl.Result{RequeueAfter: progressRequeueInterval}, err
 		}
@@ -222,9 +235,19 @@ func (r *ModelDownloadReconciler) syncDownloadWithJob(
 	return ctrl.Result{}, nil
 }
 
+// shouldSyncReadyArtifacts also repairs a Ready row whose status was advanced
+// by another controller before README persistence completed. This matters for
+// local development, where a local backend may temporarily overlap the backend
+// already running in the target cluster.
+func shouldSyncReadyArtifacts(download *model.ModelDownload, newStatus model.ModelDownloadStatus) bool {
+	return newStatus == model.ModelDownloadStatusReady &&
+		(download.Status != model.ModelDownloadStatusReady || download.SourceReadme == "")
+}
+
 type repositoryMetadata struct {
 	DisplayName    string   `json:"display_name"`
 	Description    string   `json:"description"`
+	Readme         string   `json:"readme"`
 	License        string   `json:"license"`
 	Task           string   `json:"task"`
 	Library        string   `json:"library"`
@@ -242,20 +265,19 @@ type repositoryMetadata struct {
 }
 
 func parseRepositoryMetadata(logs string) repositoryMetadata {
+	metadata := repositoryMetadata{Readme: parseReadmeFromLogs(logs)}
 	matches := metadataPattern.FindAllStringSubmatch(logs, -1)
 	if len(matches) == 0 {
-		return repositoryMetadata{}
+		return metadata
 	}
-	var metadata repositoryMetadata
 	_ = json.Unmarshal([]byte(matches[len(matches)-1][1]), &metadata)
 	return metadata
 }
 
 func (r *ModelDownloadReconciler) persistRepositoryMetadata(
-	ctx context.Context, download *model.ModelDownload, logs string,
+	ctx context.Context, download *model.ModelDownload, metadata *repositoryMetadata,
 ) error {
 	organization := strings.SplitN(download.Name, "/", 2)[0]
-	metadata := parseRepositoryMetadata(logs)
 	logoURL, logoData, logoContentType, logoErr := resolveRepositoryLogo(ctx, download, metadata.LogoURL)
 	if logoErr != nil {
 		// Logo collection is best effort and must never turn a successful model
@@ -281,6 +303,9 @@ func (r *ModelDownloadReconciler) persistRepositoryMetadata(
 	if len(logoData) > 0 {
 		updates["logo_url"] = logoURL
 	}
+	if metadata.Readme != "" {
+		updates["source_readme"] = metadata.Readme
+	}
 	if metadata.UpdatedAt != "" {
 		if updatedAt, err := time.Parse(time.RFC3339, metadata.UpdatedAt); err == nil {
 			updates["source_updated_at"] = updatedAt
@@ -304,6 +329,7 @@ func (r *ModelDownloadReconciler) persistRepositoryMetadata(
 			LogoContentType: logoContentType,
 			DisplayName:     metadata.DisplayName,
 			Description:     metadata.Description,
+			Readme:          metadata.Readme,
 			License:         metadata.License,
 			Task:            metadata.Task,
 			Library:         metadata.Library,
@@ -631,7 +657,7 @@ func (r *ModelDownloadReconciler) persistFinalLogs(ctx context.Context, job *bat
 		return ""
 	}
 
-	storedLogs := truncateLogTail(logs, maxStoredLogBytes)
+	storedLogs := truncateLogTail(logsWithoutCapturedReadme(logs), maxStoredLogBytes)
 	now := time.Now()
 	q := query.ModelDownload
 	if _, err := q.WithContext(ctx).Where(q.ID.Eq(download.ID)).Updates(map[string]any{
@@ -716,6 +742,85 @@ func parseDescriptionFromLogs(logs string) string {
 		return ""
 	}
 	return strings.TrimSpace(matches[len(matches)-1][1])
+}
+
+// parseReadmeFromLogs reconstructs the bounded, compressed README emitted by
+// the download job. Reading through a limit protects the controller from a
+// malformed compression payload while still accepting the full configured size.
+func parseReadmeFromLogs(logs string) string {
+	var payload strings.Builder
+	collecting := false
+	latest := ""
+	for _, rawLine := range strings.Split(logs, "\n") {
+		line := strings.TrimSuffix(rawLine, "\r")
+		switch line {
+		case readmeCaptureBegin:
+			payload.Reset()
+			collecting = true
+		case readmeCaptureEnd:
+			if collecting {
+				if decoded := decodeCapturedReadme(payload.String()); decoded != "" {
+					latest = decoded
+				}
+			}
+			collecting = false
+		default:
+			if !collecting || !strings.HasPrefix(line, readmeCaptureChunk) {
+				continue
+			}
+			chunk := strings.TrimPrefix(line, readmeCaptureChunk)
+			if payload.Len()+len(chunk) > maxEncodedReadmeBytes {
+				payload.Reset()
+				collecting = false
+				continue
+			}
+			payload.WriteString(chunk)
+		}
+	}
+	return latest
+}
+
+func decodeCapturedReadme(payload string) string {
+	if payload == "" || len(payload) > maxEncodedReadmeBytes {
+		return ""
+	}
+	compressed, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return ""
+	}
+	reader, err := zlib.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		return ""
+	}
+	defer reader.Close()
+
+	content, err := io.ReadAll(io.LimitReader(reader, maxStoredReadmeBytes+1))
+	if err != nil {
+		return ""
+	}
+	if len(content) > maxStoredReadmeBytes {
+		content = content[:maxStoredReadmeBytes]
+	}
+	return modeldataset.CleanReadme(string(content), maxStoredReadmeBytes)
+}
+
+// logsWithoutCapturedReadme keeps the human-facing log readable and prevents a
+// large encoded README from consuming the persisted log-tail budget.
+func logsWithoutCapturedReadme(logs string) string {
+	lines := strings.Split(logs, "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, rawLine := range lines {
+		line := strings.TrimSuffix(rawLine, "\r")
+		switch {
+		case line == readmeCaptureBegin:
+			filtered = append(filtered, readmeCapturedLogNotice)
+		case line == readmeCaptureEnd, strings.HasPrefix(line, readmeCaptureChunk):
+			continue
+		default:
+			filtered = append(filtered, rawLine)
+		}
+	}
+	return strings.Join(filtered, "\n")
 }
 
 // extractFailureReason reads the failed pod's logs (and termination state) and

--- a/backend/pkg/reconciler/modeldownload-reconciler.go
+++ b/backend/pkg/reconciler/modeldownload-reconciler.go
@@ -254,16 +254,18 @@ func (r *ModelDownloadReconciler) syncReadyArtifacts(
 		return fmt.Errorf("persist final download logs: %w", err)
 	}
 	metadata, err := parseRepositoryMetadata(logs)
-	if err != nil {
+	if err != nil && !errors.Is(err, errRepositoryPayloadMissing) {
 		return fmt.Errorf("parse repository metadata: %w", err)
 	}
 	readmeDescription := parseDescriptionFromLogs(logs)
-	if metadata.Description == "" && readmeDescription != "" {
-		metadata.Description = readmeDescription
-		metadata.markPresent("description")
-	}
-	if err := r.persistRepositoryMetadata(ctx, download, &metadata); err != nil {
-		return fmt.Errorf("persist repository metadata: %w", err)
+	if metadata.hasPayload() {
+		if metadata.Description == "" && readmeDescription != "" {
+			metadata.Description = readmeDescription
+			metadata.markPresent("description")
+		}
+		if err := r.persistRepositoryMetadata(ctx, download, &metadata); err != nil {
+			return fmt.Errorf("persist repository metadata: %w", err)
+		}
 	}
 	if err := r.createDatasetForModel(ctx, download, readmeDescription, metadata.Tags); err != nil {
 		return fmt.Errorf("create dataset for model: %w", err)

--- a/backend/pkg/reconciler/modeldownload-reconciler.go
+++ b/backend/pkg/reconciler/modeldownload-reconciler.go
@@ -45,6 +45,8 @@ type ModelDownloadReconciler struct {
 	KubeClient kubernetes.Interface
 	Scheme     *runtime.Scheme
 	log        logr.Logger
+	db         *gorm.DB
+	podLogs    func(context.Context, *v1.Pod) (string, error)
 }
 
 // NewModelDownloadReconciler returns a new reconciler
@@ -55,6 +57,13 @@ func NewModelDownloadReconciler(crClient client.Client, kubeClient kubernetes.In
 		Scheme:     scheme,
 		log:        ctrl.Log.WithName("ModelDownload-reconciler"),
 	}
+}
+
+func (r *ModelDownloadReconciler) database() *gorm.DB {
+	if r.db != nil {
+		return r.db
+	}
+	return query.GetDB()
 }
 
 // SetupWithManager sets up the controller with the Manager
@@ -97,6 +106,17 @@ var (
 	resultPattern   = regexp.MustCompile(`\[RESULT\] size_bytes=(\d+)(?:\s+duration_seconds=(\d+)\s+speed_bytes_per_sec=(\d+))?`)
 	descPattern     = regexp.MustCompile(`\[DESC\] (.+)`)
 	metadataPattern = regexp.MustCompile(`\[META\] (.+)`)
+)
+
+var (
+	errFinalLogsUnavailable      = errors.New("final download logs are unavailable")
+	errRepositoryPayloadMissing  = errors.New("repository metadata payload is missing")
+	repositoryMetadataFieldNames = map[string]struct{}{
+		"display_name": {}, "description": {}, "readme": {}, "license": {},
+		"task": {}, "library": {}, "model_type": {}, "parameter_count": {},
+		"private": {}, "gated": {}, "login_required": {}, "downloads": {},
+		"likes": {}, "logo_url": {}, "created_at": {}, "updated_at": {}, "tags": {},
+	}
 )
 
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
@@ -185,24 +205,7 @@ func (r *ModelDownloadReconciler) syncDownloadWithJob(
 	}
 
 	if shouldSyncReadyArtifacts(download, newStatus) {
-		if err := r.extractFinalResult(ctx, job, download); err != nil {
-			logger.Error(err, "failed to extract final result")
-		}
-
-		// Persist the log tail before the Job/Pod is GC'd, and reuse it to pick
-		// up the README and [DESC] summary extracted from the downloaded revision.
-		logs := r.persistFinalLogs(ctx, job, download)
-		metadata := parseRepositoryMetadata(logs)
-		readmeDescription := parseDescriptionFromLogs(logs)
-		if metadata.Description == "" {
-			metadata.Description = readmeDescription
-		}
-		if err := r.persistRepositoryMetadata(ctx, download, &metadata); err != nil {
-			logger.Error(err, "failed to persist repository metadata")
-		}
-
-		if err := r.createDatasetForModel(ctx, download, readmeDescription, metadata.Tags); err != nil {
-			logger.Error(err, "failed to create dataset for model")
+		if err := r.syncReadyArtifacts(ctx, job, download); err != nil {
 			return ctrl.Result{RequeueAfter: progressRequeueInterval}, err
 		}
 	}
@@ -210,7 +213,9 @@ func (r *ModelDownloadReconciler) syncDownloadWithJob(
 	// When a download fails, capture the reason from pod logs so the user can
 	// see why (gated repo, auth, network, OOM, ...) instead of an empty message.
 	if newStatus == model.ModelDownloadStatusFailed && download.Status != model.ModelDownloadStatusFailed {
-		r.persistFinalLogs(ctx, job, download)
+		if _, err := r.persistFinalLogs(ctx, job, download); err != nil {
+			logger.Error(err, "failed to persist failed download logs")
+		}
 		if err := r.extractFailureReason(ctx, job, download); err != nil {
 			logger.Error(err, "failed to extract failure reason")
 		}
@@ -233,6 +238,37 @@ func (r *ModelDownloadReconciler) syncDownloadWithJob(
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *ModelDownloadReconciler) syncReadyArtifacts(
+	ctx context.Context, job *batchv1.Job, download *model.ModelDownload,
+) error {
+	if err := r.extractFinalResult(ctx, job, download); err != nil {
+		return fmt.Errorf("extract final download result: %w", err)
+	}
+
+	// Persist the log tail before the Job/Pod is GC'd, and reuse it to pick
+	// up the README and [DESC] summary extracted from the downloaded revision.
+	logs, err := r.persistFinalLogs(ctx, job, download)
+	if err != nil {
+		return fmt.Errorf("persist final download logs: %w", err)
+	}
+	metadata, err := parseRepositoryMetadata(logs)
+	if err != nil {
+		return fmt.Errorf("parse repository metadata: %w", err)
+	}
+	readmeDescription := parseDescriptionFromLogs(logs)
+	if metadata.Description == "" && readmeDescription != "" {
+		metadata.Description = readmeDescription
+		metadata.markPresent("description")
+	}
+	if err := r.persistRepositoryMetadata(ctx, download, &metadata); err != nil {
+		return fmt.Errorf("persist repository metadata: %w", err)
+	}
+	if err := r.createDatasetForModel(ctx, download, readmeDescription, metadata.Tags); err != nil {
+		return fmt.Errorf("create dataset for model: %w", err)
+	}
+	return nil
 }
 
 // shouldSyncReadyArtifacts also repairs a Ready row whose status was advanced
@@ -262,90 +298,95 @@ type repositoryMetadata struct {
 	CreatedAt      string   `json:"created_at"`
 	UpdatedAt      string   `json:"updated_at"`
 	Tags           []string `json:"tags"`
+	present        map[string]struct{}
 }
 
-func parseRepositoryMetadata(logs string) repositoryMetadata {
-	metadata := repositoryMetadata{Readme: parseReadmeFromLogs(logs)}
-	matches := metadataPattern.FindAllStringSubmatch(logs, -1)
-	if len(matches) == 0 {
-		return metadata
+func (m *repositoryMetadata) markPresent(field string) {
+	if m.present == nil {
+		m.present = make(map[string]struct{})
 	}
-	_ = json.Unmarshal([]byte(matches[len(matches)-1][1]), &metadata)
-	return metadata
+	m.present[field] = struct{}{}
+}
+
+func (m *repositoryMetadata) isPresent(field string) bool {
+	_, ok := m.present[field]
+	return ok
+}
+
+func (m *repositoryMetadata) hasPayload() bool {
+	return len(m.present) > 0
+}
+
+func parseRepositoryMetadata(logs string) (repositoryMetadata, error) {
+	metadata := repositoryMetadata{}
+	if readme := parseReadmeFromLogs(logs); readme != "" {
+		metadata.Readme = readme
+		metadata.markPresent("readme")
+	}
+	matches := metadataPattern.FindAllStringSubmatch(logs, -1)
+	if len(matches) > 0 {
+		payload := []byte(matches[len(matches)-1][1])
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(payload, &fields); err != nil {
+			return metadata, fmt.Errorf("decode metadata fields: %w", err)
+		}
+		if err := json.Unmarshal(payload, &metadata); err != nil {
+			return metadata, fmt.Errorf("decode metadata payload: %w", err)
+		}
+		for field := range fields {
+			if _, supported := repositoryMetadataFieldNames[field]; supported {
+				metadata.markPresent(field)
+			}
+		}
+	}
+	if !metadata.hasPayload() {
+		return metadata, errRepositoryPayloadMissing
+	}
+	return metadata, nil
 }
 
 func (r *ModelDownloadReconciler) persistRepositoryMetadata(
 	ctx context.Context, download *model.ModelDownload, metadata *repositoryMetadata,
 ) error {
-	organization := strings.SplitN(download.Name, "/", 2)[0]
-	logoURL, logoData, logoContentType, logoErr := resolveRepositoryLogo(ctx, download, metadata.LogoURL)
+	if metadata == nil || !metadata.hasPayload() {
+		return errRepositoryPayloadMissing
+	}
+	logoURL, logoData, logoContentType, logoErr := r.resolveRepositoryLogo(ctx, download, metadata.LogoURL)
 	if logoErr != nil {
 		// Logo collection is best effort and must never turn a successful model
 		// download into a failed task. A later metadata refresh can retry it.
 		klog.Warningf("Failed to cache repository logo for %s: %v", download.Name, logoErr)
 	}
-	updates := map[string]any{
-		"organization":          organization,
-		"source_url":            downloadSourceURL(download),
-		"display_name":          metadata.DisplayName,
-		"source_description":    metadata.Description,
-		"license":               metadata.License,
-		"task":                  metadata.Task,
-		"library":               metadata.Library,
-		"model_type":            metadata.ModelType,
-		"parameter_count":       metadata.ParameterCount,
-		"source_private":        metadata.Private,
-		"source_gated":          metadata.Gated,
-		"source_login_required": metadata.LoginRequired,
-		"source_downloads":      metadata.Downloads,
-		"source_likes":          metadata.Likes,
-	}
-	if len(logoData) > 0 {
-		updates["logo_url"] = logoURL
-	}
-	if metadata.Readme != "" {
-		updates["source_readme"] = metadata.Readme
-	}
-	if metadata.UpdatedAt != "" {
-		if updatedAt, err := time.Parse(time.RFC3339, metadata.UpdatedAt); err == nil {
-			updates["source_updated_at"] = updatedAt
-		}
-	}
-	if metadata.CreatedAt != "" {
-		if createdAt, err := time.Parse(time.RFC3339, metadata.CreatedAt); err == nil {
-			updates["source_created_at"] = createdAt
-		}
+	return persistRepositoryMetadataWithDB(
+		ctx, r.database(), download, metadata, logoURL, logoData, logoContentType,
+	)
+}
+
+func persistRepositoryMetadataWithDB(
+	ctx context.Context,
+	db *gorm.DB,
+	download *model.ModelDownload,
+	metadata *repositoryMetadata,
+	logoURL string,
+	logoData []byte,
+	logoContentType string,
+) error {
+	if metadata == nil || !metadata.hasPayload() {
+		return errRepositoryPayloadMissing
 	}
 
-	return query.GetDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	organization := strings.SplitN(download.Name, "/", 2)[0]
+	downloadUpdates, sourceUpdates := repositoryMetadataUpdates(
+		download, metadata, organization, logoURL, logoData, logoContentType,
+	)
+
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		source := model.ModelDatasetSource{
-			Provider:        model.ModelDatasetProvider(download.Source),
-			ResourceType:    model.DataType(download.Category),
-			RepositoryID:    download.Name,
-			RepositoryURL:   downloadSourceURL(download),
-			Organization:    organization,
-			LogoURL:         logoURL,
-			LogoData:        logoData,
-			LogoContentType: logoContentType,
-			DisplayName:     metadata.DisplayName,
-			Description:     metadata.Description,
-			Readme:          metadata.Readme,
-			License:         metadata.License,
-			Task:            metadata.Task,
-			Library:         metadata.Library,
-			ModelType:       metadata.ModelType,
-			ParameterCount:  metadata.ParameterCount,
-			Private:         metadata.Private,
-			Gated:           metadata.Gated,
-			LoginRequired:   metadata.LoginRequired,
-			Downloads:       metadata.Downloads,
-			Likes:           metadata.Likes,
-		}
-		if value, ok := updates["source_updated_at"].(time.Time); ok {
-			source.SourceUpdatedAt = &value
-		}
-		if value, ok := updates["source_created_at"].(time.Time); ok {
-			source.SourceCreatedAt = &value
+			Provider:      model.ModelDatasetProvider(download.Source),
+			ResourceType:  model.DataType(download.Category),
+			RepositoryID:  download.Name,
+			RepositoryURL: downloadSourceURL(download),
+			Organization:  organization,
 		}
 		var persisted model.ModelDatasetSource
 		lookup := tx.Where(
@@ -359,11 +400,12 @@ func (r *ModelDownloadReconciler) persistRepositoryMetadata(
 			persisted = source
 		} else if lookup.Error != nil {
 			return lookup.Error
-		} else if err := tx.Model(&persisted).Updates(source).Error; err != nil {
+		}
+		if err := tx.Model(&persisted).Updates(sourceUpdates).Error; err != nil {
 			return err
 		}
-		updates["model_dataset_source_id"] = persisted.ID
-		if err := tx.Model(&model.ModelDownload{}).Where("id = ?", download.ID).Updates(updates).Error; err != nil {
+		downloadUpdates["model_dataset_source_id"] = persisted.ID
+		if err := tx.Model(&model.ModelDownload{}).Where("id = ?", download.ID).Updates(downloadUpdates).Error; err != nil {
 			return err
 		}
 		download.ModelDatasetSourceID = &persisted.ID
@@ -371,12 +413,80 @@ func (r *ModelDownloadReconciler) persistRepositoryMetadata(
 	})
 }
 
-func resolveRepositoryLogo(
+func repositoryMetadataUpdates(
+	download *model.ModelDownload,
+	metadata *repositoryMetadata,
+	organization string,
+	logoURL string,
+	logoData []byte,
+	logoContentType string,
+) (downloadUpdates, sourceUpdates map[string]any) {
+	downloadUpdates = map[string]any{
+		"organization": organization,
+		"source_url":   downloadSourceURL(download),
+	}
+	sourceUpdates = map[string]any{
+		"repository_url": downloadSourceURL(download),
+		"organization":   organization,
+	}
+	fieldUpdates := []struct {
+		field          string
+		downloadColumn string
+		sourceColumn   string
+		value          any
+	}{
+		{field: "display_name", downloadColumn: "display_name", sourceColumn: "display_name", value: metadata.DisplayName},
+		{field: "description", downloadColumn: "source_description", sourceColumn: "description", value: metadata.Description},
+		{field: "license", downloadColumn: "license", sourceColumn: "license", value: metadata.License},
+		{field: "task", downloadColumn: "task", sourceColumn: "task", value: metadata.Task},
+		{field: "library", downloadColumn: "library", sourceColumn: "library", value: metadata.Library},
+		{field: "model_type", downloadColumn: "model_type", sourceColumn: "model_type", value: metadata.ModelType},
+		{field: "parameter_count", downloadColumn: "parameter_count", sourceColumn: "parameter_count", value: metadata.ParameterCount},
+		{field: "private", downloadColumn: "source_private", sourceColumn: "private", value: metadata.Private},
+		{field: "gated", downloadColumn: "source_gated", sourceColumn: "gated", value: metadata.Gated},
+		{field: "login_required", downloadColumn: "source_login_required", sourceColumn: "login_required", value: metadata.LoginRequired},
+		{field: "downloads", downloadColumn: "source_downloads", sourceColumn: "downloads", value: metadata.Downloads},
+		{field: "likes", downloadColumn: "source_likes", sourceColumn: "likes", value: metadata.Likes},
+	}
+	for _, update := range fieldUpdates {
+		if !metadata.isPresent(update.field) {
+			continue
+		}
+		downloadUpdates[update.downloadColumn] = update.value
+		sourceUpdates[update.sourceColumn] = update.value
+	}
+	if len(logoData) > 0 {
+		downloadUpdates["logo_url"] = logoURL
+		sourceUpdates["logo_url"] = logoURL
+		sourceUpdates["logo_data"] = logoData
+		sourceUpdates["logo_content_type"] = logoContentType
+	}
+	if metadata.isPresent("readme") && metadata.Readme != "" {
+		downloadUpdates["source_readme"] = metadata.Readme
+		sourceUpdates["readme"] = metadata.Readme
+	}
+	if metadata.isPresent("updated_at") && metadata.UpdatedAt != "" {
+		if updatedAt, err := time.Parse(time.RFC3339, metadata.UpdatedAt); err == nil {
+			downloadUpdates["source_updated_at"] = updatedAt
+			sourceUpdates["source_updated_at"] = updatedAt
+		}
+	}
+	if metadata.isPresent("created_at") && metadata.CreatedAt != "" {
+		if createdAt, err := time.Parse(time.RFC3339, metadata.CreatedAt); err == nil {
+			downloadUpdates["source_created_at"] = createdAt
+			sourceUpdates["source_created_at"] = createdAt
+		}
+	}
+
+	return downloadUpdates, sourceUpdates
+}
+
+func (r *ModelDownloadReconciler) resolveRepositoryLogo(
 	ctx context.Context, download *model.ModelDownload, metadataLogoURL string,
 ) (logoURL string, logoData []byte, contentType string, err error) {
 	organization := strings.SplitN(download.Name, "/", 2)[0]
 	var cached model.ModelDatasetSource
-	lookup := query.GetDB().WithContext(ctx).
+	lookup := r.database().WithContext(ctx).
 		Where("LOWER(organization) = ? AND octet_length(logo_data) > 0", strings.ToLower(organization)).
 		Order("updated_at DESC").
 		First(&cached)
@@ -622,6 +732,9 @@ func (r *ModelDownloadReconciler) extractFinalResult(ctx context.Context, job *b
 }
 
 func (r *ModelDownloadReconciler) getPodLogs(ctx context.Context, pod *v1.Pod) (string, error) {
+	if r.podLogs != nil {
+		return r.podLogs(ctx, pod)
+	}
 	// Get pod logs using Kubernetes clientset
 	req := r.KubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &v1.PodLogOptions{
 		Container: "downloader",
@@ -646,30 +759,36 @@ func (r *ModelDownloadReconciler) getPodLogs(ctx context.Context, pod *v1.Pod) (
 // persistFinalLogs stores the pod's log tail on the download record so it can
 // still be inspected after the K8s Job (TTL 7 days) and its pods are GC'd.
 // Returns the raw logs so callers can parse markers without a second fetch.
-func (r *ModelDownloadReconciler) persistFinalLogs(ctx context.Context, job *batchv1.Job, download *model.ModelDownload) string {
+func (r *ModelDownloadReconciler) persistFinalLogs(
+	ctx context.Context, job *batchv1.Job, download *model.ModelDownload,
+) (string, error) {
 	pod, err := r.latestPodForJob(ctx, job)
-	if err != nil || pod == nil {
-		return ""
+	if err != nil {
+		return "", fmt.Errorf("find downloader pod: %w", err)
+	}
+	if pod == nil {
+		return "", errFinalLogsUnavailable
 	}
 
 	logs, err := r.getPodLogs(ctx, pod)
-	if err != nil || logs == "" {
-		return ""
+	if err != nil {
+		return "", fmt.Errorf("read downloader pod logs: %w", err)
+	}
+	if strings.TrimSpace(logs) == "" {
+		return "", errFinalLogsUnavailable
 	}
 
 	storedLogs := truncateLogTail(logsWithoutCapturedReadme(logs), maxStoredLogBytes)
 	now := time.Now()
-	q := query.ModelDownload
-	if _, err := q.WithContext(ctx).Where(q.ID.Eq(download.ID)).Updates(map[string]any{
+	if err := r.database().WithContext(ctx).Model(&model.ModelDownload{}).Where("id = ?", download.ID).Updates(map[string]any{
 		"logs":          storedLogs,
 		"logs_saved_at": now,
-	}); err != nil {
-		klog.Warningf("failed to persist final logs for download %d: %v", download.ID, err)
-	} else {
-		download.Logs = storedLogs
-		download.LogsSavedAt = &now
+	}).Error; err != nil {
+		return "", fmt.Errorf("update stored download logs: %w", err)
 	}
-	return logs
+	download.Logs = storedLogs
+	download.LogsSavedAt = &now
+	return logs, nil
 }
 
 // ensureFinalLogs retries terminal log persistence after transient failures,
@@ -798,10 +917,7 @@ func decodeCapturedReadme(payload string) string {
 	if err != nil {
 		return ""
 	}
-	if len(content) > maxStoredReadmeBytes {
-		content = content[:maxStoredReadmeBytes]
-	}
-	return modeldataset.CleanReadme(string(content), maxStoredReadmeBytes)
+	return modeldataset.CleanReadme(strings.ToValidUTF8(string(content), ""), maxStoredReadmeBytes)
 }
 
 // logsWithoutCapturedReadme keeps the human-facing log readable and prevents a

--- a/backend/pkg/reconciler/modeldownload-reconciler.go
+++ b/backend/pkg/reconciler/modeldownload-reconciler.go
@@ -802,7 +802,9 @@ func (r *ModelDownloadReconciler) ensureFinalLogs(
 	if finalLogsAreCurrent(job, download, status) {
 		return false
 	}
-	r.persistFinalLogs(ctx, job, download)
+	if _, err := r.persistFinalLogs(ctx, job, download); err != nil {
+		return true
+	}
 	return !finalLogsAreCurrent(job, download, status)
 }
 

--- a/backend/pkg/reconciler/modeldownload-reconciler_test.go
+++ b/backend/pkg/reconciler/modeldownload-reconciler_test.go
@@ -15,7 +15,10 @@
 package reconciler
 
 import (
+	"bytes"
+	"compress/zlib"
 	"context"
+	"encoding/base64"
 	"strings"
 	"testing"
 	"time"
@@ -103,10 +106,45 @@ func TestFinalLogsAreCurrentRejectsProgressSnapshot(t *testing.T) {
 	}
 }
 
+func TestShouldSyncReadyArtifacts(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		download   model.ModelDownload
+		jobStatus  model.ModelDownloadStatus
+		wantToSync bool
+	}{
+		{
+			name: "ready transition", download: model.ModelDownload{Status: model.ModelDownloadStatusDownloading},
+			jobStatus: model.ModelDownloadStatusReady, wantToSync: true,
+		},
+		{
+			name: "recover missing readme", download: model.ModelDownload{Status: model.ModelDownloadStatusReady},
+			jobStatus: model.ModelDownloadStatusReady, wantToSync: true,
+		},
+		{
+			name: "already persisted", download: model.ModelDownload{
+				Status: model.ModelDownloadStatusReady, SourceReadme: "# Model Card",
+			},
+			jobStatus: model.ModelDownloadStatusReady, wantToSync: false,
+		},
+		{
+			name: "failed job", download: model.ModelDownload{Status: model.ModelDownloadStatusDownloading},
+			jobStatus: model.ModelDownloadStatusFailed, wantToSync: false,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := shouldSyncReadyArtifacts(&testCase.download, testCase.jobStatus); got != testCase.wantToSync {
+				t.Fatalf("shouldSyncReadyArtifacts() = %v, want %v", got, testCase.wantToSync)
+			}
+		})
+	}
+}
+
 func TestParseRepositoryMetadata(t *testing.T) {
-	metadata := parseRepositoryMetadata(`noise
+	logs := `noise
 [META] {"downloads":4235273,"likes":333,"updated_at":"2025-07-26T16:12:41Z","tags":["text-generation"]}
-`)
+` + capturedReadmeLogs(t, "---\nlicense: apache-2.0\n---\n# Model Card\n<script>unsafe()</script>\nUseful details.", 11)
+	metadata := parseRepositoryMetadata(logs)
 
 	if metadata.Downloads != 4235273 || metadata.Likes != 333 || metadata.UpdatedAt != "2025-07-26T16:12:41Z" {
 		t.Fatalf("unexpected repository metadata: %#v", metadata)
@@ -114,6 +152,47 @@ func TestParseRepositoryMetadata(t *testing.T) {
 	if strings.Join(metadata.Tags, ",") != "text-generation" {
 		t.Fatalf("unexpected repository tags: %#v", metadata.Tags)
 	}
+	if metadata.Readme != "# Model Card\n\nUseful details." {
+		t.Fatalf("unexpected cleaned README: %q", metadata.Readme)
+	}
+}
+
+func TestCapturedReadmeIsRemovedFromStoredLogs(t *testing.T) {
+	logs := "before\n" + capturedReadmeLogs(t, "# Model Card", 4) + "after\n"
+	stored := logsWithoutCapturedReadme(logs)
+
+	if strings.Contains(stored, readmeCaptureChunk) || strings.Contains(stored, readmeCaptureBegin) ||
+		strings.Contains(stored, readmeCaptureEnd) {
+		t.Fatalf("stored logs expose encoded README: %q", stored)
+	}
+	for _, expected := range []string{"before", readmeCapturedLogNotice, "after"} {
+		if !strings.Contains(stored, expected) {
+			t.Fatalf("stored logs do not contain %q: %q", expected, stored)
+		}
+	}
+}
+
+func capturedReadmeLogs(t *testing.T, readme string, chunkSize int) string {
+	t.Helper()
+
+	var compressed bytes.Buffer
+	writer := zlib.NewWriter(&compressed)
+	if _, err := writer.Write([]byte(readme)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	payload := base64.StdEncoding.EncodeToString(compressed.Bytes())
+
+	var logs strings.Builder
+	logs.WriteString(readmeCaptureBegin + "\n")
+	for offset := 0; offset < len(payload); offset += chunkSize {
+		end := min(offset+chunkSize, len(payload))
+		logs.WriteString(readmeCaptureChunk + payload[offset:end] + "\n")
+	}
+	logs.WriteString(readmeCaptureEnd + "\n")
+	return logs.String()
 }
 
 func TestDatasetExtraForDownloadPreservesTags(t *testing.T) {

--- a/backend/pkg/reconciler/modeldownload-reconciler_test.go
+++ b/backend/pkg/reconciler/modeldownload-reconciler_test.go
@@ -173,6 +173,85 @@ func TestParseRepositoryMetadataRejectsMissingPayload(t *testing.T) {
 	}
 }
 
+func TestReadyArtifactSyncAllowsMissingRepositoryMetadata(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:missing_repository_metadata?mode=memory&cache=shared"), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+		IgnoreRelationshipsWhenMigrating:         true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(
+		&model.ModelDownload{}, &model.ModelDownloadSubmission{},
+		&model.Dataset{}, &model.UserDataset{}, &model.AccountDataset{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	query.SetDefault(db)
+
+	download := model.ModelDownload{
+		Name: "owner/result-only", Source: model.ModelSourceModelScope,
+		Category: model.DownloadCategoryModel, Revision: "master",
+		Path: "storage/Models/owner/result-only", CreatorID: 7,
+		Status: model.ModelDownloadStatusDownloading,
+	}
+	if err := db.Create(&download).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.ModelDownloadSubmission{
+		UserID: 7, ModelDownloadID: download.ID,
+		Action: model.ModelDownloadSubmissionCreate, Status: model.ModelDownloadSubmissionReserved,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "download-result-only-pod", Namespace: "jobs", Labels: map[string]string{"job-name": "download-result-only"},
+	}}
+	reconciler := &ModelDownloadReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build(),
+		podLogs: func(context.Context, *v1.Pod) (string, error) {
+			return "[RESULT] size_bytes=42\n", nil
+		},
+		db: db,
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "download-result-only", Namespace: "jobs"},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type: batchv1.JobComplete, Status: v1.ConditionTrue,
+		}}},
+	}
+
+	result, err := reconciler.syncDownloadWithJob(context.Background(), job, &download, logr.Discard())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Requeue || result.RequeueAfter != 0 {
+		t.Fatalf("syncDownloadWithJob() result = %#v, want completed reconciliation", result)
+	}
+
+	var stored model.ModelDownload
+	if err := db.First(&stored, download.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != model.ModelDownloadStatusReady || stored.SizeBytes != 42 {
+		t.Fatalf("result-only download did not become Ready: %#v", stored)
+	}
+	assertQuotaSubmissionSettlement(t, db, download.ID, model.ModelDownloadSubmissionSucceeded, true)
+
+	var datasetCount int64
+	if err := db.Model(&model.Dataset{}).Count(&datasetCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if datasetCount != 1 {
+		t.Fatalf("result-only download created %d datasets, want 1", datasetCount)
+	}
+}
+
 func TestReadyArtifactSyncRetriesWhenFinalLogsAreUnavailable(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := v1.AddToScheme(scheme); err != nil {

--- a/backend/pkg/reconciler/modeldownload-reconciler_test.go
+++ b/backend/pkg/reconciler/modeldownload-reconciler_test.go
@@ -19,20 +19,27 @@ import (
 	"compress/zlib"
 	"context"
 	"encoding/base64"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
 
+	"github.com/go-logr/logr"
+	"github.com/raids-lab/crater/dao/model"
+	"github.com/raids-lab/crater/dao/query"
 	"gorm.io/datatypes"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/raids-lab/crater/dao/model"
-	"github.com/raids-lab/crater/dao/query"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+const existingMetadataDisplayName = "Existing name"
 
 func TestClassifyDownloadFailure(t *testing.T) {
 	tests := []struct {
@@ -144,7 +151,10 @@ func TestParseRepositoryMetadata(t *testing.T) {
 	logs := `noise
 [META] {"downloads":4235273,"likes":333,"updated_at":"2025-07-26T16:12:41Z","tags":["text-generation"]}
 ` + capturedReadmeLogs(t, "---\nlicense: apache-2.0\n---\n# Model Card\n<script>unsafe()</script>\nUseful details.", 11)
-	metadata := parseRepositoryMetadata(logs)
+	metadata, err := parseRepositoryMetadata(logs)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if metadata.Downloads != 4235273 || metadata.Likes != 333 || metadata.UpdatedAt != "2025-07-26T16:12:41Z" {
 		t.Fatalf("unexpected repository metadata: %#v", metadata)
@@ -154,6 +164,194 @@ func TestParseRepositoryMetadata(t *testing.T) {
 	}
 	if metadata.Readme != "# Model Card\n\nUseful details." {
 		t.Fatalf("unexpected cleaned README: %q", metadata.Readme)
+	}
+}
+
+func TestParseRepositoryMetadataRejectsMissingPayload(t *testing.T) {
+	if _, err := parseRepositoryMetadata("[RESULT] size_bytes=42\n"); !errors.Is(err, errRepositoryPayloadMissing) {
+		t.Fatalf("parseRepositoryMetadata() error = %v, want %v", err, errRepositoryPayloadMissing)
+	}
+}
+
+func TestReadyArtifactSyncRetriesWhenFinalLogsAreUnavailable(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	reconciler := &ModelDownloadReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "download-owner-model", Namespace: "jobs"},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type: batchv1.JobComplete, Status: v1.ConditionTrue,
+		}}},
+	}
+	download := &model.ModelDownload{Status: model.ModelDownloadStatusDownloading}
+
+	result, err := reconciler.syncDownloadWithJob(context.Background(), job, download, logr.Discard())
+	if !errors.Is(err, errFinalLogsUnavailable) {
+		t.Fatalf("syncDownloadWithJob() error = %v, want %v", err, errFinalLogsUnavailable)
+	}
+	if result.RequeueAfter != progressRequeueInterval {
+		t.Fatalf("syncDownloadWithJob() RequeueAfter = %v, want %v", result.RequeueAfter, progressRequeueInterval)
+	}
+	if download.Status != model.ModelDownloadStatusDownloading {
+		t.Fatalf("download status advanced without final logs: %s", download.Status)
+	}
+}
+
+func TestReadyArtifactSyncRetriesWhenMetadataPersistenceFails(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:metadata_persistence_failure?mode=memory&cache=shared"), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+		IgnoreRelationshipsWhenMigrating:         true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.ModelDownload{}); err != nil {
+		t.Fatal(err)
+	}
+	download := model.ModelDownload{
+		Name: "owner/model", Source: model.ModelSourceModelScope, Category: model.DownloadCategoryModel,
+		Revision: "master", Path: "public/Models/owner/model", CreatorID: 1,
+		Status: model.ModelDownloadStatusDownloading, DisplayName: existingMetadataDisplayName,
+	}
+	if err := db.Create(&download).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "download-owner-model-pod", Namespace: "jobs", Labels: map[string]string{"job-name": "download-owner-model"},
+	}}
+	reconciler := &ModelDownloadReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build(),
+		podLogs: func(context.Context, *v1.Pod) (string, error) {
+			return "[META] {\"display_name\":\"Fresh name\"}\n", nil
+		},
+		db: db,
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "download-owner-model", Namespace: "jobs"},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+			Type: batchv1.JobComplete, Status: v1.ConditionTrue,
+		}}},
+	}
+
+	result, err := reconciler.syncDownloadWithJob(context.Background(), job, &download, logr.Discard())
+	if err == nil || !strings.Contains(err.Error(), "persist repository metadata") {
+		t.Fatalf("syncDownloadWithJob() error = %v, want metadata persistence failure", err)
+	}
+	if result.RequeueAfter != progressRequeueInterval {
+		t.Fatalf("syncDownloadWithJob() RequeueAfter = %v, want %v", result.RequeueAfter, progressRequeueInterval)
+	}
+	var stored model.ModelDownload
+	if err := db.First(&stored, download.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != model.ModelDownloadStatusDownloading || stored.DisplayName != existingMetadataDisplayName {
+		t.Fatalf("failed finalization advanced or overwrote the download: %#v", stored)
+	}
+}
+
+func TestRepositoryReadmePatchPreservesExistingMetadata(t *testing.T) {
+	db := newRepositoryMetadataTestDB(t)
+	source := model.ModelDatasetSource{
+		Provider: model.ModelDatasetProviderModelScope, ResourceType: model.DataTypeModel,
+		RepositoryID: "owner/model", DisplayName: existingMetadataDisplayName, Description: "Existing description",
+		License: "apache-2.0", Downloads: 99, Readme: "Old README",
+	}
+	if err := db.Create(&source).Error; err != nil {
+		t.Fatal(err)
+	}
+	download := model.ModelDownload{
+		Name: "owner/model", Source: model.ModelSourceModelScope, Category: model.DownloadCategoryModel,
+		Revision: "master", Path: "public/Models/owner/model", CreatorID: 1,
+		DisplayName: existingMetadataDisplayName, SourceDescription: "Existing description", License: "apache-2.0",
+		SourceDownloads: 99, SourceReadme: "Old README", ModelDatasetSourceID: &source.ID,
+	}
+	if err := db.Create(&download).Error; err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := parseRepositoryMetadata(capturedReadmeLogs(t, "# New model card", 8))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := persistRepositoryMetadataWithDB(
+		context.Background(), db, &download, &metadata, "", nil, "",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	assertDownloadMetadataPatch(t, db, download.ID)
+	assertSourceMetadataPatch(t, db, source.ID)
+}
+
+func assertDownloadMetadataPatch(t *testing.T, db *gorm.DB, downloadID uint) {
+	t.Helper()
+
+	var stored model.ModelDownload
+	if err := db.First(&stored, downloadID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.DisplayName != existingMetadataDisplayName || stored.SourceDescription != "Existing description" ||
+		stored.License != "apache-2.0" || stored.SourceDownloads != 99 {
+		t.Fatalf("README patch cleared download metadata: %#v", stored)
+	}
+	if stored.SourceReadme != "# New model card" {
+		t.Fatalf("download README = %q, want updated model card", stored.SourceReadme)
+	}
+}
+
+func assertSourceMetadataPatch(t *testing.T, db *gorm.DB, sourceID uint) {
+	t.Helper()
+
+	var stored model.ModelDatasetSource
+	if err := db.First(&stored, sourceID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.DisplayName != existingMetadataDisplayName || stored.Description != "Existing description" ||
+		stored.License != "apache-2.0" || stored.Downloads != 99 {
+		t.Fatalf("README patch cleared source metadata: %#v", stored)
+	}
+	if stored.Readme != "# New model card" {
+		t.Fatalf("source README = %q, want updated model card", stored.Readme)
+	}
+}
+
+func newRepositoryMetadataTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file:repository_metadata_patch?mode=memory&cache=shared"), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+		IgnoreRelationshipsWhenMigrating:         true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.ModelDatasetSource{}, &model.ModelDownload{}); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestCapturedReadmeIsBoundedAtUTF8Boundary(t *testing.T) {
+	oversized := strings.Repeat("x", maxStoredReadmeBytes+4096)
+	if got := parseReadmeFromLogs(capturedReadmeLogs(t, oversized, 128)); len(got) != maxStoredReadmeBytes {
+		t.Fatalf("oversized README length = %d, want %d", len(got), maxStoredReadmeBytes)
+	}
+
+	prefix := strings.Repeat("a", maxStoredReadmeBytes-1)
+	got := parseReadmeFromLogs(capturedReadmeLogs(t, prefix+"界tail", 128))
+	if got != prefix {
+		t.Fatalf("multibyte boundary kept partial data: length = %d", len(got))
+	}
+	if !utf8.ValidString(got) {
+		t.Fatal("truncated README is not valid UTF-8")
 	}
 }
 

--- a/backend/pkg/reconciler/modeldownload-reconciler_test.go
+++ b/backend/pkg/reconciler/modeldownload-reconciler_test.go
@@ -230,7 +230,7 @@ func TestReadyArtifactSyncAllowsMissingRepositoryMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Requeue || result.RequeueAfter != 0 {
+	if result.RequeueAfter != 0 {
 		t.Fatalf("syncDownloadWithJob() result = %#v, want completed reconciliation", result)
 	}
 


### PR DESCRIPTION
# 中文说明

## 背景与根因

模型下载完成后，Crater 会创建对应的模型数据集并在模型详情页展示基本信息。当前下载任务只从仓库根目录的 README 中提取一段 `[DESC]` 摘要，完整 README 并不会随下载结果传递给 reconciler。因此，即使模型文件和下载统计已经正确落库，`model_downloads.source_readme` 与 `model_dataset_sources.readme` 仍可能为空，页面最终只能显示自动生成的兜底介绍，与官方仓库的模型卡不一致。

此外，本地开发环境可能同时存在集群中的 backend controller 和本地 controller。一个 controller 先把下载状态写成 `Ready` 后，另一个 controller 原有的“仅处理首次 Ready 状态转换”逻辑会跳过 README 等最终产物的持久化，进一步放大该问题。

## 主要变更

- 下载任务在完成后直接读取实际下载版本根目录中的 `README.md`/兼容文件名，因此 README 与下载的 revision 保持一致，同时适用于 ModelScope 和 Hugging Face。
- 将 README 限制在 64 KiB 内，使用 zlib 压缩和 Base64 编码，并拆分为最多 4096 字符的有界日志行传递给 reconciler。
- reconciler 重组并解码 README，同时限制编码数据和解压数据大小，避免异常 payload 或压缩炸弹占用过多内存。
- 在同一个数据库事务中更新 `model_downloads.source_readme` 和 `model_dataset_sources.readme`，让模型基本信息在下载完成后即可展示，无需等待周期性元数据刷新任务。
- 将 README 清洗逻辑提取为共享实现：去除 front matter、`script`/`style` 等不安全 HTML，将简单 HTML 表格转换为 Markdown，并进行 UTF-8 安全截断。即时下载流程和元数据刷新流程现在使用相同规则。
- 保存用户可见的下载日志前移除编码后的 README 内容，仅保留一行已捕获提示，避免 README 占用 64 KiB 日志尾部预算。
- 当记录已为 `Ready` 但 `source_readme` 仍为空时允许再次同步最终产物，以兼容本地双 controller 短暂重叠的情况。

## 兼容性与回填说明

- 不包含数据库 schema 或前端改动，也不包含模型下载配额功能的任何变更。
- 新下载的模型会在下载完成时立即写入 README。
- 修复部署前已经完成的下载，其旧 Pod 日志中没有新增的 `[README]` payload，无法凭空恢复完整 README；这类记录需要执行一次模型元数据刷新，或重新下载模型。
- 若双 controller 场景下 README payload 仍存在于 Pod 日志中，新的 Ready 恢复逻辑可以补齐数据。

## 验证

- `go test ./internal/governance/modeldataset ./pkg/reconciler ./internal/handler ./cmd/model-metadata-refresh`
- `go vet ./internal/governance/modeldataset ./pkg/reconciler ./internal/handler ./cmd/model-metadata-refresh`
- `git diff --cached --check`
- 提交钩子：全量 golangci-lint 通过，基于 `upstream/main` 的增量 golangci-lint 通过，Swagger 文档生成检查通过。

新增测试覆盖：下载命令的 README 捕获协议、分块 payload 重组和清洗、持久化日志脱敏，以及 `Ready` 状态下缺失 README 的恢复判断。

---

# English Description

## Background and root cause

After a model download completes, Crater creates the associated model dataset and displays its metadata on the model details page. The download job previously extracted only a short `[DESC]` summary from the repository README. The complete README was not transferred to the reconciler. As a result, even when the downloaded files and source statistics were correct, both `model_downloads.source_readme` and `model_dataset_sources.readme` could remain empty, leaving the UI with a generated fallback description instead of the official model card.

Local development can also temporarily run the in-cluster backend controller and a local controller against the same environment. If one controller marks the record as `Ready` first, the other controller previously skipped final artifact persistence because that work only ran on the initial transition to `Ready`.

## What changed

- The download job now reads the root README from the exact downloaded revision, with compatible README filename variants. This path is source-agnostic and works for both ModelScope and Hugging Face.
- README input is capped at 64 KiB, compressed with zlib, Base64-encoded, and emitted as bounded log chunks of at most 4096 characters for the reconciler.
- The reconciler reassembles and decodes the payload with limits on both encoded and decompressed sizes, preventing malformed payloads or compression bombs from consuming unbounded memory.
- `model_downloads.source_readme` and `model_dataset_sources.readme` are persisted in the same database transaction, so the model card is available as soon as the download finishes without waiting for the periodic metadata refresh command.
- README sanitization is now shared by the immediate download path and the periodic refresh path. It removes front matter and unsafe `script`/`style` blocks, converts simple HTML tables to Markdown, strips remaining raw HTML, and truncates safely at a UTF-8 boundary.
- Encoded README chunks are removed before user-facing download logs are stored. A single capture notice remains, preserving the 64 KiB log-tail budget for useful operational output.
- Final artifacts are synchronized again when a record is already `Ready` but `source_readme` is empty, covering temporary overlap between local and in-cluster controllers.

## Compatibility and backfill

- This PR contains no database schema changes, frontend changes, or model-download quota changes.
- New downloads persist the README immediately after completion.
- Downloads completed before this fix do not contain the new `[README]` payload in their historical Pod logs, so the full README cannot be reconstructed automatically. Those records require a one-time metadata refresh or a model re-download.
- In an overlapping-controller scenario, the Ready recovery path can fill the fields when the README payload is still available in the Pod logs.

## Validation

- `go test ./internal/governance/modeldataset ./pkg/reconciler ./internal/handler ./cmd/model-metadata-refresh`
- `go vet ./internal/governance/modeldataset ./pkg/reconciler ./internal/handler ./cmd/model-metadata-refresh`
- `git diff --cached --check`
- Commit hooks: full golangci-lint passed, the `upstream/main` differential golangci-lint passed, and Swagger generation validation passed.

New tests cover the download-command capture protocol, chunked README reconstruction and sanitization, removal of encoded payloads from persisted logs, and recovery when a `Ready` record is still missing its README.
