### PR TITLE
fix(model): write quota reservations to submission table

### DIFF
--- a/backend/internal/service/model_download_quota.go
+++ b/backend/internal/service/model_download_quota.go
@@ -77,7 +77,8 @@ func (s *ModelDownloadQuotaService) Reserve(
 		UserID: userID, ModelDownloadID: downloadID, Action: action,
 		Status: model.ModelDownloadSubmissionReserved,
 	}
-	if err := query.Use(tx).ModelDownloadSubmission.WithContext(ctx).Create(submission); err != nil {
+	if err := query.Use(tx).ModelDownloadSubmission.Table("model_download_submissions").
+		WithContext(ctx).Create(submission); err != nil {
 		return bizerr.Internal.DatabaseError.Wrap(err, "record model download submission")
 	}
 	return nil

--- a/backend/internal/service/model_download_quota_test.go
+++ b/backend/internal/service/model_download_quota_test.go
@@ -129,6 +129,25 @@ func TestModelDownloadQuotaServiceTracksJobsAcrossConfigurationChanges(t *testin
 	}
 }
 
+func TestModelDownloadQuotaServiceReserveUsesSubmissionTableFromScopedDB(t *testing.T) {
+	db, _, quotaService := newModelDownloadQuotaTestServices(t, "scoped_db_submission_table")
+	userID := uint(7)
+	download := createModelDownloadQuotaTestRecord(
+		t, db, userID, "scoped-db", model.ModelDownloadStatusPending,
+	)
+
+	err := query.Use(db).Transaction(func(tx *query.Query) error {
+		return quotaService.Reserve(
+			t.Context(), tx.ModelDownload.WithContext(t.Context()).UnderlyingDB(),
+			userID, download.ID, model.ModelDownloadSubmissionCreate,
+		)
+	})
+	if err != nil {
+		t.Fatalf("reserve with a model-download-scoped DB should use the submission table: %v", err)
+	}
+	assertModelDownloadQuotaTestSubmission(t, db, userID, download.ID)
+}
+
 func TestModelDownloadQuotaServiceReservesAndSettlesByOperator(t *testing.T) {
 	db, configService, quotaService := newModelDownloadQuotaTestServices(t, "settlement_by_operator")
 	updateModelDownloadQuotaTestConfig(t, configService, ModelDownloadLimitConfig{


### PR DESCRIPTION
## What changed

- explicitly route quota reservation inserts to `model_download_submissions`
- add a regression test covering the model-download-scoped transaction used by create/retry flows

## Root cause and impact

The download handler passes a GORM connection derived from the `model_downloads` DAO into the quota service. The generated submission DAO inherited that scoped table name, so reservation creation attempted to insert `user_id` and other submission columns into `model_downloads`. Every new model or dataset download therefore failed with HTTP 500 before its Kubernetes Job was created.

## Validation

- targeted quota service tests pass, including the new production-path regression
- repository pre-commit backend lint and generated-doc checks pass
