### PR TITLE
fix(ci): split AutoCorrect workflows by PR source

### DIFF
--- a/.github/workflows/docs-autocorrect-fix.yml
+++ b/.github/workflows/docs-autocorrect-fix.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Crater
+# Copyright 2026 The Crater Project Team, RAIDS-Lab
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,34 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: AutoCorrect Docs
+name: AutoCorrect Docs Fix
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
-      - ".github/workflows/docs-autocorrect.yml"
+      - ".github/workflows/docs-autocorrect-fix.yml"
       - "website/src/**"
       - "website/content/**"
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
-  group: docs-autocorrect-${{ github.event.pull_request.number }}
+  group: docs-autocorrect-fix-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   autocorrect:
-    name: Run AutoCorrect on Website
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    name: Fix AutoCorrect issues on Website
+    # Never check out fork code in this write-capable job.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      # Required only for pushing the AutoCorrect commit to an internal PR branch.
+      contents: write
 
     steps:
-      - name: Checkout PR code
+      - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-          persist-credentials: false
+          # The auto-commit step uses these credentials to push to the internal branch.
+          persist-credentials: true
 
       - name: Prepare changed files
         id: changed-files
@@ -47,6 +52,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FILE_LIST: ${{ runner.temp }}/autocorrect-files
         run: |
           set -euo pipefail
 
@@ -56,7 +62,7 @@ jobs:
             exit 1
           fi
           mkdir "$input_dir"
-          files_exist=false
+          : > "$FILE_LIST"
 
           while IFS= read -r -d '' file; do
             filename=${file##*/}
@@ -71,7 +77,7 @@ jobs:
             target="$input_dir/$file"
             mkdir -p -- "${target%/*}"
             cp -- "$file" "$target"
-            files_exist=true
+            printf '%s\0' "$file" >> "$FILE_LIST"
           done < <(
             git diff --name-only -z --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" -- \
               "website/src/**" \
@@ -79,13 +85,39 @@ jobs:
               "website/messages/**"
           )
 
-          echo "files_exist=$files_exist" >> "$GITHUB_OUTPUT"
-          if [[ "$files_exist" == "false" ]]; then
+          if [[ -s "$FILE_LIST" ]]; then
+            echo "files_exist=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "files_exist=false" >> "$GITHUB_OUTPUT"
             rmdir "$input_dir"
           fi
 
-      - name: Lint changed files
+      - name: Fix changed files
         if: steps.changed-files.outputs.files_exist == 'true'
         uses: huacnlee/autocorrect-action@v2
         with:
-          args: autocorrect-input --lint --no-diff-bg-color
+          args: autocorrect-input --fix
+
+      - name: Copy fixes to PR branch
+        if: steps.changed-files.outputs.files_exist == 'true'
+        shell: bash
+        env:
+          FILE_LIST: ${{ runner.temp }}/autocorrect-files
+        run: |
+          set -euo pipefail
+
+          input_dir="autocorrect-input"
+          while IFS= read -r -d '' file; do
+            cp -- "$input_dir/$file" "$file"
+          done < "$FILE_LIST"
+          rm -r -- "$input_dir"
+
+      - name: Commit changes
+        if: steps.changed-files.outputs.files_exist == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: ${{ github.event.pull_request.head.ref }}
+          commit_message: "style(website): Auto-correct files by autocorrect-action"
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          commit_author: GitHub Actions <41898282+github-actions[bot]@users.noreply.github.com>

--- a/docs/en/CI.md
+++ b/docs/en/CI.md
@@ -418,9 +418,9 @@ Unlike frontend/backend and dependency images, the documentation website include
 
 Taking creating a PR that updates the documentation website as an example, the execution flow is as follows:
 
-1. **When PR is created**: When the PR modifies files under `website/src/**` or `website/content/**` directories, two workflows are triggered simultaneously:
+1. **When PR is created**: When the PR modifies files under `website/src/**` or `website/content/**` directories, the documentation CI runs the following stages:
    - **PR Check** (`docs-build.yml`): Builds the Next.js website to verify successful build and checks whether newly added or modified images are in WebP format
-   - **Automatic Correction** (`docs-autocorrect.yml`): Automatically corrects documentation format. For internal PRs, it directly commits corrections; for Fork PRs, it reports issues in PR comments
+   - **Automatic Correction** (`docs-autocorrect.yml` and `docs-autocorrect-fix.yml`): Checks documentation formatting. For internal PRs, it directly commits corrections; for Fork PRs, it runs a read-only lint check and reports issues in the workflow output
 
 2. **After PR merge**: When the PR is merged to the main branch, two workflows are triggered:
    - **Documentation Deployment** (`docs-deploy.yml`): Builds the Next.js website including Pagefind search index and deploys it to GitHub Pages, automatically updating the documentation website
@@ -470,21 +470,21 @@ After deployment, the documentation website is automatically updated, and users 
 
 ### Automatic Correction
 
-Automatic correction uses the `autocorrect` tool to automatically correct documentation format, triggered when creating Pull Requests, listening to changes in `website/src/**` and `website/content/**`. Different processing strategies are adopted based on PR source.
+Automatic correction uses the `autocorrect` tool to check documentation format, triggered when creating Pull Requests and listening to changes in `website/src/**` and `website/content/**`. The workflow is split by PR source so Fork PR code never runs with a write-capable token.
 
 For internal PRs (from the same repository), automatic correction directly fixes files and commits changes:
 
 ```yaml
-- name: AutoCorrect and Fix (for internal PRs)
+- name: Fix changed files
   uses: huacnlee/autocorrect-action@v2
   with:
-    args: --fix ${{ steps.internal_files.outputs.files }}
+    args: autocorrect-input --fix
 
-- name: Commit changes (for internal PRs)
+- name: Commit changes
   uses: stefanzweifel/git-auto-commit-action@v5
 ```
 
-For Fork PRs (from external repositories), due to permission limitations, changes cannot be directly committed. Therefore, Reviewdog is used to report format issues in PR comments, and contributors fix them themselves.
+For Fork PRs (from external repositories), `docs-autocorrect.yml` runs on the low-privilege `pull_request` event with read-only repository access. It checks only changed documentation files and reports formatting issues in the workflow output, and contributors fix them themselves. Internal PR auto-fixes run separately in `docs-autocorrect-fix.yml` under `pull_request_target`, guarded so it never checks out a Fork PR branch.
 
 Automatic correction excludes `*.*.mdx` files (multi-language files) to avoid affecting translation files.
 

--- a/docs/zh-CN/CI.md
+++ b/docs/zh-CN/CI.md
@@ -418,9 +418,9 @@ detect-changes:
 
 以创建一个更新文档网站的 PR 为例，执行流程如下：
 
-1. **PR 创建时**：当 PR 修改了 `website/src/**` 或 `website/content/**` 目录下的文件时，会同时触发两个 workflow：
+1. **PR 创建时**：当 PR 修改了 `website/src/**` 或 `website/content/**` 目录下的文件时，文档 CI 会执行以下阶段：
    - **PR 检查**（`docs-build.yml`）：构建 Next.js 网站验证构建是否成功，检查新增或修改的图片是否为 WebP 格式
-   - **自动修正**（`docs-autocorrect.yml`）：自动修正文档格式，对于内部 PR 会直接提交修正，对于 Fork PR 会在 PR 评论中报告问题
+   - **自动修正**（`docs-autocorrect.yml` 和 `docs-autocorrect-fix.yml`）：检查文档格式，对于内部 PR 会直接提交修正，对于 Fork PR 会执行只读 lint 检查并在 workflow 输出中报告问题
 
 2. **PR 合并后**：当 PR 合并到 main 分支后，会触发两个 workflow：
    - **文档部署**（`docs-deploy.yml`）：构建包含 PageFind 搜索索引的 Next.js 网站，并部署到 GitHub Pages，文档网站自动更新
@@ -470,21 +470,21 @@ PR 检查在创建 Pull Request 时触发，监听 `website/src/**`、`website/c
 
 ### 自动修正
 
-自动修正使用 `autocorrect` 工具自动修正文档格式，在创建 Pull Request 时触发，监听 `website/src/**` 和 `website/content/**` 的变更。根据 PR 来源的不同，采用不同的处理策略。
+自动修正使用 `autocorrect` 工具检查文档格式，在创建 Pull Request 时触发，监听 `website/src/**` 和 `website/content/**` 的变更。workflow 会按照 PR 来源拆分，避免 Fork PR 代码在拥有写权限的 Token 环境中运行。
 
 对于内部 PR（来自同一仓库），自动修正会直接修复文件并提交更改：
 
 ```yaml
-- name: AutoCorrect and Fix (for internal PRs)
+- name: Fix changed files
   uses: huacnlee/autocorrect-action@v2
   with:
-    args: --fix ${{ steps.internal_files.outputs.files }}
+    args: autocorrect-input --fix
 
-- name: Commit changes (for internal PRs)
+- name: Commit changes
   uses: stefanzweifel/git-auto-commit-action@v5
 ```
 
-对于 Fork PR（来自外部仓库），由于权限限制，无法直接提交更改，因此使用 Reviewdog 在 PR 评论中报告格式问题，由贡献者自行修正。
+对于 Fork PR（来自外部仓库），`docs-autocorrect.yml` 使用低权限的 `pull_request` 事件运行，仅拥有仓库只读权限。它只检查本次 PR 变更的文档文件，并在 workflow 输出中报告格式问题，由贡献者自行修正。内部 PR 的自动修正由 `docs-autocorrect-fix.yml` 在 `pull_request_target` 事件中单独执行，并通过条件保证不会 checkout Fork PR 分支。
 
 自动修正会排除 `*.*.mdx` 文件（多语言文件），避免影响翻译文件。
 


### PR DESCRIPTION
## 中文

### 变更意图

修复 `actions/checkout@v4.4.0` 安全策略收紧后，外部 Fork PR 的 AutoCorrect workflow 在 checkout 阶段失败的问题，同时避免启用 `allow-unsafe-pr-checkout`。

### 核心改动

- 将外部 Fork PR 的 AutoCorrect 检查迁移到低权限 `pull_request` workflow，仅授予仓库只读权限并关闭凭据持久化。
- 新增仅面向同仓库分支的 `pull_request_target` 自动修正 workflow，将写权限限制在实际执行的 job。
- 仅处理 PR 新增或修改的文档源文件，继续排除 `*.*.mdx` 多语言文件。
- 使用独立暂存目录处理文件，避免把 PR 可控路径直接作为 AutoCorrect action 参数。
- 增加按 PR 隔离的 concurrency，避免过期 workflow 与新提交并发运行。
- 同步更新中英文 CI 文档。

### 测试验证

Agent / 自动检查：

- `actionlint`：通过。
- workflow 事件、权限及 Fork/同仓库条件断言：通过。
- `git diff --check`：通过。
- 使用 PR #467 的真实文件集模拟：仅选中源语言 MDX，正确排除 `.en/.jp/.ko.mdx`。
- AutoCorrect lint、fix 和修正文件回写流程模拟：通过。
- `make pre-commit-check`：已运行，本次目录没有额外模块检查。

开发者人工检查：

- 已确认外部 Fork 仅执行只读 lint、内部 PR 自动修正的权限边界。
- 已确认外部 Fork 的问题改为在 workflow 输出中展示，不再发布 Reviewdog PR 评论。

### 其他说明

- 本 PR 不会在内容合入 `main` 后再次运行 AutoCorrect；格式问题应在 PR 合入前处理。
- 本 PR 不修改仓库 required check 规则。
- 不涉及 UI 变更，无需截图。

受影响问题示例：#463、#465、#467。

---

## English

### Intent

Fix AutoCorrect failures for external Fork PRs after the `actions/checkout@v4.4.0` security hardening, without enabling `allow-unsafe-pr-checkout`.

### Core changes

- Move external Fork PR linting to a low-privilege `pull_request` workflow with read-only repository access and no persisted Git credentials.
- Add a separate `pull_request_target` workflow for same-repository PR auto-fixes, with write permission scoped to the executing job.
- Process only documentation source files added or modified by the PR while continuing to exclude multilingual `*.*.mdx` files.
- Use an isolated staging directory instead of passing PR-controlled paths directly to the AutoCorrect action.
- Add per-PR concurrency to prevent stale runs from racing with newer commits.
- Update the English and Chinese CI documentation.

### Test verification

Agent / automated checks:

- `actionlint`: passed.
- Workflow event, permission, and Fork/internal condition assertions: passed.
- `git diff --check`: passed.
- Simulated the workflow using the real file set from PR #467: only the source-language MDX file was selected, while `.en/.jp/.ko.mdx` files were excluded.
- Simulated AutoCorrect lint, fix, and corrected-file synchronization: passed.
- `make pre-commit-check`: executed; no additional module-specific checks applied to these paths.

Developer manual verification:

- Confirmed the permission boundary between read-only Fork linting and internal PR auto-fixes.
- Confirmed that Fork PR findings are now reported in workflow output instead of Reviewdog PR comments.

### Other notes

- AutoCorrect does not run again after content is merged into `main`; formatting issues should be resolved before merge.
- This PR does not change repository required-check rules.
- No UI changes; screenshots are not applicable.

Affected PR examples: #463, #465, and #467.
