### PR TITLE
fix: keep Hugging Face pagination on configured mirror

### DIFF
--- a/backend/internal/handler/modeldownload.go
+++ b/backend/internal/handler/modeldownload.go
@@ -1520,17 +1520,33 @@ python -c 'import huggingface_hub; print("[TOOLS] huggingface_hub=" + huggingfac
 python - << 'PY'
 import os
 from huggingface_hub import snapshot_download
+from huggingface_hub.utils import _pagination
 
 repo_id = %q
 revision = %q
 repo_type = %q
 
+# Some Hub mirrors return an absolute Link header whose rel="next" URL points to huggingface.co.
+# header for paginated repository trees. Respect the configured endpoint for
+# those next-page requests as well, otherwise large repositories unexpectedly
+# bypass the mirror after the first 1,000 entries.
+mirror = os.environ.get("HF_ENDPOINT", "https://huggingface.co").rstrip("/")
+upstream = "https://huggingface.co"
+original_get_next_page = _pagination._get_next_page
+
+def get_next_page_via_configured_endpoint(response):
+    url = original_get_next_page(response)
+    if mirror != upstream and url and url.startswith(upstream + "/"):
+        print("[PAGINATION] rewriting next-page URL to configured Hugging Face endpoint", flush=True)
+        return mirror + url[len(upstream):]
+    return url
+
+_pagination._get_next_page = get_next_page_via_configured_endpoint
+
 kwargs = {
     "repo_id": repo_id,
     "repo_type": repo_type,
     "local_dir": os.environ["OUT_DIR"],
-    "local_dir_use_symlinks": False,
-    "resume_download": True,
 }
 if revision:
     kwargs["revision"] = revision

--- a/backend/internal/handler/modeldownload.go
+++ b/backend/internal/handler/modeldownload.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -1496,14 +1497,35 @@ func (mgr *ModelDownloadMgr) buildDownloadCommand(download *model.ModelDownload,
 		disableXetCmd = "export HF_HUB_DISABLE_XET=1"
 	}
 	if download.Source == model.ModelSourceHuggingFace {
-		// The project image already contains this dependency. The fallback preserves
-		// compatibility with existing custom Python images used by open-source deployments.
+		// The official downloader image pins the Hub client version because the mirror
+		// pagination workaround below intentionally targets that verified API surface.
+		// Internal registries may mirror the image, but must preserve its contents.
 		installCmd = fmt.Sprintf(
-			`if ! python -c 'import huggingface_hub' >/dev/null 2>&1; then
-    echo "huggingface_hub is missing; installing the tested fallback version"
-    pip install --no-cache-dir 'huggingface_hub==%s'
-fi
-python -c 'import huggingface_hub; print("[TOOLS] huggingface_hub=" + huggingface_hub.__version__)'`,
+			`python - << 'PY'
+import sys
+
+try:
+    import huggingface_hub
+except ImportError as error:
+    print(
+        "[ERROR] huggingface_hub is missing; use crater-model-downloader:v1.0.0 or an exact mirror of it",
+        file=sys.stderr,
+        flush=True,
+    )
+    raise SystemExit(20) from error
+
+expected = %q
+actual = huggingface_hub.__version__
+print("[TOOLS] huggingface_hub=" + actual, flush=True)
+if actual != expected:
+    print(
+        "[ERROR] unsupported huggingface_hub version: expected {}, got {}; "
+        "use crater-model-downloader:v1.0.0 or an exact mirror of it".format(expected, actual),
+        file=sys.stderr,
+        flush=True,
+    )
+    raise SystemExit(20)
+PY`,
 			huggingFaceHubVersion,
 		)
 
@@ -1520,28 +1542,34 @@ python -c 'import huggingface_hub; print("[TOOLS] huggingface_hub=" + huggingfac
 python - << 'PY'
 import os
 from huggingface_hub import snapshot_download
-from huggingface_hub.utils import _pagination
 
 repo_id = %q
 revision = %q
 repo_type = %q
 
-# Some Hub mirrors return an absolute Link header whose rel="next" URL points to huggingface.co.
-# header for paginated repository trees. Respect the configured endpoint for
-# those next-page requests as well, otherwise large repositories unexpectedly
-# bypass the mirror after the first 1,000 entries.
+# Some mirrors return an absolute rel="next" Link URL pointing to huggingface.co.
+# Rewrite those next-page requests so pagination stays on the configured mirror
+# for repositories containing more than 1,000 entries.
 mirror = os.environ.get("HF_ENDPOINT", "https://huggingface.co").rstrip("/")
 upstream = "https://huggingface.co"
-original_get_next_page = _pagination._get_next_page
+if mirror != upstream:
+    try:
+        from huggingface_hub.utils import _pagination
+        original_get_next_page = _pagination._get_next_page
+    except (ImportError, AttributeError) as error:
+        raise RuntimeError(
+            "crater-model-downloader:v1.0.0 requires the pagination API from "
+            "huggingface_hub==1.23.0; rebuild or re-mirror the official downloader image"
+        ) from error
 
-def get_next_page_via_configured_endpoint(response):
-    url = original_get_next_page(response)
-    if mirror != upstream and url and url.startswith(upstream + "/"):
-        print("[PAGINATION] rewriting next-page URL to configured Hugging Face endpoint", flush=True)
-        return mirror + url[len(upstream):]
-    return url
+    def get_next_page_via_configured_endpoint(response):
+        url = original_get_next_page(response)
+        if url and url.startswith(upstream + "/"):
+            print("[PAGINATION] rewriting next-page URL to configured Hugging Face endpoint", flush=True)
+            return mirror + url[len(upstream):]
+        return url
 
-_pagination._get_next_page = get_next_page_via_configured_endpoint
+    _pagination._get_next_page = get_next_page_via_configured_endpoint
 
 kwargs = {
     "repo_id": repo_id,
@@ -2075,10 +2103,15 @@ func (mgr *ModelDownloadMgr) captureJobLogsToRecord(c *gin.Context, download *mo
 }
 
 func truncateDownloadLogTail(logs string, maxBytes int) string {
+	logs = strings.ToValidUTF8(logs, "\uFFFD")
 	if len(logs) <= maxBytes {
 		return logs
 	}
-	tail := logs[len(logs)-maxBytes:]
+	start := len(logs) - maxBytes
+	for start < len(logs) && !utf8.RuneStart(logs[start]) {
+		start++
+	}
+	tail := logs[start:]
 	if idx := strings.IndexByte(tail, '\n'); idx >= 0 && idx+1 < len(tail) {
 		return tail[idx+1:]
 	}

--- a/backend/internal/handler/modeldownload_test.go
+++ b/backend/internal/handler/modeldownload_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/driver/sqlite"
@@ -257,6 +258,12 @@ func TestHuggingFaceDownloadCommandKeepsPaginationOnConfiguredEndpoint(t *testin
 	command := (&ModelDownloadMgr{}).buildDownloadCommand(download, "loveda")
 
 	for _, expected := range []string{
+		`expected = "` + huggingFaceHubVersion + `"`,
+		`if actual != expected:`,
+		`unsupported huggingface_hub version`,
+		`use crater-model-downloader:v1.0.0 or an exact mirror of it`,
+		`if mirror != upstream:`,
+		`except (ImportError, AttributeError) as error:`,
 		"from huggingface_hub.utils import _pagination",
 		`mirror = os.environ.get("HF_ENDPOINT", "https://huggingface.co").rstrip("/")`,
 		`url.startswith(upstream + "/")`,
@@ -273,6 +280,9 @@ func TestHuggingFaceDownloadCommandKeepsPaginationOnConfiguredEndpoint(t *testin
 		if strings.Contains(command, deprecated) {
 			t.Fatalf("download command still contains deprecated argument %q", deprecated)
 		}
+	}
+	if strings.Contains(command, "pip install") {
+		t.Fatal("download command mutates the pinned downloader image at runtime")
 	}
 }
 
@@ -547,11 +557,14 @@ func TestDownloadTokenEnvIsSourceSpecificAndEphemeral(t *testing.T) {
 }
 
 func TestTruncateDownloadLogTail(t *testing.T) {
-	logs := strings.Repeat("old line\n", 20) + "last line\n"
+	logs := strings.Repeat("old line\n", 20) + string([]byte{0xe2, 0x96, '[', 0xff}) + "\nlast line\n"
 	truncated := truncateDownloadLogTail(logs, 32)
 
 	if len(truncated) > 32 || strings.Contains(truncated, "old line\nold line\nold line\nold line") || !strings.HasSuffix(truncated, "last line\n") {
 		t.Fatalf("unexpected truncated log tail: %q", truncated)
+	}
+	if !utf8.ValidString(truncated) {
+		t.Fatalf("truncated log tail is not valid UTF-8: %q", truncated)
 	}
 }
 

--- a/backend/internal/handler/modeldownload_test.go
+++ b/backend/internal/handler/modeldownload_test.go
@@ -247,6 +247,35 @@ func TestModelScopeDownloadCommandUsesArgumentArray(t *testing.T) {
 	}
 }
 
+func TestHuggingFaceDownloadCommandKeepsPaginationOnConfiguredEndpoint(t *testing.T) {
+	download := &model.ModelDownload{
+		Name:     "chloechia/loveda",
+		Source:   model.ModelSourceHuggingFace,
+		Category: model.DownloadCategoryDataset,
+	}
+
+	command := (&ModelDownloadMgr{}).buildDownloadCommand(download, "loveda")
+
+	for _, expected := range []string{
+		"from huggingface_hub.utils import _pagination",
+		`mirror = os.environ.get("HF_ENDPOINT", "https://huggingface.co").rstrip("/")`,
+		`url.startswith(upstream + "/")`,
+		`return mirror + url[len(upstream):]`,
+		"_pagination._get_next_page = get_next_page_via_configured_endpoint",
+		"[PAGINATION] rewriting next-page URL to configured Hugging Face endpoint",
+		`"repo_type": repo_type`,
+	} {
+		if !strings.Contains(command, expected) {
+			t.Fatalf("download command does not contain %q", expected)
+		}
+	}
+	for _, deprecated := range []string{"local_dir_use_symlinks", "resume_download"} {
+		if strings.Contains(command, deprecated) {
+			t.Fatalf("download command still contains deprecated argument %q", deprecated)
+		}
+	}
+}
+
 func TestShouldDisableHuggingFaceXet(t *testing.T) {
 	for _, testCase := range []struct {
 		name     string

--- a/backend/pkg/reconciler/modeldownload-reconciler.go
+++ b/backend/pkg/reconciler/modeldownload-reconciler.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-logr/logr"
 	"gorm.io/datatypes"
@@ -202,6 +203,8 @@ func (r *ModelDownloadReconciler) syncDownloadWithJob(
 		}
 	}
 
+	retryFinalLogs := r.ensureFinalLogs(ctx, job, download, newStatus)
+
 	if newStatus != oldStatus {
 		if err := r.updateDownloadStatus(ctx, download, newStatus); err != nil {
 			logger.Error(err, "failed to update download status")
@@ -210,6 +213,9 @@ func (r *ModelDownloadReconciler) syncDownloadWithJob(
 		logger.Info(fmt.Sprintf("model download: %s, status: %s -> %s", job.Name, oldStatus, newStatus))
 	}
 	if newStatus == model.ModelDownloadStatusDownloading {
+		return ctrl.Result{RequeueAfter: progressRequeueInterval}, nil
+	}
+	if retryFinalLogs {
 		return ctrl.Result{RequeueAfter: progressRequeueInterval}, nil
 	}
 
@@ -625,24 +631,74 @@ func (r *ModelDownloadReconciler) persistFinalLogs(ctx context.Context, job *bat
 		return ""
 	}
 
+	storedLogs := truncateLogTail(logs, maxStoredLogBytes)
 	now := time.Now()
 	q := query.ModelDownload
 	if _, err := q.WithContext(ctx).Where(q.ID.Eq(download.ID)).Updates(map[string]any{
-		"logs":          truncateLogTail(logs, maxStoredLogBytes),
+		"logs":          storedLogs,
 		"logs_saved_at": now,
 	}); err != nil {
 		klog.Warningf("failed to persist final logs for download %d: %v", download.ID, err)
+	} else {
+		download.Logs = storedLogs
+		download.LogsSavedAt = &now
 	}
 	return logs
+}
+
+// ensureFinalLogs retries terminal log persistence after transient failures,
+// including after a controller restart when there is no status transition.
+func (r *ModelDownloadReconciler) ensureFinalLogs(
+	ctx context.Context, job *batchv1.Job, download *model.ModelDownload, status model.ModelDownloadStatus,
+) bool {
+	if status != model.ModelDownloadStatusReady && status != model.ModelDownloadStatusFailed {
+		return false
+	}
+	if finalLogsAreCurrent(job, download, status) {
+		return false
+	}
+	r.persistFinalLogs(ctx, job, download)
+	return !finalLogsAreCurrent(job, download, status)
+}
+
+// finalLogsAreCurrent distinguishes a terminal log snapshot from the periodic
+// progress snapshots written while the pod is running.
+func finalLogsAreCurrent(job *batchv1.Job, download *model.ModelDownload, status model.ModelDownloadStatus) bool {
+	if download.LogsSavedAt == nil {
+		return false
+	}
+	if terminalTime := terminalJobTime(job); terminalTime != nil && download.LogsSavedAt.Before(*terminalTime) {
+		return false
+	}
+	return status != model.ModelDownloadStatusReady || resultPattern.MatchString(download.Logs)
+}
+
+func terminalJobTime(job *batchv1.Job) *time.Time {
+	if job.Status.CompletionTime != nil {
+		return &job.Status.CompletionTime.Time
+	}
+	for i := range job.Status.Conditions {
+		condition := &job.Status.Conditions[i]
+		if condition.Status == v1.ConditionTrue &&
+			(condition.Type == batchv1.JobComplete || condition.Type == batchv1.JobFailed) {
+			return &condition.LastTransitionTime.Time
+		}
+	}
+	return nil
 }
 
 // truncateLogTail keeps at most maxBytes from the end of the logs, starting at
 // a line boundary so the stored tail stays readable.
 func truncateLogTail(logs string, maxBytes int) string {
+	logs = strings.ToValidUTF8(logs, "\uFFFD")
 	if len(logs) <= maxBytes {
 		return logs
 	}
-	tail := logs[len(logs)-maxBytes:]
+	start := len(logs) - maxBytes
+	for start < len(logs) && !utf8.RuneStart(logs[start]) {
+		start++
+	}
+	tail := logs[start:]
 	if idx := strings.IndexByte(tail, '\n'); idx >= 0 && idx+1 < len(tail) {
 		tail = tail[idx+1:]
 	}

--- a/backend/pkg/reconciler/modeldownload-reconciler_test.go
+++ b/backend/pkg/reconciler/modeldownload-reconciler_test.go
@@ -18,10 +18,14 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
+	"unicode/utf8"
 
 	"gorm.io/datatypes"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/raids-lab/crater/dao/model"
 	"github.com/raids-lab/crater/dao/query"
@@ -60,6 +64,42 @@ func TestStoredLogTailAndDescription(t *testing.T) {
 	}
 	if got := parseDescriptionFromLogs(truncated); got != "Useful repository summary." {
 		t.Fatalf("parseDescriptionFromLogs() = %q", got)
+	}
+}
+
+func TestStoredLogTailRepairsInvalidUTF8(t *testing.T) {
+	logs := "progress: " + string([]byte{0xe2, 0x96, '[', 0xff}) + "\n[RESULT] size_bytes=42\n"
+	truncated := truncateLogTail(logs, 40)
+
+	if len(truncated) > 40 {
+		t.Fatalf("stored log tail has %d bytes, want at most 40", len(truncated))
+	}
+	if !utf8.ValidString(truncated) {
+		t.Fatalf("stored log tail is not valid UTF-8: %q", truncated)
+	}
+	if !strings.Contains(truncated, "[RESULT] size_bytes=42") {
+		t.Fatalf("stored log tail lost the result marker: %q", truncated)
+	}
+}
+
+func TestFinalLogsAreCurrentRejectsProgressSnapshot(t *testing.T) {
+	finishedAt := time.Now()
+	staleAt := finishedAt.Add(-time.Second)
+	currentAt := finishedAt.Add(time.Second)
+	job := &batchv1.Job{Status: batchv1.JobStatus{CompletionTime: &metav1.Time{Time: finishedAt}}}
+	download := &model.ModelDownload{
+		Status:      model.ModelDownloadStatusReady,
+		Logs:        "[PROGRESS] downloaded_bytes=41\n",
+		LogsSavedAt: &staleAt,
+	}
+
+	if finalLogsAreCurrent(job, download, model.ModelDownloadStatusReady) {
+		t.Fatal("progress snapshot saved before job completion was treated as final")
+	}
+	download.LogsSavedAt = &currentAt
+	download.Logs = "Download completed successfully\n[RESULT] size_bytes=42\n"
+	if !finalLogsAreCurrent(job, download, model.ModelDownloadStatusReady) {
+		t.Fatal("completed result log saved after job completion was treated as stale")
 	}
 }
 


### PR DESCRIPTION
## What changed

- Rewrite absolute Hugging Face `rel="next"` pagination URLs to the configured `HF_ENDPOINT` when using a mirror.
- Preserve official Hugging Face behavior when no mirror is configured.
- Remove two deprecated `snapshot_download` arguments that are ignored by the pinned client.
- Add a regression test for the generated Hugging Face download command.

## Root cause

Some mirrors return an absolute next-page URL pointing to `https://huggingface.co` after the first 1,000 repository entries. `snapshot_download` follows that URL verbatim, bypassing `HF_ENDPOINT`. Clusters that can reach the mirror but not the upstream site then fail on large repositories with `Network is unreachable`.

## Impact

Large model and dataset repositories continue paginating through the configured mirror instead of unexpectedly reaching the upstream Hugging Face endpoint.

## Validation

- Backend pre-commit checks: full lint and changed-code lint passed with 0 issues.
- `go test -c ./internal/handler`: passed.
- `git diff --check`: passed.
- The same pagination rewrite was exercised against repositories with more than 1,000 entries using `huggingface_hub==1.23.0`.

Full handler test execution is left to CI because local package initialization uses the deployment PostgreSQL configuration; no cluster database was used for PR validation.
