### PR TITLE
chore: add development build version metadata

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -19,6 +19,7 @@ on:
     branches: [main]
     paths:
       - "backend/**"
+      - "hack/set-build-version.sh"
       - ".github/workflows/backend-build.yml"
     tags:
       - "v*.*.*"
@@ -104,26 +105,7 @@ jobs:
 
       - name: Set version variables
         id: set-version
-        run: |
-          COMMIT_SHA="${{ github.sha }}"
-          SHORT_SHA="${COMMIT_SHA:0:7}"
-
-          # Check if triggered by tag
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            # Tag trigger: use tag version (keep v prefix)
-            APP_VERSION="${{ github.ref_name }}"
-            BUILD_TYPE="release"
-          else
-            # Branch trigger: use commit SHA
-            APP_VERSION="$SHORT_SHA"
-            BUILD_TYPE="development"
-          fi
-
-          # Set outputs
-          echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT
-          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-          echo "build_type=$BUILD_TYPE" >> $GITHUB_OUTPUT
-          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+        run: bash ../hack/set-build-version.sh
 
       - name: Build backend binaries
         run: |

--- a/.github/workflows/backend-pr.yml
+++ b/.github/workflows/backend-pr.yml
@@ -19,6 +19,7 @@ on:
     branches: [main]
     paths:
       - "backend/**"
+      - "hack/set-build-version.sh"
       - ".github/workflows/backend-pr.yml"
 
 env:
@@ -88,19 +89,7 @@ jobs:
 
       - name: Set version variables
         id: set-version
-        run: |
-          COMMIT_SHA="${{ github.sha }}"
-          SHORT_SHA="${COMMIT_SHA:0:7}"
-
-          # PR builds are always development builds
-          APP_VERSION="$SHORT_SHA"
-          BUILD_TYPE="development"
-
-          # Set outputs
-          echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT
-          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-          echo "build_type=$BUILD_TYPE" >> $GITHUB_OUTPUT
-          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+        run: bash ../hack/set-build-version.sh
 
       - name: Build backend binaries
         run: |

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -21,6 +21,7 @@ on:
       - "v*.*.*"
     paths:
       - "frontend/**"
+      - "hack/set-build-version.sh"
       - ".github/workflows/frontend-build.yml"
       - "website/**"
 
@@ -84,30 +85,7 @@ jobs:
       - name: Set version variables
         id: set-version
         run: |
-          COMMIT_SHA="${{ github.sha }}"
-          SHORT_SHA="${COMMIT_SHA:0:7}"
-
-          # Check if triggered by tag
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            # Tag trigger: use tag version (keep v prefix)
-            APP_VERSION="${{ github.ref_name }}"
-            BUILD_TYPE="release"
-          else
-            # Branch trigger: use commit SHA
-            APP_VERSION="$SHORT_SHA"
-            BUILD_TYPE="development"
-          fi
-
-          # Set outputs
-          echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT
-          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-          echo "build_type=$BUILD_TYPE" >> $GITHUB_OUTPUT
-
-          # Set environment variables
-          echo "VITE_APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
-          echo "VITE_APP_COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
-          echo "VITE_APP_BUILD_TYPE=$BUILD_TYPE" >> $GITHUB_ENV
-          echo "VITE_APP_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+          bash hack/set-build-version.sh
           echo "HUSKY=0" >> $GITHUB_ENV
 
       - name: Setup pnpm
@@ -138,6 +116,11 @@ jobs:
           cd frontend
           pnpm install
           pnpm build
+        env:
+          VITE_APP_VERSION: ${{ steps.set-version.outputs.app_version }}
+          VITE_APP_COMMIT_SHA: ${{ steps.set-version.outputs.commit_sha }}
+          VITE_APP_BUILD_TYPE: ${{ steps.set-version.outputs.build_type }}
+          VITE_APP_BUILD_TIME: ${{ steps.set-version.outputs.build_time }}
 
       # 3. 合并产物 (关键点：使用明确的相对根目录路径)
       - name: Merge Docs into Frontend Dist

--- a/.github/workflows/frontend-pr.yml
+++ b/.github/workflows/frontend-pr.yml
@@ -19,6 +19,7 @@ on:
     branches: [main]
     paths:
       - "frontend/**"
+      - "hack/set-build-version.sh"
       - ".github/workflows/frontend-pr.yml"
 
 jobs:
@@ -70,23 +71,7 @@ jobs:
       - name: Set version variables
         id: set-version
         run: |
-          COMMIT_SHA="${{ github.sha }}"
-          SHORT_SHA="${COMMIT_SHA:0:7}"
-
-          # PR builds are always development builds
-          APP_VERSION="$SHORT_SHA"
-          BUILD_TYPE="development"
-
-          # Set outputs
-          echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT
-          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-          echo "build_type=$BUILD_TYPE" >> $GITHUB_OUTPUT
-
-          # Set environment variables
-          echo "VITE_APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
-          echo "VITE_APP_COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
-          echo "VITE_APP_BUILD_TYPE=$BUILD_TYPE" >> $GITHUB_ENV
-          echo "VITE_APP_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+          bash ../hack/set-build-version.sh
           echo "HUSKY=0" >> $GITHUB_ENV
 
       - name: Setup pnpm
@@ -107,3 +92,8 @@ jobs:
 
       - name: Build project
         run: pnpm build
+        env:
+          VITE_APP_VERSION: ${{ steps.set-version.outputs.app_version }}
+          VITE_APP_COMMIT_SHA: ${{ steps.set-version.outputs.commit_sha }}
+          VITE_APP_BUILD_TYPE: ${{ steps.set-version.outputs.build_type }}
+          VITE_APP_BUILD_TIME: ${{ steps.set-version.outputs.build_time }}

--- a/.github/workflows/storage-build.yml
+++ b/.github/workflows/storage-build.yml
@@ -28,6 +28,7 @@ on:
       - "backend/storage-server.Dockerfile"
       - "backend/go.mod"
       - "backend/go.sum"
+      - "hack/set-build-version.sh"
       - ".github/workflows/storage-build.yml"
     tags:
       - "v*.*.*"
@@ -109,26 +110,7 @@ jobs:
 
       - name: Set version variables
         id: set-version
-        run: |
-          COMMIT_SHA="${{ github.sha }}"
-          SHORT_SHA="${COMMIT_SHA:0:7}"
-
-          # Check if triggered by tag
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            # Tag trigger: use tag version (keep v prefix)
-            APP_VERSION="${{ github.ref_name }}"
-            BUILD_TYPE="release"
-          else
-            # Branch trigger: use commit SHA
-            APP_VERSION="$SHORT_SHA"
-            BUILD_TYPE="development"
-          fi
-
-          # Set outputs
-          echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT
-          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-          echo "build_type=$BUILD_TYPE" >> $GITHUB_OUTPUT
-          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+        run: bash ../hack/set-build-version.sh
 
       - name: Build storage server binaries
         run: |

--- a/.github/workflows/storage-pr.yml
+++ b/.github/workflows/storage-pr.yml
@@ -23,6 +23,7 @@ on:
       - "backend/storage-server.Dockerfile"
       - "backend/go.mod"
       - "backend/go.sum"
+      - "hack/set-build-version.sh"
       - ".github/workflows/storage-pr.yml"
 
 env:
@@ -88,19 +89,7 @@ jobs:
 
       - name: Set version variables
         id: set-version
-        run: |
-          COMMIT_SHA="${{ github.sha }}"
-          SHORT_SHA="${COMMIT_SHA:0:7}"
-
-          # PR builds are always development builds
-          APP_VERSION="$SHORT_SHA"
-          BUILD_TYPE="development"
-
-          # Set outputs
-          echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT
-          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-          echo "build_type=$BUILD_TYPE" >> $GITHUB_OUTPUT
-          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+        run: bash ../hack/set-build-version.sh
 
       - name: Build storage server binary
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -338,6 +338,18 @@ Before opening or updating a PR, run the relevant local review path for the chan
 
 After creating the PR, check workflow status. The PR may need multiple rounds of iteration with Copilot review or human review. An Agent may fetch the PR link itself or ask the developer for it, inspect review comments, judge whether each suggestion is correct and worth changing, then propose a modification plan. Do not apply review-driven code changes until the developer has discussed and approved the plan.
 
+## Application Build Versions
+
+Frontend, backend, and storage build workflows use `hack/set-build-version.sh` to derive one consistent set of build fields.
+
+- A release tag such as `v1.1.1` produces `AppVersion=1.1.1` and `BuildType=release`.
+- Release tags must use exactly `vX.Y.Z`; prerelease tags such as `v1.1.1-rc.1` are not supported. Crater does not currently need prerelease channels, and their additional release, version-comparison, and artifact-cleanup complexity is not justified.
+- The version portion of GitHub release tags must follow SemVer, so tags with leading-zero numeric identifiers such as `v01.2.3` are not accepted; this is a repository tag-naming constraint, not an application-code constraint.
+- A development commit produces `AppVersion=<base>+dev.<first-parent-distance>.g<short-sha>` and `BuildType=development`, for example `1.1.1+dev.8.g0163298b`.
+- The base is the nearest reachable release tag on the first-parent history. Git chooses an unambiguous abbreviated commit name.
+- `CommitSHA` remains the full commit SHA, and `BuildTime` remains the UTC build timestamp.
+- Development build metadata identifies an artifact but does not determine release precedence or API compatibility. CLI/backend compatibility uses the separate API version contract below.
+
 ## CLI / Backend API Compatibility Versions
 
 This contract applies only to APIs consumed by the independently distributed CLI. The administrator-deployed frontend is outside its scope.

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -15,8 +15,8 @@ export GOLANGCI_LINT_CACHE
 # DEV_BUILD_TYPE ?= development
 # DEV_BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 # Version information for release builds
-DEV_APP_VERSION ?= v0.0.0
-DEV_COMMIT_SHA ?= 1234567890abcdef1234567890abcdef12345678
+DEV_APP_VERSION ?= 1.1.1
+DEV_COMMIT_SHA ?= 568788e23a3e72218235e4852ad76f7e56c9c2dc
 DEV_BUILD_TYPE ?= release
 DEV_BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -13497,7 +13497,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "appVersion": {
-                    "description": "Application version (tag name or short SHA)",
+                    "description": "Release version or development build metadata",
                     "type": "string"
                 },
                 "buildTime": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -13489,7 +13489,7 @@
             "type": "object",
             "properties": {
                 "appVersion": {
-                    "description": "Application version (tag name or short SHA)",
+                    "description": "Release version or development build metadata",
                     "type": "string"
                 },
                 "buildTime": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -2185,7 +2185,7 @@ definitions:
   internal_handler.VersionInfo:
     properties:
       appVersion:
-        description: Application version (tag name or short SHA)
+        description: Release version or development build metadata
         type: string
       buildTime:
         description: Build time in UTC

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -98,7 +98,7 @@ type (
 	}
 
 	VersionInfo struct {
-		AppVersion string `json:"appVersion"` // Application version (tag name or short SHA)
+		AppVersion string `json:"appVersion"` // Release version or development build metadata
 		CommitSHA  string `json:"commitSHA"`  // Full commit SHA
 		BuildType  string `json:"buildType"`  // Build type (release or development)
 		BuildTime  string `json:"buildTime"`  // Build time in UTC

--- a/docs/zh-CN/CONTRIBUTING.md
+++ b/docs/zh-CN/CONTRIBUTING.md
@@ -332,6 +332,18 @@ PR 描述必须使用**双语 Markdown**，并覆盖：
 
 PR 创建后，需要检查 workflow 状态。PR 也可能需要和 Copilot review 或人工 review 进行多轮迭代。Agent 可以自行获取 PR 链接，或要求开发者提供链接；随后阅读 review 意见，判断每条意见是否正确、是否值得修改，再提出修改方案。未经开发者讨论和确认，不要直接按 review 意见修改代码。
 
+## 应用构建版本
+
+前端、后端和存储服务的构建 workflow 统一调用 `hack/set-build-version.sh`，生成一致的构建字段。
+
+- `v1.1.1` 这样的正式发布 tag 会生成 `AppVersion=1.1.1` 和 `BuildType=release`。
+- 正式发布 tag 必须严格使用 `vX.Y.Z` 格式，不支持 `v1.1.1-rc.1` 这样的预发布 tag。Crater 目前不需要预发布渠道，不值得为此引入额外的发布、版本比较和产物清理复杂度。
+- GitHub 正式发布 tag 中的版本部分必须遵循 SemVer，因此不接受 `v01.2.3` 这类数字标识符含前导零的 tag；这是仓库的 tag 命名约束，不是对应用代码的约束。
+- 开发提交会生成 `AppVersion=<base>+dev.<first-parent-distance>.g<short-sha>` 和 `BuildType=development`，例如 `1.1.1+dev.8.g0163298b`。
+- 基础版本取 first-parent 历史上最近的可达正式发布 tag；Git 会选择无歧义的提交缩写。
+- `CommitSHA` 始终保留完整提交 SHA，`BuildTime` 始终使用 UTC 构建时间戳。
+- 开发版构建元数据用于标识具体产物，不决定正式版本顺序或 API 兼容性。CLI 与后端的兼容性由下方独立的 API 版本契约决定。
+
 ## CLI / 后端 API 兼容版本
 
 这套约定只适用于由用户独立安装和升级的 CLI 所调用的 API；由管理员统一部署的前端不在其范围内。

--- a/frontend/src/components/version/VersionPage.tsx
+++ b/frontend/src/components/version/VersionPage.tsx
@@ -20,6 +20,8 @@ import { Badge } from '@/components/ui/badge'
 
 import { atomBackendVersion } from '@/utils/store'
 
+import { VersionValue } from './VersionValue'
+
 /**
  * VersionPage - Version information business component
  *
@@ -70,11 +72,13 @@ export default function VersionPage() {
           {/* Frontend version row */}
           <div className="flex flex-col items-center gap-2 md:flex-row md:gap-8">
             {/* Frontend version */}
-            <div className="flex items-center gap-2">
+            <div className="flex min-w-0 flex-wrap items-center justify-center gap-2">
               <span className="text-muted-foreground">{t('about.frontendVersion')}</span>
-              <span className="text-foreground font-mono font-semibold">
-                {frontendAppVersion || t('about.unavailable')}
-              </span>
+              <VersionValue
+                version={frontendAppVersion}
+                buildType={frontendBuildType}
+                fallback={t('about.unavailable')}
+              />
               {frontendBuildType && frontendBuildType !== 'release' && (
                 <Badge variant="secondary" className="text-xs">
                   {t('about.developmentVersion')}
@@ -128,11 +132,13 @@ export default function VersionPage() {
           {/* Backend version row */}
           <div className="flex flex-col items-center gap-2 md:flex-row md:gap-8">
             {/* Backend version */}
-            <div className="flex items-center gap-2">
+            <div className="flex min-w-0 flex-wrap items-center justify-center gap-2">
               <span className="text-muted-foreground">{t('about.backendVersion')}</span>
-              <span className="text-foreground font-mono font-semibold">
-                {backendVersion?.appVersion || t('about.unavailable')}
-              </span>
+              <VersionValue
+                version={backendVersion?.appVersion}
+                buildType={backendVersion?.buildType}
+                fallback={t('about.unavailable')}
+              />
               {backendVersion?.buildType && backendVersion.buildType !== 'release' && (
                 <Badge variant="secondary" className="text-xs">
                   {t('about.developmentVersion')}

--- a/frontend/src/components/version/VersionValue.tsx
+++ b/frontend/src/components/version/VersionValue.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2026 The Crater Project Team, RAIDS-Lab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+const DEVELOPMENT_VERSION_PATTERN = /^(\d+\.\d+\.\d+)\+dev\.(\d+)\.g[0-9a-f]+$/i
+
+type VersionValueProps = {
+  version?: string
+  buildType?: string
+  fallback: string
+}
+
+function summarizeVersion(version: string, buildType?: string) {
+  if (buildType !== 'development') {
+    return version
+  }
+
+  const match = DEVELOPMENT_VERSION_PATTERN.exec(version)
+  if (!match) {
+    return version
+  }
+
+  return `${match[1]}+dev.${match[2]}`
+}
+
+export function VersionValue({ version, buildType, fallback }: VersionValueProps) {
+  if (!version) {
+    return <span className="text-foreground font-mono font-semibold">{fallback}</span>
+  }
+
+  const displayVersion = summarizeVersion(version, buildType)
+  const hasHiddenMetadata = displayVersion !== version
+
+  if (!hasHiddenMetadata) {
+    return (
+      <span className="text-foreground max-w-full font-mono font-semibold break-all">
+        {displayVersion}
+      </span>
+    )
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={version}
+          className="text-foreground focus-visible:ring-ring/50 cursor-help rounded-sm border-b border-dotted font-mono font-semibold outline-none focus-visible:ring-[3px]"
+        >
+          {displayVersion}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-[min(24rem,calc(100vw-2rem))] font-mono break-all">
+        {version}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/hack/set-build-version.sh
+++ b/hack/set-build-version.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Crater Project Team, RAIDS-Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+commit_sha="${BUILD_COMMIT_SHA:-${GITHUB_SHA:-}}"
+ref_type="${BUILD_REF_TYPE:-${GITHUB_REF_TYPE:-branch}}"
+ref_name="${BUILD_REF_NAME:-${GITHUB_REF_NAME:-}}"
+build_time="${BUILD_TIME:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+release_tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+$'
+
+if [[ -z "$commit_sha" ]]; then
+	echo "BUILD_COMMIT_SHA or GITHUB_SHA is required" >&2
+	exit 1
+fi
+
+if ! git rev-parse --verify "${commit_sha}^{commit}" >/dev/null 2>&1; then
+	echo "Commit does not exist in the checkout: $commit_sha" >&2
+	exit 1
+fi
+
+if [[ "$ref_type" == "tag" ]]; then
+	if [[ -z "$ref_name" ]]; then
+		echo "BUILD_REF_NAME or GITHUB_REF_NAME is required for tag builds" >&2
+		exit 1
+	fi
+	if [[ ! "$ref_name" =~ $release_tag_pattern ]]; then
+		echo "Release tag must use the vX.Y.Z format: $ref_name" >&2
+		exit 1
+	fi
+
+	app_version="${ref_name#v}"
+	build_type="release"
+else
+	if ! base_tag="$(
+		git describe \
+			--tags \
+			--match 'v[0-9]*.[0-9]*.[0-9]*' \
+			--exclude '*-*' \
+			--exclude '*+*' \
+			--first-parent \
+			--abbrev=0 \
+			"$commit_sha"
+	)"; then
+		echo "No reachable release tag matching v<major>.<minor>.<patch>" >&2
+		exit 1
+	fi
+	if [[ ! "$base_tag" =~ $release_tag_pattern ]]; then
+		echo "Release tag must use the vX.Y.Z format: $base_tag" >&2
+		exit 1
+	fi
+
+	base_version="${base_tag#v}"
+	commit_distance="$(git rev-list --first-parent --count "${base_tag}..${commit_sha}")"
+	short_sha="$(git rev-parse --short "$commit_sha")"
+	app_version="${base_version}+dev.${commit_distance}.g${short_sha}"
+	build_type="development"
+fi
+
+version_info="$(
+	printf 'app_version=%s\n' "$app_version"
+	printf 'commit_sha=%s\n' "$commit_sha"
+	printf 'build_type=%s\n' "$build_type"
+	printf 'build_time=%s\n' "$build_time"
+)"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	printf '%s\n' "$version_info" >>"$GITHUB_OUTPUT"
+else
+	printf '%s\n' "$version_info"
+fi


### PR DESCRIPTION
Make Crater development builds identifiable across frontend, backend, and storage while keeping release tags stable and the version page compact.

### Changes

- Add `hack/set-build-version.sh` to derive consistent build metadata for frontend, backend, and storage workflows:
  - Release tag `vX.Y.Z` produces `AppVersion=X.Y.Z`
  - Development commits produce `X.Y.Z+dev.<first-parent-distance>.g<short-sha>`
- Update six build and PR workflows to pass the generated application version, full commit SHA, build type, and UTC build time into their artifacts.
- Shorten development versions on the version page to `X.Y.Z+dev.N`, while exposing the full value through the interactive tooltip and preserving release versions unchanged.
- Improve version-page wrapping on narrow screens.
- Document the GitHub release-tag policy in English and Chinese:
  - GitHub release tags remain `vX.Y.Z`
  - Prerelease tags such as `v1.1.1-rc.1` are not supported
  - Tags such as `v01.2.3` are not accepted because their version portion does not follow SemVer
  - These are repository tag-naming constraints, not application-code constraints
- Synchronize the backend version-field description and generated Swagger documents, and update local release preview values.

### Testing

AI:

- `hack/set-build-version.sh` temporary test suite: 10/10 cases passed, covering release builds, development builds, first-parent history, GitHub Actions variables, `GITHUB_OUTPUT`, invalid tags, missing tags, and invalid or missing commit SHAs.
- `bash -n hack/set-build-version.sh`, six workflow YAML parse checks, and `git diff --check`: passed.
- Frontend `make pre-commit-check`: TypeScript, ESLint, translation formatting, and Prettier checks passed.
- Frontend production build with real version environment variables: passed.
- Backend pre-commit checks with Go 1.25.4: full and changed-code lint reported 0 issues; Swagger generation passed.

Developer:

- Started the frontend and backend locally, opened the Crater frontend version page on desktop and mobile, and confirmed that the frontend development version and backend release version were displayed as expected.
- Manually read the updated English and Chinese contribution documentation and confirmed the build-version and GitHub release-tag rules.

### Screenshots

- Attach the verified desktop version-page screenshot before marking this PR ready for review.
- Attach the verified mobile/narrow-screen version-page screenshot before marking this PR ready for review.

### Other

- CLI/backend API contract is unchanged; `APIVersion` and both minimum supported API versions remain unchanged.
- Configuration and Helm Chart behavior are unchanged; no Chart version bump or additional deployment action is required.

---

让 Crater 的前端、后端和存储服务开发构建具备统一、可追踪的版本标识，同时保持 GitHub 正式发布 tag 稳定，并让版本页面维持紧凑展示。

### 修改

- 新增 `hack/set-build-version.sh`，为前端、后端和存储服务 workflow 统一生成构建元数据：
  - 正式发布 tag `vX.Y.Z` 生成 `AppVersion=X.Y.Z`
  - 开发提交生成 `X.Y.Z+dev.<first-parent-distance>.g<short-sha>`
- 更新六个构建与 PR workflow，将生成的应用版本、完整提交 SHA、构建类型和 UTC 构建时间写入构建产物。
- 版本页面将开发版缩略显示为 `X.Y.Z+dev.N`，通过可交互 tooltip 展示完整值，并保持正式版本原样显示。
- 改善版本页面在窄屏下的换行布局。
- 在中英文贡献文档中说明 GitHub 发布 tag 规范：
  - GitHub 正式发布 tag 保持 `vX.Y.Z`
  - 不支持 `v1.1.1-rc.1` 这样的预发布 tag
  - `v01.2.3` 的版本部分不符合 SemVer，因此不予接受
  - 这些是仓库 tag 命名约束，不是应用代码约束
- 同步后端版本字段说明和生成的 Swagger 文档，并更新本地正式版预览值。

### 测试

AI：

- 在临时 Git 仓库中为 `hack/set-build-version.sh` 构造 10 个用例，全部通过，覆盖正式版、开发版、first-parent 历史、GitHub Actions 环境变量、`GITHUB_OUTPUT`、非法 tag、无可达 tag，以及无效或缺失提交 SHA。
- `bash -n hack/set-build-version.sh`、六个 workflow YAML 解析检查和 `git diff --check`：通过。
- 前端 `make pre-commit-check`：TypeScript、ESLint、翻译格式和 Prettier 检查通过。
- 使用真实版本环境变量执行前端生产构建：通过。
- 使用 Go 1.25.4 执行后端 pre-commit 检查：全量及变更代码 lint 均为 0 issues，Swagger 生成通过。

开发者：

- 在本地启动前端和后端，分别通过桌面和手机打开 Crater 前端版本页面，确认前端开发版本和后端正式版本均按预期展示。
- 人工阅读中英文贡献文档更新，确认构建版本和 GitHub 发布 tag 规则符合预期。

### 截图

- 在将此 PR 标记为可供审查前，附上已验证的桌面版本页面截图。
- 在将此 PR 标记为可供审查前，附上已验证的手机/窄屏版本页面截图。

### 其他

- CLI/后端 API 契约未变化，`APIVersion` 及双方最低支持 API 版本均保持不变。
- 配置和 Helm Chart 行为未变化，无需提升 Chart 版本或执行额外部署操作。
