### PR TITLE
fix(gpu-analysis): handle already deleted jobs

### DIFF
--- a/backend/internal/handler/gpu_analysis.go
+++ b/backend/internal/handler/gpu_analysis.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -9,8 +10,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 
@@ -298,7 +300,13 @@ func (mgr *GpuAnalysisMgr) ConfirmAndStopJob(c *gin.Context) {
 		return
 	}
 
-	// 3. 更新分析记录状态为“已确认”(ReviewStatusConfirmed)
+	// 3. Stop the job, treating an already deleted job as a successful no-op.
+	if err := mgr.stopJobByName(ctx, analysis.JobName); err != nil {
+		resputil.HandleError(c, err)
+		return
+	}
+
+	// 4. Mark the analysis only after the job is stopped or already absent.
 	if _, err := ga.WithContext(ctx).
 		Where(ga.ID.Eq(uint(id))).
 		Updates(model.GpuAnalysis{ReviewStatus: model.ReviewStatusConfirmed}); err != nil {
@@ -306,53 +314,48 @@ func (mgr *GpuAnalysisMgr) ConfirmAndStopJob(c *gin.Context) {
 		return
 	}
 
-	// 4. 调用复用的停止作业逻辑
-	// 注意：这里复用了 VolcanojobMgr 中的 StopJobByName 逻辑
-	if err := mgr.stopJobByName(ctx, analysis.JobName); err != nil {
-		resputil.Error(c, fmt.Sprintf("review confirmed but failed to stop job '%s': %v", analysis.JobName, err), resputil.ServiceError)
-		return
-	}
-
 	resputil.Success(c, fmt.Sprintf("Job '%s' stopped and analysis confirmed.", analysis.JobName))
 }
 
-// stopJobByName 是从 VolcanojobMgr.StopJobByName 复用（移植）过来的逻辑
-// 它负责更新数据库状态并删除 K8s 中的 Job 资源
+// stopJobByName updates the database state and deletes the Kubernetes Job.
 func (mgr *GpuAnalysisMgr) stopJobByName(ctx context.Context, jobName string) error {
 	j := query.Job
 
-	// 1. 获取数据库记录
+	// 1. Read the active database record. A missing or soft-deleted record means
+	// the job has already been removed and should not make this operation fail.
 	_, err := j.WithContext(ctx).Where(j.JobName.Eq(jobName)).First()
-	if err != nil {
-		return fmt.Errorf("job record not found in db: %w", err)
+	jobRecordExists := err == nil
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return bizerr.Internal.DatabaseError.Wrap(err, "get job record failed")
 	}
 
-	// 2. 尝试从 K8s 获取实体
+	// 2. Look up the Kubernetes resource. NotFound means it is already stopped.
 	job := &batch.Job{}
 	namespace := config.GetConfig().Namespaces.Job
 	err = mgr.client.Get(ctx, client.ObjectKey{Name: jobName, Namespace: namespace}, job)
 
 	exists := err == nil
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("failed to get job from k8s: %w", err)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return bizerr.Internal.K8sServiceError.Wrap(err, "get job from Kubernetes failed")
 	}
 
-	// 3. 更新数据库状态为 Deleted
-	if _, err := j.WithContext(ctx).Where(j.JobName.Eq(jobName)).Updates(model.Job{
-		Status:             model.Deleted,
-		CompletedTimestamp: time.Now(),
-	}); err != nil {
-		return fmt.Errorf("failed to update job status in db: %w", err)
+	// 3. Update the database state only when an active record still exists.
+	if jobRecordExists {
+		if _, err := j.WithContext(ctx).Where(j.JobName.Eq(jobName)).Updates(model.Job{
+			Status:             model.Deleted,
+			CompletedTimestamp: time.Now(),
+		}); err != nil {
+			return bizerr.Internal.DatabaseError.Wrap(err, "update stopped job status failed")
+		}
 	}
 
-	// 4. 如果 K8s 中存在该 Job，则删除它（OwnerReference 会处理关联的 Pod/Svc/Ingress）
+	// 4. Delete the Kubernetes Job when present. OwnerReferences clean up related resources.
 	if exists {
-		// PropagationPolicy: Background 是默认行为，但显式写出更清晰
 		deleteOptions := &client.DeleteOptions{}
 		if err := mgr.client.Delete(ctx, job, deleteOptions); err != nil {
-			// 如果删除时发现由于某种原因已经被删除了，忽略错误
-			if !errors.IsNotFound(err) {
-				return fmt.Errorf("failed to delete job from k8s: %w", err)
+			// Ignore a concurrent deletion.
+			if !k8serrors.IsNotFound(err) {
+				return bizerr.Internal.K8sServiceError.Wrap(err, "delete job from Kubernetes failed")
 			}
 		}
 	}

--- a/backend/internal/handler/gpu_analysis_test.go
+++ b/backend/internal/handler/gpu_analysis_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 The Crater Project Team, RAIDS-Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+
+	"github.com/raids-lab/crater/dao/model"
+	"github.com/raids-lab/crater/dao/query"
+)
+
+func TestConfirmAndStopJobSucceedsWhenJobWasAlreadyDeleted(t *testing.T) {
+	db := newGpuAnalysisHandlerTestDB(t, "confirm_stop_deleted_job")
+	const jobID uint = 1
+	const jobName = "deleted-job"
+	if err := db.Exec(
+		"INSERT INTO jobs (id, job_name, status, deleted_at) VALUES (?, ?, ?, ?)",
+		jobID,
+		jobName,
+		batch.Completed,
+		time.Now(),
+	).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	analysis := model.GpuAnalysis{
+		JobID:        jobID,
+		JobName:      jobName,
+		ReviewStatus: model.ReviewStatusPending,
+	}
+	if err := db.Create(&analysis).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := &GpuAnalysisMgr{
+		client: newGpuAnalysisFakeClient(t),
+	}
+	recorder := requestConfirmAndStopJob(t, mgr, analysis.ID)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("POST confirm-stop returned HTTP %d: %s", recorder.Code, recorder.Body.String())
+	}
+
+	var updatedAnalysis model.GpuAnalysis
+	if err := db.First(&updatedAnalysis, analysis.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if updatedAnalysis.ReviewStatus != model.ReviewStatusConfirmed {
+		t.Fatalf("review status = %d, want %d", updatedAnalysis.ReviewStatus, model.ReviewStatusConfirmed)
+	}
+
+	var deletedJob model.Job
+	if err := db.Unscoped().First(&deletedJob, jobID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if !deletedJob.DeletedAt.Valid {
+		t.Fatal("confirm-stop restored or modified the soft-deleted job record")
+	}
+	if deletedJob.Status != batch.Completed {
+		t.Fatalf("deleted job status = %s, want %s", deletedJob.Status, batch.Completed)
+	}
+}
+
+func TestConfirmAndStopJobDoesNotMarkReviewWhenKubernetesLookupFails(t *testing.T) {
+	db := newGpuAnalysisHandlerTestDB(t, "confirm_stop_kubernetes_error")
+	analysis := model.GpuAnalysis{
+		JobName:      "unavailable-job",
+		ReviewStatus: model.ReviewStatusPending,
+	}
+	if err := db.Create(&analysis).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := &GpuAnalysisMgr{
+		client: failingGetClient{
+			Client: newGpuAnalysisFakeClient(t),
+			err:    io.ErrUnexpectedEOF,
+		},
+	}
+	recorder := requestConfirmAndStopJob(t, mgr, analysis.ID)
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("POST confirm-stop returned HTTP %d: %s", recorder.Code, recorder.Body.String())
+	}
+
+	var unchangedAnalysis model.GpuAnalysis
+	if err := db.First(&unchangedAnalysis, analysis.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if unchangedAnalysis.ReviewStatus != model.ReviewStatusPending {
+		t.Fatalf("review status = %d, want pending after stop failure", unchangedAnalysis.ReviewStatus)
+	}
+}
+
+func newGpuAnalysisHandlerTestDB(t *testing.T, name string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+name+"?mode=memory&cache=shared"), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.GpuAnalysis{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`CREATE TABLE jobs (
+		id INTEGER PRIMARY KEY,
+		deleted_at DATETIME,
+		job_name TEXT NOT NULL,
+		status TEXT,
+		completed_timestamp DATETIME
+	)`).Error; err != nil {
+		t.Fatal(err)
+	}
+	query.SetDefault(db)
+	return db
+}
+
+func newGpuAnalysisFakeClient(t *testing.T) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := batch.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).Build()
+}
+
+func requestConfirmAndStopJob(t *testing.T, mgr *GpuAnalysisMgr, analysisID uint) *httptest.ResponseRecorder {
+	t.Helper()
+	router := gin.New()
+	mgr.RegisterAdmin(router.Group("/v1/admin/gpu-analysis"))
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/admin/gpu-analysis/"+fmt.Sprint(analysisID)+"/confirm-stop",
+		http.NoBody,
+	)
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+type failingGetClient struct {
+	client.Client
+	err error
+}
+
+func (c failingGetClient) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return c.err
+}


### PR DESCRIPTION
## Summary

- treat missing or soft-deleted jobs as already stopped in the GPU analysis confirm-stop endpoint
- update the review status only after the stop operation succeeds or is confirmed unnecessary
- preserve real database and Kubernetes failures as structured backend errors
- add regression coverage for deleted jobs and Kubernetes lookup failures

## Testing

- `CRATER_DEBUG_CONFIG_PATH=/home/cx330/devspace/crater/crater/backend/etc/debug-config.yaml go test ./internal/handler -count=1`
- `make pre-commit-check`